### PR TITLE
Fix MongoDB throwing error when perPage is string

### DIFF
--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -96,7 +96,7 @@ abstract class TableComponent extends Component
     {
         return view($this->view(), [
             'columns' => $this->columns(),
-            'models' => $this->paginationEnabled ? $this->models()->paginate($this->perPage) : $this->models()->get(),
+            'models' => $this->paginationEnabled ? $this->models()->paginate((int)$this->perPage) : $this->models()->get(),
         ]);
     }
 

--- a/src/TableComponent.php
+++ b/src/TableComponent.php
@@ -96,7 +96,7 @@ abstract class TableComponent extends Component
     {
         return view($this->view(), [
             'columns' => $this->columns(),
-            'models' => $this->paginationEnabled ? $this->models()->paginate((int)$this->perPage) : $this->models()->get(),
+            'models' => $this->paginationEnabled ? $this->models()->paginate((int) $this->perPage) : $this->models()->get(),
         ]);
     }
 


### PR DESCRIPTION
Hello, we're using MongoDB in our Laravel project and it seems to require strictly integer type when passing the limit for pagination.
Whenever you attempt to change Per Page in frontend it will replace `$perPage` to a string type and when `render` function calls `paginate` it will throw error.

This pull request fixes it, but not sure if it is the right place where to type cast.