### PR TITLE
Remove padding from bootstrap container to keep it flush with sides like Tailwind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [1.2.1] - 2021-04-22
+
+### Changed
+
+- Remove padding from bootstrap container to keep it flush with sides like Tailwind
+
 ## [1.2.0] - 2021-04-22
 
 ### Added

--- a/resources/views/bootstrap-4/datatable.blade.php
+++ b/resources/views/bootstrap-4/datatable.blade.php
@@ -10,7 +10,7 @@
             wire:poll="{{ $refresh }}"
         @endif
     @endif
-    class="container-fluid"
+    class="container-fluid p-0"
 >
     @include('livewire-tables::bootstrap-4.includes.offline')
     @include('livewire-tables::bootstrap-4.includes.sorting-pills')

--- a/resources/views/bootstrap-5/datatable.blade.php
+++ b/resources/views/bootstrap-5/datatable.blade.php
@@ -10,7 +10,7 @@
             wire:poll="{{ $refresh }}"
         @endif
     @endif
-    class="container-fluid"
+    class="container-fluid p-0"
 >
     @include('livewire-tables::bootstrap-5.includes.offline')
     @include('livewire-tables::bootstrap-5.includes.sorting-pills')


### PR DESCRIPTION
### Changed

- Remove padding from bootstrap container to keep it flush with sides like Tailwind