### PR TITLE
Make the search button fully clickable on Tailwind

### DIFF
--- a/resources/views/tailwind/includes/search.blade.php
+++ b/resources/views/tailwind/includes/search.blade.php
@@ -8,8 +8,8 @@
         />
 
         @if (isset($filters['search']) && strlen($filters['search']))
-            <span class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
-                <svg wire:click="$set('filters.search', null)" xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <span wire:click="$set('filters.search', null)" class="inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 cursor-pointer sm:text-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
             </span>


### PR DESCRIPTION
This fixes the "cancel search" button clickable area on Tailwind by moving the wire:click attribute from the SVG icon to the parent element.