### PR TITLE
Fix use of $clearSearchButtonClass variable

### DIFF
--- a/resources/views/bootstrap-4/includes/options.blade.php
+++ b/resources/views/bootstrap-4/includes/options.blade.php
@@ -27,7 +27,7 @@
                         />
                         @if ($clearSearchButton)
                             <div class="input-group-append">
-                                <button class="btn btn-outline-dark" type="button" wire:click="clearSearch">@lang('laravel-livewire-tables::strings.clear')</button>
+                                <button class="{{ $clearSearchButtonClass }}" type="button" wire:click="clearSearch">@lang('laravel-livewire-tables::strings.clear')</button>
                             </div>
                     </div>
                 @endif

--- a/src/Traits/Search.php
+++ b/src/Traits/Search.php
@@ -43,7 +43,7 @@ trait Search
     public $clearSearchButton = false;
 
     /**
-     * The class applied to the clear button
+     * The class applied to the clear button.
      *
      * @var bool
      */

--- a/src/Traits/Search.php
+++ b/src/Traits/Search.php
@@ -43,6 +43,13 @@ trait Search
     public $clearSearchButton = false;
 
     /**
+     * The class applied to the clear button
+     *
+     * @var bool
+     */
+    public $clearSearchButtonClass = false;
+
+    /**
      * Resets the search string.
      */
     public function clearSearch(): void

--- a/src/Traits/Search.php
+++ b/src/Traits/Search.php
@@ -47,7 +47,7 @@ trait Search
      *
      * @var bool
      */
-    public $clearSearchButtonClass = false;
+    public $clearSearchButtonClass = 'btn btn-outline-dark';
 
     /**
      * Resets the search string.


### PR DESCRIPTION
Variable was in the Readme, but it was not used in the package.
Added the functionality.
