### PR TITLE
Add pagination reset for perPage updates

### DIFF
--- a/src/Traits/Pagination.php
+++ b/src/Traits/Pagination.php
@@ -55,4 +55,13 @@ trait Pagination
     {
         $this->resetPage();
     }
+
+    /**
+     * https://laravel-livewire.com/docs/pagination
+     * Resetting Pagination After Changing the perPage.
+     */
+    public function updatingPerPage(): void
+    {
+        $this->resetPage();
+    }
 }


### PR DESCRIPTION
If you have a small amount of records shown, the number of pages will be bigger than when you change the perPage to a larger amount of records. For instance, if you have 50 records total with a perPage of 10 and you are on page 5, when you change the perPage to 25, there won't be any results shown. With this change, the 1st page will be shown instead of incorrectly showing the no results message.