### PR TITLE
add-missing-translation-labels

### DIFF
--- a/resources/views/includes/_options.blade.php
+++ b/resources/views/includes/_options.blade.php
@@ -21,7 +21,8 @@
         @if ($searchEnabled)
             <div class="col">
                 <input
-                    @if (is_numeric($searchDebounce)) wire:model.debounce.{{ $searchDebounce }}ms="search" @endif
+                    @if (is_numeric($searchDebounce)&&$searchType=='debounce') wire:model.debounce.{{ $searchDebounce }}ms="search" @endif
+                    @if ($searchType=='lazy') wire:model.lazy="search" @endif
                     @if ($disableSearchOnLoading) wire:loading.attr="disabled" @endif
                     class="form-control"
                     type="text"

--- a/resources/views/includes/_pagination.blade.php
+++ b/resources/views/includes/_pagination.blade.php
@@ -5,7 +5,7 @@
         </div>
 
         <div class="col text-right text-muted">
-            {{ __('Showing :first to :last out of :total results', ['first' => $models->count() ? $models->firstItem() : 0, 'last' => $models->count() ? $models->lastItem() : 0, 'total' => $models->total()]) }}
+            {{ __($shownLabel.' :first '.$toLabel.' :last '.$outOfLabel.' :total '.$resultsLable, ['first' => $models->count() ? $models->firstItem() : 0, 'last' => $models->count() ? $models->lastItem() : 0, 'total' => $models->total()]) }}
         </div>
     </div>
 @endif

--- a/src/Traits/Pagination.php
+++ b/src/Traits/Pagination.php
@@ -48,6 +48,34 @@ trait Pagination
     public $perPageLabel;
 
     /**
+     * The label for shown string.
+     *
+     * @var string
+     */
+    public $shownLabel='Showing';
+
+    /**
+     * The label for results string.
+     *
+     * @var string
+     */
+    public $resultsLable='results';
+
+    /**
+     * The label for out of string.
+     *
+     * @var string
+     */
+    public $outOfLabel='out of';
+
+    /**
+     * The label for to string.
+     *
+     * @var string
+     */
+    public $toLabel='to';
+
+    /**
      * https://laravel-livewire.com/docs/pagination
      * Resetting Pagination After Filtering Data.
      */

--- a/src/Traits/Search.php
+++ b/src/Traits/Search.php
@@ -11,6 +11,13 @@ trait Search
      * Search.
      */
 
+
+    /**
+     * Whether search work:  debounce or lazy
+     * @var string
+     */
+    public $searchType = 'debounce';
+
     /**
      * Whether or not searching is enabled.
      *


### PR DESCRIPTION
adding next labels:

- shownLabel
- resultsLable
- outOfLabel
- toLabel

to be used in translation for different languages

- adding whether search work: debounce or lazy

