### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
 
+### Changed
+
+- Removed default padding on bootstrap tables
+- Clarified where rowView looks in read me
+
 ## [1.1.0] - 2021-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 ### Added
 
 - Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
+- Ability to define the sorting direction names for each column. i.e. A-Z, Z-A, Yes, No, Enabled, Disabled, etc.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+### Added
+
+- Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
+
 ## [1.1.0] - 2021-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [1.2.0] - 2021-04-22
+
 ### Added
 
 - Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
@@ -223,7 +225,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Initial release
 
-[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.1.0...development
+[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.2.0...development
+[1.2.0]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.4...v1.2.0
 [1.1.0]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.2...v1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
 - Ability to define the sorting direction names for each column. i.e. A-Z, Z-A, Yes, No, Enabled, Disabled, etc.
+- Added ability to define primary key of rows for bulk select
+- Added selectedKeys property that returns an array of the ids of the selected rows
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Clarified where rowView looks in read me
 - Null the search filter when it's empty
+- Fill per page options from $perPageAccepted in views
+- Make $perPageAccepted public
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ### Changed
 
-- Removed default padding on bootstrap tables
 - Clarified where rowView looks in read me
+- Null the search filter when it's empty
+
+### Removed
+
+- Removed `text-secondary` class from sorting title
 
 ## [1.1.0] - 2021-04-21
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,18 @@ public array $sortNames = [
 ];
 ```
 
+#### Configuring Sort Direction Names
+
+The default sort direction names are A-Z for ascending and Z-A for descending.
+
+```php
+public array $sortDirectionNames = [
+    'enabled' => [
+        'asc' => 'Yes',
+        'desc' => 'No',
+    ],
+];
+
 ### Defining The Query
 
 Your datatable must have a base query, which you define in the **query()** method:
@@ -404,6 +416,8 @@ There are some class level properties you can set:
 | $showPagination | true | bool | Show the pagination when pagination is enabled |
 | $showSorting | true | bool | Show the sorting pills |
 | $showFilters | true | bool | Show the filter pills |
+| $sortNames | [] | string[] | Change the sort name of the column for the sorting pill display |
+| $sortDirectionNames | [] | string[] | Change the direction name of the column for the sorting pill display (i.e. A-Z, Z-A) |
 | $perPage | 10 | int | The default per page amount selected (must exist in list) |
 | $perPageAccepted | [10, 25, 50] | int[] | The values for the per page dropdown, in order |
 | $searchFilterDebounce | null | null/int | Adds a debounce of `$searchFilterDebounce` ms to the search input |

--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ There are some class level properties you can set:
 | $showPagination | true | bool | Show the pagination when pagination is enabled |
 | $showSorting | true | bool | Show the sorting pills |
 | $showFilters | true | bool | Show the filter pills |
+| $perPage | 10 | int | The default per page amount selected (must exist in list) |
+| $perPageAccepted | [10, 25, 50] | int[] | The values for the per page dropdown, in order |
 | $searchFilterDebounce | null | null/int | Adds a debounce of `$searchFilterDebounce` ms to the search input |
 | $searchFilterDefer | null | null/bool | Adds `.defer` to the search input |
 | $searchFilterLazy | null | null/bool | Adds `.lazy` to the search input |

--- a/README.md
+++ b/README.md
@@ -110,11 +110,14 @@ Column::make('Name')
 
 If you would like full control over your rows without using the Column formatter, than you can define a `rowView` and return the string to the view to render the rows. The view will be passed the current $row.
 
+The string is just passed to a regular Laravel `@include()` so it starts at the resources/views directory which you do not need to specify.
+
 **row.blade.php**
 
 ```php
 public function rowView(): string
 {
+     // Becomes /resources/views/location/to/my/row.blade.php
      return 'location.to.my.row.view';
 }
 ```

--- a/README.md
+++ b/README.md
@@ -396,8 +396,9 @@ There are some class level properties you can set:
 | Property | Default | Options | Usage |
 | -------- | ------- | ------- | ----- |
 | $showSearch | true | bool | Show the search box |
-| $showPerPage | true | bool | Show the per page selector |
-| $showPagination | true | bool | Show the pagination |
+| $paginationEnabled | true | bool | Enable pagination or fetch all records with no pagination |
+| $showPerPage | true | bool | Show the per page selector when pagination is enabled |
+| $showPagination | true | bool | Show the pagination when pagination is enabled |
 | $showSorting | true | bool | Show the sorting pills |
 | $showFilters | true | bool | Show the filter pills |
 | $searchFilterDebounce | null | null/int | Adds a debounce of `$searchFilterDebounce` ms to the search input |

--- a/README.md
+++ b/README.md
@@ -375,9 +375,15 @@ And then using it like this:
 }
 ```
 
-### Creating Bulk Actions
+### Bulk Actions
 
 Bulk actions are not required, and the bulk actions box, as well as the left-hand checkboxes will be hidden if none are defined.
+
+#### The primary key
+
+Each row must have a primary key, it's `'id'` by default but you can override it with the `$primaryKey` property.
+
+#### Defining Bulk Actions
 
 To define your bulk actions, you add them to the **$bulkActions** array.
 
@@ -404,6 +410,29 @@ public function exportSelected()
 
 In the component you have access to `$this->selectedRowsQuery` which is a **Builder** instance of the selected rows.
 
+You may also call `selectedKeys` which gives you an array of the primary keys in order they were selected:
+
+**Note:** See above to setting the primary key if not `'id`.
+
+```php
+public function exportSelected()
+{
+    if (count($this->selectedKeys)) {
+        // Do something with the selected rows
+        dd($this->selectedKeys);
+        
+//        => [
+//            1,
+//            2,
+//            3,
+//            4,
+//        ]   
+    }
+
+    // Notify there is nothing to export
+}
+```
+
 ### Options
 
 There are some class level properties you can set:
@@ -420,6 +449,7 @@ There are some class level properties you can set:
 | $sortDirectionNames | [] | string[] | Change the direction name of the column for the sorting pill display (i.e. A-Z, Z-A) |
 | $perPage | 10 | int | The default per page amount selected (must exist in list) |
 | $perPageAccepted | [10, 25, 50] | int[] | The values for the per page dropdown, in order |
+| $primaryKey | id | string | The column to pluck for bulk actions to populate the `selectedKeys` property |
 | $searchFilterDebounce | null | null/int | Adds a debounce of `$searchFilterDebounce` ms to the search input |
 | $searchFilterDefer | null | null/bool | Adds `.defer` to the search input |
 | $searchFilterLazy | null | null/bool | Adds `.lazy` to the search input |

--- a/resources/views/bootstrap-4/datatable.blade.php
+++ b/resources/views/bootstrap-4/datatable.blade.php
@@ -10,7 +10,6 @@
             wire:poll="{{ $refresh }}"
         @endif
     @endif
-    class="container-fluid"
 >
     @include('livewire-tables::bootstrap-4.includes.offline')
     @include('livewire-tables::bootstrap-4.includes.sorting-pills')

--- a/resources/views/bootstrap-4/datatable.blade.php
+++ b/resources/views/bootstrap-4/datatable.blade.php
@@ -27,10 +27,7 @@
 
         <div class="d-md-flex">
             @include('livewire-tables::bootstrap-4.includes.bulk-actions')
-
-            <div class="ml-0 ml-md-3">
-                @include('livewire-tables::bootstrap-4.includes.per-page')
-            </div>
+            @include('livewire-tables::bootstrap-4.includes.per-page')
         </div>
     </div>
 

--- a/resources/views/bootstrap-4/datatable.blade.php
+++ b/resources/views/bootstrap-4/datatable.blade.php
@@ -10,6 +10,7 @@
             wire:poll="{{ $refresh }}"
         @endif
     @endif
+    class="container-fluid"
 >
     @include('livewire-tables::bootstrap-4.includes.offline')
     @include('livewire-tables::bootstrap-4.includes.sorting-pills')

--- a/resources/views/bootstrap-4/includes/filter-pills.blade.php
+++ b/resources/views/bootstrap-4/includes/filter-pills.blade.php
@@ -1,6 +1,6 @@
 @if ($showFilters && count(array_filter($filters)) && !(count(array_filter($filters)) === 1 && isset($filters['search'])))
     <div class="mb-3">
-        <small class="text-secondary">@lang('Applied Filters'):</small>
+        <small>@lang('Applied Filters'):</small>
 
         @foreach($filters as $key => $value)
             @if ($key !== 'search' && strlen($value))

--- a/resources/views/bootstrap-4/includes/pagination.blade.php
+++ b/resources/views/bootstrap-4/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($pagination ?? false || $showPerPage ?? false)
+@if ($pagination ?? false && $showPerPage ?? false)
     <div class="row">
         <div class="col-12 col-md-6">
             {{ $rows->links() }}

--- a/resources/views/bootstrap-4/includes/pagination.blade.php
+++ b/resources/views/bootstrap-4/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($showPagination)
+@if ($pagination ?? false || $showPerPage ?? false)
     <div class="row">
         <div class="col-12 col-md-6">
             {{ $rows->links() }}

--- a/resources/views/bootstrap-4/includes/pagination.blade.php
+++ b/resources/views/bootstrap-4/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($pagination ?? false && $showPerPage ?? false)
+@if ($paginationEnabled && $showPerPage)
     <div class="row">
         <div class="col-12 col-md-6">
             {{ $rows->links() }}

--- a/resources/views/bootstrap-4/includes/per-page.blade.php
+++ b/resources/views/bootstrap-4/includes/per-page.blade.php
@@ -1,4 +1,4 @@
-@if ($pagination ?? false || $showPerPage ?? false)
+@if ($pagination ?? false && $showPerPage ?? false)
     <select
         wire:model="perPage"
         id="perPage"

--- a/resources/views/bootstrap-4/includes/per-page.blade.php
+++ b/resources/views/bootstrap-4/includes/per-page.blade.php
@@ -1,4 +1,4 @@
-@if ($showPerPage)
+@if ($pagination ?? false || $showPerPage ?? false)
     <select
         wire:model="perPage"
         id="perPage"

--- a/resources/views/bootstrap-4/includes/per-page.blade.php
+++ b/resources/views/bootstrap-4/includes/per-page.blade.php
@@ -5,9 +5,9 @@
             id="perPage"
             class="form-control"
         >
-            <option value="10">10</option>
-            <option value="25">25</option>
-            <option value="50">50</option>
+            @foreach ($perPageAccepted as $item)
+                <option value="{{ $item }}">{{ $item }}</option>
+            @endforeach
         </select>
     </div>
 @endif

--- a/resources/views/bootstrap-4/includes/per-page.blade.php
+++ b/resources/views/bootstrap-4/includes/per-page.blade.php
@@ -1,11 +1,13 @@
-@if ($pagination ?? false && $showPerPage ?? false)
-    <select
-        wire:model="perPage"
-        id="perPage"
-        class="form-control"
-    >
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50">50</option>
-    </select>
+@if ($paginationEnabled && $showPerPage)
+    <div class="ml-0 ml-md-3">
+        <select
+            wire:model="perPage"
+            id="perPage"
+            class="form-control"
+        >
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+        </select>
+    </div>
 @endif

--- a/resources/views/bootstrap-4/includes/sorting-pills.blade.php
+++ b/resources/views/bootstrap-4/includes/sorting-pills.blade.php
@@ -1,6 +1,6 @@
 @if ($showSorting && count($sorts))
     <div class="mb-3">
-        <small class="text-secondary">@lang('Applied Sorting'):</small>
+        <small>@lang('Applied Sorting'):</small>
 
         @foreach($sorts as $col => $dir)
             <span

--- a/resources/views/bootstrap-4/includes/sorting-pills.blade.php
+++ b/resources/views/bootstrap-4/includes/sorting-pills.blade.php
@@ -7,7 +7,7 @@
                 wire:key="sorting-pill-{{ $col }}"
                 class="badge badge-pill badge-info d-inline-flex align-items-center"
             >
-                <span>{{ $sortNames[$col] ?? ucwords(strtr($col, ['_' => ' ', '-' => ' '])) }}: {{ $dir === 'asc' ? 'A-Z' : 'Z-A' }}</span>
+                <span>{{ $sortNames[$col] ?? ucwords(strtr($col, ['_' => ' ', '-' => ' '])) }}: {{ $dir === 'asc' ? ($sortDirectionNames[$col]['asc'] ?? 'A-Z') : ($sortDirectionNames[$col]['desc'] ?? 'Z-A') }}</span>
 
                 <a
                     href="#"

--- a/resources/views/bootstrap-5/datatable.blade.php
+++ b/resources/views/bootstrap-5/datatable.blade.php
@@ -27,10 +27,7 @@
 
         <div class="d-md-flex">
             @include('livewire-tables::bootstrap-5.includes.bulk-actions')
-
-            <div class="ms-0 ms-md-3">
-                @include('livewire-tables::bootstrap-5.includes.per-page')
-            </div>
+            @include('livewire-tables::bootstrap-5.includes.per-page')
         </div>
     </div>
 

--- a/resources/views/bootstrap-5/datatable.blade.php
+++ b/resources/views/bootstrap-5/datatable.blade.php
@@ -10,6 +10,7 @@
             wire:poll="{{ $refresh }}"
         @endif
     @endif
+    class="container-fluid"
 >
     @include('livewire-tables::bootstrap-5.includes.offline')
     @include('livewire-tables::bootstrap-5.includes.sorting-pills')

--- a/resources/views/bootstrap-5/datatable.blade.php
+++ b/resources/views/bootstrap-5/datatable.blade.php
@@ -10,7 +10,6 @@
             wire:poll="{{ $refresh }}"
         @endif
     @endif
-    class="container-fluid"
 >
     @include('livewire-tables::bootstrap-5.includes.offline')
     @include('livewire-tables::bootstrap-5.includes.sorting-pills')

--- a/resources/views/bootstrap-5/includes/filter-pills.blade.php
+++ b/resources/views/bootstrap-5/includes/filter-pills.blade.php
@@ -1,6 +1,6 @@
 @if ($showFilters && count(array_filter($filters)) && !(count(array_filter($filters)) === 1 && isset($filters['search'])))
     <div class="mb-3">
-        <small class="text-secondary">@lang('Applied Filters'):</small>
+        <small>@lang('Applied Filters'):</small>
 
         @foreach($filters as $key => $value)
             @if ($key !== 'search' && strlen($value))

--- a/resources/views/bootstrap-5/includes/pagination.blade.php
+++ b/resources/views/bootstrap-5/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($pagination ?? false || $showPerPage ?? false)
+@if ($pagination ?? false && $showPerPage ?? false)
     <div class="row">
         <div class="col-12 col-md-6">
             {{ $rows->links() }}

--- a/resources/views/bootstrap-5/includes/pagination.blade.php
+++ b/resources/views/bootstrap-5/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($showPagination)
+@if ($pagination ?? false || $showPerPage ?? false)
     <div class="row">
         <div class="col-12 col-md-6">
             {{ $rows->links() }}

--- a/resources/views/bootstrap-5/includes/pagination.blade.php
+++ b/resources/views/bootstrap-5/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($pagination ?? false && $showPerPage ?? false)
+@if ($paginationEnabled && $showPerPage)
     <div class="row">
         <div class="col-12 col-md-6">
             {{ $rows->links() }}

--- a/resources/views/bootstrap-5/includes/per-page.blade.php
+++ b/resources/views/bootstrap-5/includes/per-page.blade.php
@@ -1,4 +1,4 @@
-@if ($pagination ?? false || $showPerPage ?? false)
+@if ($pagination ?? false && $showPerPage ?? false)
     <select
         wire:model="perPage"
         id="perPage"

--- a/resources/views/bootstrap-5/includes/per-page.blade.php
+++ b/resources/views/bootstrap-5/includes/per-page.blade.php
@@ -1,4 +1,4 @@
-@if ($showPerPage)
+@if ($pagination ?? false || $showPerPage ?? false)
     <select
         wire:model="perPage"
         id="perPage"

--- a/resources/views/bootstrap-5/includes/per-page.blade.php
+++ b/resources/views/bootstrap-5/includes/per-page.blade.php
@@ -1,11 +1,13 @@
-@if ($pagination ?? false && $showPerPage ?? false)
-    <select
-        wire:model="perPage"
-        id="perPage"
-        class="form-select"
-    >
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50">50</option>
-    </select>
+@if ($paginationEnabled && $showPerPage)
+    <div class="ms-0 ms-md-3">
+        <select
+            wire:model="perPage"
+            id="perPage"
+            class="form-select"
+        >
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+        </select>
+    </div>
 @endif

--- a/resources/views/bootstrap-5/includes/per-page.blade.php
+++ b/resources/views/bootstrap-5/includes/per-page.blade.php
@@ -5,9 +5,9 @@
             id="perPage"
             class="form-select"
         >
-            <option value="10">10</option>
-            <option value="25">25</option>
-            <option value="50">50</option>
+            @foreach ($perPageAccepted as $item)
+                <option value="{{ $item }}">{{ $item }}</option>
+            @endforeach
         </select>
     </div>
 @endif

--- a/resources/views/bootstrap-5/includes/sorting-pills.blade.php
+++ b/resources/views/bootstrap-5/includes/sorting-pills.blade.php
@@ -7,7 +7,7 @@
                 wire:key="sorting-pill-{{ $col }}"
                 class="badge rounded-pill bg-info d-inline-flex align-items-center"
             >
-                <span>{{ $sortNames[$col] ?? ucwords(strtr($col, ['_' => ' ', '-' => ' '])) }}: {{ $dir === 'asc' ? 'A-Z' : 'Z-A' }}</span>
+                <span>{{ $sortNames[$col] ?? ucwords(strtr($col, ['_' => ' ', '-' => ' '])) }}: {{ $dir === 'asc' ? ($sortDirectionNames[$col]['asc'] ?? 'A-Z') : ($sortDirectionNames[$col]['desc'] ?? 'Z-A') }}</span>
 
                 <a
                     href="#"

--- a/resources/views/bootstrap-5/includes/sorting-pills.blade.php
+++ b/resources/views/bootstrap-5/includes/sorting-pills.blade.php
@@ -1,6 +1,6 @@
 @if ($showSorting && count($sorts))
     <div class="mb-3">
-        <small class="text-secondary">@lang('Applied Sorting'):</small>
+        <small>@lang('Applied Sorting'):</small>
 
         @foreach($sorts as $col => $dir)
             <span

--- a/resources/views/tailwind/datatable.blade.php
+++ b/resources/views/tailwind/datatable.blade.php
@@ -25,10 +25,7 @@
 
             <div class="md:space-x-2 md:flex md:items-center">
                 @include('livewire-tables::tailwind.includes.bulk-actions')
-
-                <div class="w-full md:w-auto">
-                    @include('livewire-tables::tailwind.includes.per-page')
-                </div>
+                @include('livewire-tables::tailwind.includes.per-page')
             </div>
         </div>
 

--- a/resources/views/tailwind/includes/pagination.blade.php
+++ b/resources/views/tailwind/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($showPagination)
+@if ($pagination ?? false && $showPerPage ?? false)
     <div class="p-6 md:p-0">
         {{ $rows->links() }}
     </div>

--- a/resources/views/tailwind/includes/pagination.blade.php
+++ b/resources/views/tailwind/includes/pagination.blade.php
@@ -1,4 +1,4 @@
-@if ($pagination ?? false && $showPerPage ?? false)
+@if ($paginationEnabled && $showPerPage)
     <div class="p-6 md:p-0">
         {{ $rows->links() }}
     </div>

--- a/resources/views/tailwind/includes/per-page.blade.php
+++ b/resources/views/tailwind/includes/per-page.blade.php
@@ -1,4 +1,4 @@
-@if ($showPerPage)
+@if ($pagination ?? false && $showPerPage ?? false)
     <select
         wire:model="perPage"
         id="perPage"

--- a/resources/views/tailwind/includes/per-page.blade.php
+++ b/resources/views/tailwind/includes/per-page.blade.php
@@ -1,11 +1,13 @@
-@if ($pagination ?? false && $showPerPage ?? false)
-    <select
-        wire:model="perPage"
-        id="perPage"
-        class="rounded-md shadow-sm block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:border-indigo-300 focus:shadow-outline-indigo sm:text-sm sm:leading-5"
-    >
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50">50</option>
-    </select>
+@if ($paginationEnabled && $showPerPage)
+    <div class="w-full md:w-auto">
+        <select
+            wire:model="perPage"
+            id="perPage"
+            class="rounded-md shadow-sm block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:border-indigo-300 focus:shadow-outline-indigo sm:text-sm sm:leading-5"
+        >
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+        </select>
+    </div>
 @endif

--- a/resources/views/tailwind/includes/per-page.blade.php
+++ b/resources/views/tailwind/includes/per-page.blade.php
@@ -5,9 +5,9 @@
             id="perPage"
             class="rounded-md shadow-sm block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:border-indigo-300 focus:shadow-outline-indigo sm:text-sm sm:leading-5"
         >
-            <option value="10">10</option>
-            <option value="25">25</option>
-            <option value="50">50</option>
+            @foreach ($perPageAccepted as $item)
+                <option value="{{ $item }}">{{ $item }}</option>
+            @endforeach
         </select>
     </div>
 @endif

--- a/resources/views/tailwind/includes/sorting-pills.blade.php
+++ b/resources/views/tailwind/includes/sorting-pills.blade.php
@@ -7,7 +7,7 @@
                 wire:key="sorting-pill-{{ $col }}"
                 class="inline-flex items-center py-0.5 pl-2 pr-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700"
             >
-                {{ $sortNames[$col] ?? ucwords(strtr($col, ['_' => ' ', '-' => ' '])) }}: {{ $dir === 'asc' ? 'A-Z' : 'Z-A' }}
+                {{ $sortNames[$col] ?? ucwords(strtr($col, ['_' => ' ', '-' => ' '])) }}: {{ $dir === 'asc' ? ($sortDirectionNames[$col]['asc'] ?? 'A-Z') : ($sortDirectionNames[$col]['desc'] ?? 'Z-A') }}
 
                 <button
                     wire:click="removeSort('{{ $col }}')"

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -40,34 +40,6 @@ abstract class DataTableComponent extends Component
     public bool $showSearch = true;
 
     /**
-     * Show the per page select.
-     *
-     * @var bool
-     */
-    public bool $showPerPage = true;
-
-    /**
-     * Show the pagination numbers and links.
-     *
-     * @var bool
-     */
-    public bool $showPagination = true;
-
-    /**
-     * Show the sorting indicators.
-     *
-     * @var bool
-     */
-    public bool $showSorting = true;
-
-    /**
-     * Show the filtering indicators.
-     *
-     * @var bool
-     */
-    public bool $showFilters = true;
-
-    /**
      * Whether or not to refresh the table at a certain interval
      * false is off
      * If it's an integer it will be treated as milliseconds (2000 = refresh every 2 seconds)
@@ -166,11 +138,11 @@ abstract class DataTableComponent extends Component
      */
     public function getRowsProperty()
     {
-        if ($this->pagination ?? false === true) {
+        if ($this->paginationEnabled) {
             return $this->applyPagination($this->rowsQuery);
-        } else {
-            return $this->rowsQuery->get();
         }
+
+        return $this->rowsQuery->get();
     }
 
     /**

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -4,6 +4,7 @@ namespace Rappasoft\LaravelLivewireTables;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Livewire\Component;
 use Rappasoft\LaravelLivewireTables\Traits\WithBulkActions;
 use Rappasoft\LaravelLivewireTables\Traits\WithCustomPagination;
@@ -13,6 +14,8 @@ use Rappasoft\LaravelLivewireTables\Traits\WithSorting;
 
 /**
  * Class TableComponent.
+ *
+ * @property LengthAwarePaginator|Collection|null $rows
  */
 abstract class DataTableComponent extends Component
 {
@@ -159,11 +162,15 @@ abstract class DataTableComponent extends Component
     /**
      * Get the rows paginated collection that will be returned to the view.
      *
-     * @return LengthAwarePaginator
+     * @return LengthAwarePaginator|Collection
      */
-    public function getRowsProperty(): LengthAwarePaginator
+    public function getRowsProperty()
     {
-        return $this->applyPagination($this->rowsQuery);
+        if ($this->pagination ?? false === true) {
+            return $this->applyPagination($this->rowsQuery);
+        } else {
+            return $this->rowsQuery->get();
+        }
     }
 
     /**

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -10,6 +10,7 @@ use Rappasoft\LaravelLivewireTables\Traits\WithBulkActions;
 use Rappasoft\LaravelLivewireTables\Traits\WithCustomPagination;
 use Rappasoft\LaravelLivewireTables\Traits\WithFilters;
 use Rappasoft\LaravelLivewireTables\Traits\WithPerPagePagination;
+use Rappasoft\LaravelLivewireTables\Traits\WithSearch;
 use Rappasoft\LaravelLivewireTables\Traits\WithSorting;
 
 /**
@@ -23,6 +24,7 @@ abstract class DataTableComponent extends Component
     use WithCustomPagination;
     use WithFilters;
     use WithPerPagePagination;
+    use WithSearch;
     use WithSorting;
 
     /**
@@ -31,13 +33,6 @@ abstract class DataTableComponent extends Component
      * @var string
      */
     public $paginationTheme = 'tailwind';
-
-    /**
-     * Show the search field.
-     *
-     * @var bool
-     */
-    public bool $showSearch = true;
 
     /**
      * Whether or not to refresh the table at a certain interval

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -124,7 +124,7 @@ abstract class DataTableComponent extends Component
      *
      * @return Builder
      */
-    public function getRowsQueryProperty(): Builder
+    public function rowsQuery(): Builder
     {
         $this->cleanFilters();
 
@@ -132,17 +132,25 @@ abstract class DataTableComponent extends Component
     }
 
     /**
+     * @return Builder
+     */
+    public function getRowsQueryProperty(): Builder
+    {
+        return $this->rowsQuery();
+    }
+
+    /**
      * Get the rows paginated collection that will be returned to the view.
      *
-     * @return LengthAwarePaginator|Collection
+     * @return Builder[]|\Illuminate\Database\Eloquent\Collection|mixed
      */
     public function getRowsProperty()
     {
         if ($this->paginationEnabled) {
-            return $this->applyPagination($this->rowsQuery);
+            return $this->applyPagination($this->rowsQuery());
         }
 
-        return $this->rowsQuery->get();
+        return $this->rowsQuery()->get();
     }
 
     /**

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -19,11 +19,11 @@ use Rappasoft\LaravelLivewireTables\Traits\WithSorting;
  */
 abstract class DataTableComponent extends Component
 {
-    use WithBulkActions;
-    use WithCustomPagination;
-    use WithFilters;
-    use WithPerPagePagination;
-    use WithSorting;
+    use WithBulkActions,
+        WithCustomPagination,
+        WithFilters,
+        WithPerPagePagination,
+        WithSorting;
 
     /**
      * The default pagination theme.

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -7,6 +7,7 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
  */
 trait WithBulkActions
 {
+    public string $primaryKey = 'id';
     public bool $showFilters = true;
     public bool $selectPage = false;
     public bool $selectAll = false;
@@ -40,7 +41,7 @@ trait WithBulkActions
 
     public function selectPageRows(): void
     {
-        $this->selected = $this->rows->pluck('id')->map(fn ($id) => (string) $id);
+        $this->selected = $this->rows->pluck($this->primaryKey)->map(fn ($id) => (string) $id);
     }
 
     public function selectAll(): void
@@ -59,5 +60,10 @@ trait WithBulkActions
     {
         return (clone $this->rowsQuery())
             ->unless($this->selectAll, fn ($query) => $query->whereKey($this->selected));
+    }
+
+    public function getSelectedKeysProperty()
+    {
+        return $this->selectedRowsQuery->pluck($this->primaryKey)->toArray();
     }
 }

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -57,7 +57,7 @@ trait WithBulkActions
 
     public function getSelectedRowsQueryProperty()
     {
-        return (clone $this->rowsQuery)
+        return (clone $this->rowsQuery())
             ->unless($this->selectAll, fn ($query) => $query->whereKey($this->selected));
     }
 }

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -7,6 +7,8 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
  */
 trait WithBulkActions
 {
+
+    public bool $showFilters = true;
     public bool $selectPage = false;
     public bool $selectAll = false;
     public $selected = [];

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -7,7 +7,6 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
  */
 trait WithBulkActions
 {
-
     public bool $showFilters = true;
     public bool $selectPage = false;
     public bool $selectAll = false;

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -2,6 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
+
 /**
  * Trait WithBulkActions.
  */
@@ -41,7 +43,7 @@ trait WithBulkActions
 
     public function selectPageRows(): void
     {
-        $this->selected = $this->rows->pluck($this->primaryKey)->map(fn ($id) => (string) $id);
+        $this->selected = $this->rows->pluck($this->primaryKey)->map(fn ($key) => (string) $key);
     }
 
     public function selectAll(): void
@@ -56,14 +58,24 @@ trait WithBulkActions
         $this->selected = [];
     }
 
-    public function getSelectedRowsQueryProperty()
+    public function selectedRowsQuery(): Builder
     {
         return (clone $this->rowsQuery())
             ->unless($this->selectAll, fn ($query) => $query->whereKey($this->selected));
     }
 
-    public function getSelectedKeysProperty()
+    public function getSelectedRowsQueryProperty(): Builder
     {
-        return $this->selectedRowsQuery->pluck($this->primaryKey)->toArray();
+        return $this->selectedRowsQuery();
+    }
+
+    public function selectedKeys(): array
+    {
+        return $this->selectedRowsQuery()->pluck($this->primaryKey)->toArray();
+    }
+
+    public function getSelectedKeysProperty(): array
+    {
+        return $this->selectedKeys();
     }
 }

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -31,21 +31,6 @@ trait WithFilters
     ];
 
     /**
-     * @var int|null
-     */
-    public ?int $searchFilterDebounce = null;
-
-    /**
-     * @var bool|null
-     */
-    public ?bool $searchFilterDefer = null;
-
-    /**
-     * @var bool|null
-     */
-    public ?bool $searchFilterLazy = null;
-
-    /**
      * Prebuild the $filters array
      */
     public function mountWithFilters(): void
@@ -55,28 +40,6 @@ trait WithFilters
                 $this->filters[$filter] = null;
             }
         }
