### PR TITLE
fix cleanFilter() bug and auto-initialize filters parameter

### DIFF
--- a/resources/views/tailwind/includes/filters.blade.php
+++ b/resources/views/tailwind/includes/filters.blade.php
@@ -51,6 +51,7 @@
                                 <div class="mt-1 relative rounded-md shadow-sm">
                                     <select
                                         wire:model="filters.{{ $key }}"
+                                        wire:key="filter-{{ $key }}"
                                         id="filter-{{ $key }}"
                                         class="rounded-md shadow-sm block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:border-indigo-300 focus:shadow-outline-indigo sm:text-sm sm:leading-5"
                                     >

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -150,7 +150,7 @@ abstract class DataTableComponent extends Component
      */
     public function getRowsQueryProperty(): Builder
     {
-        $this->cleanFilters();
+        //$this->cleanFilters();
 
         return $this->applySorting($this->query());
     }

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -150,7 +150,7 @@ abstract class DataTableComponent extends Component
      */
     public function getRowsQueryProperty(): Builder
     {
-        //$this->cleanFilters();
+        $this->cleanFilters();
 
         return $this->applySorting($this->query());
     }

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -63,7 +63,7 @@ trait WithFilters
         $filterDefinitions = $this->filters();
 
         // filter $filters values
-        $this->filters = array_filter($this->filters, function($filterValue, $filterName) use($filterDefinitions) {
+        $this->filters = array_filter($this->filters, function ($filterValue, $filterName) use ($filterDefinitions) {
 
             // ignore search
             if ($filterName === 'search') {
@@ -71,7 +71,7 @@ trait WithFilters
             }
 
             // filter out any keys that weren't defined as a filter
-            if (!isset($filterDefinitions[$filterName])) {
+            if (! isset($filterDefinitions[$filterName])) {
                 return false;
             }
 
@@ -82,7 +82,6 @@ trait WithFilters
 
             // handle Select filters
             if ($filterDefinitions[$filterName]->isSelect()) {
-
                 foreach ($filterDefinitions[$filterName]->options() as $optionValue => $optionLabel) {
 
                     // if the option is an integer, typecast filter value
@@ -92,13 +91,10 @@ trait WithFilters
                     } elseif ($optionValue === $filterValue) {
                         return true;
                     }
-
                 }
-
             }
 
             return false;
-
         }, ARRAY_FILTER_USE_BOTH);
     }
 

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -13,6 +13,15 @@ trait WithFilters
         'search' => null,
     ];
 
+    public function mountWithFilters()
+    {
+        foreach($this->filters() as $filter => $options){
+            if(!isset($this->filters[$filter])){
+                $this->filters[$filter] = null;
+            }
+        }
+    }
+
     public function resetFilters(): void
     {
         $search = $this->filters['search'] ?? null;


### PR DESCRIPTION
* commented out $this->cleanFilters() on getRowsQueryProperty(). Filtering was broken in my environment and this was the cause. I couldn't figure out why this would be here so I commented it out.
* added mountWithFilters which will auto-initialize $filters from filters(). This removes the requirement to define $filters and filters().