### PR TITLE
Make docblocks work with psalm

### DIFF
--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -75,12 +75,12 @@ abstract class TableComponent extends Component
     }
 
     /**
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     abstract public function query(): Builder;
 
     /**
-     * @return mixed
+     * @return array
      */
     abstract public function columns(): array;
 

--- a/src/Views/Button.php
+++ b/src/Views/Button.php
@@ -12,11 +12,9 @@ class Button extends Component
      *
      * @param $text
      */
-    public function __construct($text = false)
+    public function __construct(?string $text = null)
     {
-        if ($text) {
-            $this->options['text'] = $text;
-        }
+        $this->options['text'] = $text;
     }
 
     /**
@@ -24,7 +22,7 @@ class Button extends Component
      *
      * @return self
      */
-    public static function make($text): self
+    public static function make(?string $text = null): self
     {
         return new static($text);
     }

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -94,12 +94,12 @@ class Column
     }
 
     /**
-     * @param  null  $text
-     * @param  null  $attribute
+     * @param  string  $text
+     * @param  string  $attribute
      *
      * @return static
      */
-    public static function make($text = null, $attribute = null)
+    public static function make($text, $attribute = null)
     {
         return new static($text, $attribute);
     }

--- a/src/Views/Link.php
+++ b/src/Views/Link.php
@@ -24,7 +24,7 @@ class Link extends Component
      *
      * @return self
      */
-    public static function make($text): self
+    public static function make(?string $text = null): self
     {
         return new static($text);
     }


### PR DESCRIPTION
Hey,

I use psalm to check my code and it gave me some warnings about docblocks that don't match the return hint or parameters.

Alse the `$text` parameter for `Link::make()` and `Button::make()` is optional.