-    }
-
-    /**
-     * Build Livewire model options for the search input
-     *
-     * @return string
-     */
-    public function getSearchFilterOptionsProperty(): string
-    {
-        if ($this->searchFilterDebounce) {
-            return '.debounce.' . $this->searchFilterDebounce . 'ms';
-        }
-
-        if ($this->searchFilterDefer) {
-            return '.defer';
-        }
-
-        if ($this->searchFilterLazy) {
-            return '.lazy';
-        }
-
-        return '';
     }
 
     /**

--- a/src/Traits/WithPerPagePagination.php
+++ b/src/Traits/WithPerPagePagination.php
@@ -7,21 +7,11 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
  */
 trait WithPerPagePagination
 {
-    /**
-     * Enable / Disable Pagination
-     *
-     * @var bool
-     */
-    public bool $pagination = true;
 
-    /**
-     * @var int
-     */
+    public bool $paginationEnabled = true;
+    public bool $showPerPage = true;
+    public bool $showPagination = true;
     public int $perPage = 10;
-
-    /**
-     * @var array|int[]
-     */
     protected array $perPageAccepted = [10, 25, 50];
 
     public function mountWithPerPagePagination(): void

--- a/src/Traits/WithPerPagePagination.php
+++ b/src/Traits/WithPerPagePagination.php
@@ -7,7 +7,21 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
  */
 trait WithPerPagePagination
 {
+    /**
+     * Enable / Disable Pagination
+     *
+     * @var bool
+     */
+    public bool $pagination = true;
+
+    /**
+     * @var int
+     */
     public int $perPage = 10;
+
+    /**
+     * @var array|int[]
+     */
     protected array $perPageAccepted = [10, 25, 50];
 
     public function mountWithPerPagePagination(): void
@@ -19,6 +33,9 @@ trait WithPerPagePagination
         }
     }
 
