### PR TITLE
Upgraded to include Livewire v2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "livewire/livewire": "^1.3"
+        "livewire/livewire": "^1.3|^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
Doesn't appears to be any breaking changes after looking over the [upgrade log](https://laravel-livewire.com/docs/2.x/upgrading) to Livewire v2.