### PR TITLE
Allow dot notation for customer attributes

### DIFF
--- a/resources/views/includes/_body.blade.php
+++ b/resources/views/includes/_body.blade.php
@@ -41,13 +41,13 @@
                         @else
                             @if ($column->isHtml())
                                 @if ($column->isCustomAttribute())
-                                    {{ new \Illuminate\Support\HtmlString($model->{$column->attribute}) }}
+                                    {{ new \Illuminate\Support\HtmlString(data_get($model, $column->attribute)) }}
                                 @else
                                     {{ new \Illuminate\Support\HtmlString(Arr::get($model->toArray(), $column->attribute)) }}
                                 @endif
                             @elseif ($column->isUnescaped())
                                 @if ($column->isCustomAttribute())
-                                    {!! $model->{$column->attribute} !!}
+                                    {!! data_get($model, $column->attribute) !!}
                                 @else
                                     {!! Arr::get($model->toArray(), $column->attribute) !!}
                                 @endif

--- a/resources/views/includes/_body.blade.php
+++ b/resources/views/includes/_body.blade.php
@@ -53,7 +53,7 @@
                                 @endif
                             @else
                                 @if ($column->isCustomAttribute())
-                                    {{ $model->{$column->attribute} }}
+                                    {{ data_get($model, $column->attribute) }}
                                 @else
                                     {{ Arr::get($model->toArray(), $column->attribute) }}
                                 @endif


### PR DESCRIPTION
I'd like to propose allowing the use of dot notation for accessing nested attributes via relationships when using custom attributes.

Eg: For a table of posts, instead of adding an accessor attribute to the Post model `getAuthorFullNameAttribute()`, using dot notation, you can simply access the authors full_name attribute directly, through the relationship:

```
Column::make(__('Author'), 'author.full_name')
                ->customAttribute()
                ->searchable()
                ->sortable(),
```

The `data_get()` helper method will be available even outside of Laravel since Livewire already requires `illuminate/support`.

Thanks for this awesome package. Truly is a pleasure.