### PR TITLE
Added bootstrap.classes.thead option

### DIFF
--- a/resources/views/bootstrap-4/includes/thead.blade.php
+++ b/resources/views/bootstrap-4/includes/thead.blade.php
@@ -1,5 +1,5 @@
 @if ($tableHeaderEnabled)
-    <thead>
+    <thead class="{{ $this->getOption('bootstrap.classes.thead') }}">
         @include('laravel-livewire-tables::'.config('laravel-livewire-tables.theme').'.includes.columns')
     </thead>
 @endif


### PR DESCRIPTION
There are classes built into bootstrap to allow styling of the table header [(see here)].(https://getbootstrap.com/docs/4.5/content/tables/#table-head-options)

I've added this in as an option much like the table classes as I very much doubt there would be a use case to modify this via a method.