+    /**
+     * @param $value
+     */
     public function updatedPerPage($value): void
     {
         if (in_array(session()->get($this->tableName.'-perPage', $this->perPage), $this->perPageAccepted, true)) {
@@ -30,6 +47,10 @@ trait WithPerPagePagination
         $this->resetPage();
     }
 
+    /**
+     * @param $query
+     * @return mixed
+     */
     public function applyPagination($query)
     {
         return $query->paginate($this->perPage, ['*'], $this->pageName());

--- a/src/Traits/WithPerPagePagination.php
+++ b/src/Traits/WithPerPagePagination.php
@@ -11,7 +11,7 @@ trait WithPerPagePagination
     public bool $showPerPage = true;
     public bool $showPagination = true;
     public int $perPage = 10;
-    protected array $perPageAccepted = [10, 25, 50];
+    public array $perPageAccepted = [10, 25, 50];
 
     public function mountWithPerPagePagination(): void
     {

--- a/src/Traits/WithPerPagePagination.php
+++ b/src/Traits/WithPerPagePagination.php
@@ -7,7 +7,6 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
  */
 trait WithPerPagePagination
 {
-
     public bool $paginationEnabled = true;
     public bool $showPerPage = true;
     public bool $showPagination = true;

--- a/src/Traits/WithSearch.php
+++ b/src/Traits/WithSearch.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits;
+
+/**
+ * Trait WithSearch.
+ */
+trait WithSearch
+{
+    /**
+     * Show the search field.
+     *
+     * @var bool
+     */
+    public bool $showSearch = true;
+
+    /**
+     * @var int|null
+     */
+    public ?int $searchFilterDebounce = null;
+
+    /**
+     * @var bool|null
+     */
+    public ?bool $searchFilterDefer = null;
+
+    /**
+     * @var bool|null
+     */
+    public ?bool $searchFilterLazy = null;
+
+    /**
+     * Remove the search filter when it's empty
+     */
+    public function updatedFilters(): void
+    {
+        if (isset($this->filters['search']) && $this->filters['search'] === '')
+        {
+            $this->filters['search'] = null;
+        }
+    }
+
+    /**
+     * Build Livewire model options for the search input
+     *
+     * @return string
+     */
+    public function getSearchFilterOptionsProperty(): string
+    {
+        if ($this->searchFilterDebounce) {
+            return '.debounce.' . $this->searchFilterDebounce . 'ms';
+        }
+
+        if ($this->searchFilterDefer) {
+            return '.defer';
+        }
+
+        if ($this->searchFilterLazy) {
+            return '.lazy';
+        }
+
+        return '';
+    }
+}

--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Builder;
  */
 trait WithSorting
 {
+
+    public bool $showSorting = true;
     public array $sorts = [];
     public array $sortNames = [];
 

--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -12,6 +12,7 @@ trait WithSorting
     public bool $showSorting = true;
     public array $sorts = [];
     public array $sortNames = [];
+    public array $sortDirectionNames = [];
 
     public function sortBy(string $field): ?string
     {

--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Builder;
  */
 trait WithSorting
 {
-
     public bool $showSorting = true;
     public array $sorts = [];
     public array $sortNames = [];

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -46,7 +46,7 @@ class DataTableComponentTest extends TestCase
     {
         $this->assertInstanceOf(LengthAwarePaginator::class, $this->table->rows);
         $this->assertEquals(10, $this->table->perPage);
-        $this->assertTrue($this->table->pagination);
+        $this->assertTrue($this->table->paginationEnabled);
         $this->assertTrue($this->table->showPerPage);
     }
 
@@ -62,7 +62,7 @@ class DataTableComponentTest extends TestCase
     /** @test */
     public function test_pagination_disabled(): void
     {
-        $this->table->pagination = false;
+        $this->table->paginationEnabled = false;
         $this->table->perPage = 2;
         $this->assertInstanceOf(Collection::class, $this->table->rows);
         $this->assertCount(5, $this->table->rows);

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -3,6 +3,7 @@
 namespace Rappasoft\LaravelLivewireTables\Tests;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 
@@ -38,6 +39,33 @@ class DataTableComponentTest extends TestCase
 
         $this->assertInstanceOf(LengthAwarePaginator::class, $rows);
         $this->assertEquals(5, $this->table->getRowsProperty()->total());
+    }
+
+    /** @test */
+    public function test_pagination_default(): void
+    {
+        $this->assertInstanceOf(LengthAwarePaginator::class, $this->table->rows);
+        $this->assertEquals(10, $this->table->perPage);
+        $this->assertTrue($this->table->pagination);
+        $this->assertTrue($this->table->showPerPage);
+    }
+
+    /** @test */
+    public function test_pagination(): void
+    {
+        $this->table->perPage = 2;
+        $this->assertEquals(1, $this->table->rows->currentPage());
+        $this->assertEquals(2, $this->table->rows->count());
+        $this->assertEquals(3, $this->table->rows->lastPage());
+    }
+
+    /** @test */
+    public function test_pagination_disabled(): void
+    {
+        $this->table->pagination = false;
+        $this->table->perPage = 2;
+        $this->assertInstanceOf(Collection::class, $this->table->rows);
+        $this->assertCount(5, $this->table->rows);
     }
 
     /** @test */


### PR DESCRIPTION
### Added

- Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
- Ability to define the sorting direction names for each column. i.e. A-Z, Z-A, Yes, No, Enabled, Disabled, etc.
- Added ability to define primary key of rows for bulk select
- Added selectedKeys property that returns an array of the ids of the selected rows

### Changed

- Clarified where rowView looks in read me
- Null the search filter when it's empty
- Fill per page options from $perPageAccepted in views
- Make $perPageAccepted public

### Removed

- Removed `text-secondary` class from sorting title