### PR TITLE
Feature 1.0.0

### DIFF
--- a/resources/views/tailwind/components/table/row-columns.blade.php
+++ b/resources/views/tailwind/components/table/row-columns.blade.php
@@ -1,0 +1,10 @@
+@php /** @var \Rappasoft\LaravelLivewireTables\Views\Column[] $columns **/ @endphp
+@foreach($columns as $column)
+    <td>
+        @if($column->asHtml)
+            {!! (string)$column->formatted($row) !!}
+        @else
+            {{ $column->formatted($row) }}
+        @endif
+    </td>
+@endforeach

--- a/resources/views/tailwind/components/table/row.blade.php
+++ b/resources/views/tailwind/components/table/row.blade.php
@@ -1,3 +1,8 @@
-<tr {{ $attributes->merge(['class' => 'bg-white']) }}>
+<tr {{ $attributes->merge(['class' => 'bg-white']) }}
+    @if ($url)
+    onclick="window.location='{{ $url }}';"
+    style="cursor:pointer"
+    @endif
+>
     {{ $slot }}
 </tr>

--- a/resources/views/tailwind/datatable.blade.php
+++ b/resources/views/tailwind/datatable.blade.php
@@ -314,6 +314,7 @@
                 <x-livewire-tables::table.row
                     wire:loading.class.delay="opacity-50"
                     wire:key="table-row-{{ $row->getKey() }}"
+                    url="{{ method_exists($this, 'getTableRowUrl') ? $this->getTableRowUrl($row) : null }}"
                     class="{{ $index % 2 === 0 ? 'bg-white' : 'bg-gray-50' }}"
                 >
                     @if (count($bulkActions))
@@ -329,7 +330,7 @@
                         </x-livewire-tables::table.cell>
                     @endif
 
-                    @include($rowsView, ['row' => $row])
+                    @include($rowsView)
                 </x-livewire-tables::table.row>
             @empty
                 <x-livewire-tables::table.row>

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -117,7 +117,10 @@ abstract class DataTableComponent extends Component
      *
      * @return string
      */
-    abstract public function rowView(): string;
+    public function rowView(): string
+    {
+        return 'livewire-tables::'.config('livewire-tables.theme').'.components.table.row-columns';
+    }
 
     /**
      * TableComponent constructor.

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -58,9 +58,9 @@ class Column
     public function __construct(string $text = null, string $column = null)
     {
         $this->text = $text;
-        if (!$column) {
+        if (! $column) {
             $this->column = Str::snake($text);
-        }else{
+        } else {
             $this->column = $column;
         }
 
@@ -190,7 +190,7 @@ class Column
     {
         if ($column && $column instanceof Column) {
             $columnName = $column->column();
-        } elseif ( is_string($column) ) {
+        } elseif (is_string($column)) {
             $columnName = $column;
         } else {
             $columnName = $this->column();
@@ -200,7 +200,7 @@ class Column
 
         if ($this->formatCallback) {
             return app()->call($this->formatCallback, ['value' => $value, 'column' => $column, 'row' => $row]);
-        }else{
+        } else {
             return $value;
         }
     }


### PR DESCRIPTION
- Added row-columns blade and set rowView() method to this new blade. This makes the definition of a rowView blade optional per-table
- re-added format() method on column and with new parameter ordering. new parameter ordering is meant to make it easier to grab only the needed information on a callback (value, column, row)
- re-added formatted() method to column with some enhancements to make it easier to use. This is so that formatted() can be called indiscriminately from a blade template
- added asHtml() mutator to control data output. this was also an issue in the primary branch.
- re-added support for getTableRowUrl link
- flipped column and text parameters for Column constructor to improve backwards compatibility, if column parameter is missing then set it to the column text snake cased.
