### PR TITLE
new feature: searchable()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [1.2.0] - 2021-04-22
+
 ### Added
 
 - Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
@@ -223,7 +225,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Initial release
 
-[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.1.0...development
+[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.2.0...development
+[1.2.0]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.4...v1.2.0
 [1.1.0]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.0.2...v1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Ability to disable pagination (https://github.com/rappasoft/laravel-livewire-tables/pull/222)
 - Ability to define the sorting direction names for each column. i.e. A-Z, Z-A, Yes, No, Enabled, Disabled, etc.
+- Added ability to define primary key of rows for bulk select
+- Added selectedKeys property that returns an array of the ids of the selected rows
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ public array $sortDirectionNames = [
         'desc' => 'No',
     ],
 ];
+```
 
 ### Defining The Query
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ class Table extends DataTableComponent
     {
         return [
             Column::make('Type')
-                ->sortable(),
+                ->sortable()
+				->searchable(),
             Column::make('Name')
-                ->sortable(),
+                ->sortable()
+				->searchable(),
             Column::make('Permissions'),
             Column::blank(),
         ];
@@ -345,7 +347,14 @@ public array $filterNames = [
 
 ### Adding Search
 
-The search is a special built-in filter that is managed by the component, but you need to define the search query, you can do so the same as any other filter:
+The search is a special built-in filter that is managed by the component, but you need to define the behavior. For a simple default search behavior, add searchable() to columns:
+
+```php
+Column::make('Type')
+	->searchable()
+```
+
+Sometimes the default search behavior may not meet your requirements. If this is the case, skip using the searchable() method on columns and define your own behavior directly on the query.
 
 ```php
 public function query(): Builder

--- a/README.md
+++ b/README.md
@@ -375,9 +375,15 @@ And then using it like this:
 }
 ```
 
-### Creating Bulk Actions
+### Bulk Actions
 
 Bulk actions are not required, and the bulk actions box, as well as the left-hand checkboxes will be hidden if none are defined.
+
+#### The primary key
+
+Each row must have a primary key, it's `'id'` by default but you can override it with the `$primaryKey` property.
+
+#### Defining Bulk Actions
 
 To define your bulk actions, you add them to the **$bulkActions** array.
 
@@ -404,6 +410,29 @@ public function exportSelected()
 
 In the component you have access to `$this->selectedRowsQuery` which is a **Builder** instance of the selected rows.
 
+You may also call `selectedKeys` which gives you an array of the primary keys in order they were selected:
+
+**Note:** See above to setting the primary key if not `'id`.
+
+```php
+public function exportSelected()
+{
+    if (count($this->selectedKeys)) {
+        // Do something with the selected rows
+        dd($this->selectedKeys);
+        
+//        => [
+//            1,
+//            2,
+//            3,
+//            4,
+//        ]   
+    }
+
+    // Notify there is nothing to export
+}
+```
+
 ### Options
 
 There are some class level properties you can set:
@@ -420,6 +449,7 @@ There are some class level properties you can set:
 | $sortDirectionNames | [] | string[] | Change the direction name of the column for the sorting pill display (i.e. A-Z, Z-A) |
 | $perPage | 10 | int | The default per page amount selected (must exist in list) |
 | $perPageAccepted | [10, 25, 50] | int[] | The values for the per page dropdown, in order |
+| $primaryKey | id | string | The column to pluck for bulk actions to populate the `selectedKeys` property |
 | $searchFilterDebounce | null | null/int | Adds a debounce of `$searchFilterDebounce` ms to the search input |
 | $searchFilterDefer | null | null/bool | Adds `.defer` to the search input |
 | $searchFilterLazy | null | null/bool | Adds `.lazy` to the search input |

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -123,15 +123,19 @@ abstract class DataTableComponent extends Component
     {
         $this->cleanFilters();
 
-        return $this->applySorting($this->query());
-    }
+        $query = $this->query();
 
-    /**
-     * @return Builder
-     */
-    public function getRowsQueryProperty(): Builder
-    {
-        return $this->rowsQuery();
+        // sorting?
+        if (method_exists($this, 'applySorting')) {
+            $query = $this->applySorting($query);
+        }
+
+        // searching?
+        if (method_exists($this, 'applySearchFilter')) {
+            $query = $this->applySearchFilter($query);
+        }
+
+        return $query;
     }
 
     /**

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -7,6 +7,7 @@ namespace Rappasoft\LaravelLivewireTables\Traits;
  */
 trait WithBulkActions
 {
+    public string $primaryKey = 'id';
     public bool $showFilters = true;
     public bool $selectPage = false;
     public bool $selectAll = false;
@@ -40,7 +41,7 @@ trait WithBulkActions
 
     public function selectPageRows(): void
     {
-        $this->selected = $this->rows->pluck('id')->map(fn ($id) => (string) $id);
+        $this->selected = $this->rows->pluck($this->primaryKey)->map(fn ($id) => (string) $id);
     }
 
     public function selectAll(): void
@@ -59,5 +60,10 @@ trait WithBulkActions
     {
         return (clone $this->rowsQuery())
             ->unless($this->selectAll, fn ($query) => $query->whereKey($this->selected));
+    }
+
+    public function getSelectedKeysProperty()
+    {
+        return $this->selectedRowsQuery->pluck($this->primaryKey)->toArray();
     }
 }

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -2,6 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
+
 /**
  * Trait WithBulkActions.
  */
@@ -41,7 +43,7 @@ trait WithBulkActions
 
     public function selectPageRows(): void
     {
-        $this->selected = $this->rows->pluck($this->primaryKey)->map(fn ($id) => (string) $id);
+        $this->selected = $this->rows->pluck($this->primaryKey)->map(fn ($key) => (string) $key);
     }
 
     public function selectAll(): void
@@ -56,14 +58,24 @@ trait WithBulkActions
         $this->selected = [];
     }
 
-    public function getSelectedRowsQueryProperty()
+    public function selectedRowsQuery(): Builder
     {
         return (clone $this->rowsQuery())
             ->unless($this->selectAll, fn ($query) => $query->whereKey($this->selected));
     }
 
-    public function getSelectedKeysProperty()
+    public function getSelectedRowsQueryProperty(): Builder
     {
-        return $this->selectedRowsQuery->pluck($this->primaryKey)->toArray();
+        return $this->selectedRowsQuery();
+    }
+
+    public function selectedKeys(): array
+    {
+        return $this->selectedRowsQuery()->pluck($this->primaryKey)->toArray();
+    }
+
+    public function getSelectedKeysProperty(): array
+    {
+        return $this->selectedKeys();
     }
 }

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -236,8 +236,15 @@ trait WithFilters
                     // if the column isn't a relation or if it was previously selected
                     } elseif (! $hasRelation || $selectedColumn) {
 
+                        $whereColumn = $selectedColumn ?? $column->column();
+
+                        // @todo: skip aggregates
+                        if (!$hasRelation && $query instanceof Builder) {
+                            $whereColumn = $query->getModel()->getTable() . '.' . $whereColumn;
+                        }
+
                         // we can use a simple where clause
-                        $subQuery->orWhere($selectedColumn ?? $column->column(), 'like', '%' . $search . '%');
+                        $subQuery->orWhere($whereColumn, 'like', '%' . $search . '%');
 
                     } else {
 

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -2,6 +2,10 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\Utilities\ColumnUtilities;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+
 /**
  * Trait WithFilters.
  */
@@ -182,5 +186,76 @@ trait WithFilters
     public function getFilterOptions(string $filter): array
     {
         return array_filter(array_keys($this->filters()[$filter]->options() ?? []));
+    }
+
+    /**
+     * Collects columns with $searchable = true
+     *
+     * @return Column[]
+     */
+    public function getSearchableColumns() : array
+    {
+        return array_filter($this->columns(), function(Column $column) {
+            return $column->isSearchable();
+        });
+    }
+
+    /**
+     * Apply Search Filter
+     *
+     * @param Builder $query
+     * @return Builder
+     */
+    public function applySearchFilter(Builder $query): Builder
+    {
+        if ($this->hasFilter('search')) {
+
+            // get search value
+            $search = $this->getFilter('search');
+
+            // trim
+            $search = trim($search);
+
+            // group search conditions together
+            $query->where(function (Builder $subQuery) use ($search, $query) {
+
+                foreach ($this->getSearchableColumns() as $column) {
+
+                    // does this column have an alias or relation?
+                    $hasRelation = ColumnUtilities::hasRelation($column->column());
+
+                    // let's try to map this column to a selected column
+                    $selectedColumn = ColumnUtilities::mapToSelected($column->column(), $query);
+
+                    // if the column has a search callback, just use that
+                    if ($column->searchCallback) {
+
+                        // call the callback
+                        ($column->searchCallback)($query, $search);
+
+                    // if the column isn't a relation or if it was previously selected
+                    } elseif (! $hasRelation || $selectedColumn) {
+
+                        // we can use a simple where clause
+                        $subQuery->orWhere($selectedColumn ?? $column->column(), 'like', '%' . $search . '%');
+
+                    } else {
+
+                        // parse the column
+                        $relationName = ColumnUtilities::parseRelation($column->column());
+                        $fieldName = ColumnUtilities::parseField($column->column());
+
+                        // we use whereHas which can work with unselected relations
+                        $subQuery->orWhereHas($relationName, function (Builder $hasQuery) use ($fieldName, $column, $search) {
+                            $hasQuery->where($fieldName, 'like', '%' . $search . '%');
+                        });
+
+                    }
+                }
+            });
+
+        }
+
+        return $query;
     }
 }

--- a/src/Utilities/ColumnUtilities.php
+++ b/src/Utilities/ColumnUtilities.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Utilities;
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as Builder;
+use Illuminate\Support\Str;
+
+class ColumnUtilities
+{
+    /**
+     * Grab the relation part of a column
+     *
+     * @param $column
+     * @return bool
+     */
+    public static function hasRelation($column)
+    {
+        return Str::contains($column, '.');
+    }
+
+    /**
+     * Grab the relation part of a column
+     *
+     * @param $column
+     * @return string
+     */
+    public static function parseRelation($column)
+    {
+        return Str::beforeLast($column, '.');
+    }
+
+    /**
+     * Grab the field part of a column
+     *
+     * @param $column
+     * @return string
+     */
+    public static function parseField($column)
+    {
+        return Str::afterLast($column, '.');
+    }
+
+    /**
+     * Is the column selected?
+     *
+     * @param $column
+     * @param $searchColumns
+     * @return bool
+     */
+    public static function hasMatch($column, $searchColumns)
+    {
+        return array_search($column, $searchColumns ?? []) !== false;
+    }
+
+    /**
+     * Is the column selected by a wildcard match?
+     *
+     * @param $column
+     * @param $searchColumns
+     * @return bool
+     */
+    public static function hasWildcardMatch($column, $searchColumns)
+    {
+        return count(array_filter($searchColumns ?? [], function ($searchColumn) use ($column) {
+
+                // match wildcards such as * or table.*
+                $hasWildcard = Str::endsWith($searchColumn, '*');
+
+                // if no wildcard, skip
+                if (! $hasWildcard) {
+                    return false;
+                }
+
+                if (! self::hasRelation($column)) {
+                    return true;
+                } else {
+                    $selectColumnPrefix = self::parseRelation($searchColumn);
+                    $columnPrefix = self::parseRelation($column);
+
+                    return $selectColumnPrefix === $columnPrefix;
+                }
+
+            })) > 0;
+    }
+
+    /**
+     * @param EloquentBuilder|Builder $queryBuilder
+     * @return null
+     */
+    public static function columnsFromBuilder($queryBuilder = null)
+    {
+        if ($queryBuilder instanceof EloquentBuilder) {
+            return $queryBuilder->getQuery()->columns;
+        } elseif ($queryBuilder instanceof Builder) {
+            return $queryBuilder->columns;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Try to map a given column to an already selected column
+     *
+     * @param $column
+     * @param $queryBuilder
+     * @return string
+     */
+    public static function mapToSelected($column, $queryBuilder)
+    {
+        // grab select
+        $select = self::columnsFromBuilder($queryBuilder);
+
+        // can't match anything if no select
+        if (is_null($select)) {
+            return null;
+        }
+
+        // search builder select for a match
+        $hasMatch = self::hasMatch($column, $select);
+
+        // example 2 - match
+        // column: service_statuses.name
+        // select: service_statuses.name
+        // maps to: service_statuses.name
+
+        // if we found a match, lets use that instead of searching relations
+        if ($hasMatch) {
+            return $column;
+        }
+
+        // search builder select for a wildcard match
+        $hasWildcardMatch = self::hasWildcardMatch($column, $select);
+
+        // example 3 - wildcard match
+        // column: service_statuses.name
+        // select: service_statuses.*
+        // maps to: service_statuses.name
+
+        // if we found a wildcard match, lets use that instead of matching relations
+        if ($hasWildcardMatch) {
+            return $column;
+        }
+
+        // split the relation and field
+        $hasRelation = self::hasRelation($column);
+        $relationName = self::parseRelation($column);
+        $fieldName = self::parseField($column);
+
+        // we know there is a relation and we know it doesn't match any of the
+        // select columns. Let's try to grab the table name for the relation
+        // and see if that matches something in the select
+        //
+        // example 4 - relation to already selected table
+        // column: serviceStatus.name
+        // select: service_statuses.name
+        // maps to: service_statuses.name
+
+        // if we didn't previously match the column and there isn't a relation
+        if (! $hasRelation) {
+
+            // there's nothing else to do
+            return null;
+
+        // this is easiest when using the eloquent query builder
+        } elseif ($queryBuilder instanceof EloquentBuilder) {
+
+            $relation = $queryBuilder->getRelation($relationName);
+            $possibleTable = $relation->getModel()->getTable();
+
+        } elseif ($queryBuilder instanceof Builder) {
+
+            // @todo: possible ways to do this?
+            $possibleTable = null;
+
+        } else {
+
+            // we would have already returned before this is possible
+            $possibleTable = null;
+
+        }
+
+        // if we found a possible table
+        if (! is_null($possibleTable)) {
+
+            // build possible selected column
+            $possibleSelectColumn = $possibleTable . '.' . $fieldName;
+
+            $possibleMatch = self::hasMatch($possibleSelectColumn, $select);
+
+            // if we found a possible match for a relation to an already selected
+            // column, let's use that
+            if ($possibleMatch) {
+                return $possibleSelectColumn;
+            }
+
+            $possibleWildcardMatch = self::hasWildcardMatch($possibleSelectColumn, $select);
+
+            // ditto with a possible wildcard match
+            if ($possibleWildcardMatch) {
+                return $possibleSelectColumn;
+            }
+        }
+
+        // we couldn't match to a selected column
+        return null;
+    }
+}

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -30,6 +30,16 @@ class Column
     public $sortCallback;
 
     /**
+     * @var bool
+     */
+    public bool $searchable = false;
+
+    /**
+     * @var callable
+     */
+    public $searchCallback;
+
+    /**
      * @var string|null
      */
     public ?string $class = null;
@@ -100,6 +110,14 @@ class Column
     /**
      * @return bool
      */
+    public function isSearchable(): bool
+    {
+        return $this->searchable === true;
+    }
+
+    /**
+     * @return bool
+     */
     public function isBlank(): bool
     {
         return $this->blank === true;
@@ -113,6 +131,19 @@ class Column
         $this->sortable = true;
 
         $this->sortCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @param callable|null $callback
+     * @return $this
+     */
+    public function searchable(callable $callback = null): self
+    {
+        $this->searchable = true;
+
+        $this->searchCallback = $callback;
 
         return $this;
     }

--- a/tests/ColumnUtilitiesTest.php
+++ b/tests/ColumnUtilitiesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
+use Rappasoft\LaravelLivewireTables\Utilities\ColumnUtilities;
+
+class ColumnUtilitiesTest extends TestCase
+{
+    protected $query;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /** @test */
+    public function test_parse_relation(): void
+    {
+        $this->assertFalse(ColumnUtilities::hasRelation('id'));
+        $this->assertTrue(ColumnUtilities::hasRelation('pets.id'));
+        $this->assertEquals('pets', ColumnUtilities::parseRelation('pets.id'));
+        $this->assertEquals('pets.breeds', ColumnUtilities::parseRelation('pets.breeds.id'));
+    }
+
+    /** @test */
+    public function test_parse_field(): void
+    {
+        $this->assertEquals('id', ColumnUtilities::parseField('pets.id'));
+    }
+
+    /** @test */
+    public function test_has_match(): void
+    {
+        $this->assertTrue(ColumnUtilities::hasMatch('id', ['id', 'name']));
+        $this->assertTrue(ColumnUtilities::hasMatch('name', ['id', 'name']));
+    }
+
+    /** @test */
+    public function test_has_wildcard_match(): void
+    {
+        $this->assertTrue(ColumnUtilities::hasWildcardMatch('id', ['*']));
+        $this->assertTrue(ColumnUtilities::hasWildcardMatch('pets.id', ['pets.*']));
+    }
+
+    /** @test */
+    public function test_get_columns(): void
+    {
+        $query = Pet::query();
+        $this->assertIsNotArray(ColumnUtilities::columnsFromBuilder($query));
+        $query->select('id', 'name');
+        $this->assertIsArray(ColumnUtilities::columnsFromBuilder($query));
+        $this->assertCount(2, ColumnUtilities::columnsFromBuilder($query));
+        $this->assertEquals(['id', 'name',], ColumnUtilities::columnsFromBuilder($query));
+    }
+
+    /** @test */
+    public function test_map(): void
+    {
+        // simple match
+        $query = Pet::query()->select('id');
+        $this->assertEquals('id', ColumnUtilities::mapToSelected('id', $query));
+
+        // wildcard match
+        $query = Pet::query()->select('*');
+        $this->assertEquals('id', ColumnUtilities::mapToSelected('id', $query));
+
+        // alias match
+        $query = Pet::query()->select('pets.id');
+        $this->assertEquals('pets.id', ColumnUtilities::mapToSelected('pets.id', $query));
+
+        // alias wildcard match
+        $query = Pet::query()->select('pets.*');
+        $this->assertEquals('pets.id', ColumnUtilities::mapToSelected('pets.id', $query));
+
+        // join relation wildcard match
+        $query = Pet::query()->select('breeds.*')->join('breeds', 'pets.breeds_id', '=', 'breeds.id');
+        $this->assertEquals('breeds.id', ColumnUtilities::mapToSelected('breeds.id', $query));
+        // using relation only
+        $this->assertEquals('breeds.id', ColumnUtilities::mapToSelected('breed.id', $query));
+    }
+}

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -5,17 +5,20 @@ namespace Rappasoft\LaravelLivewireTables\Tests;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsAltQueryTable;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 
 class DataTableComponentTest extends TestCase
 {
     protected DataTableComponent $table;
+    protected DataTableComponent $tableAltQuery;
 
     public function setUp(): void
     {
         parent::setUp();
 
         $this->table = new PetsTable();
+        $this->tableAltQuery = new PetsAltQueryTable();
     }
 
     /** @test */
@@ -89,5 +92,17 @@ class DataTableComponentTest extends TestCase
         $this->table->filters['search'] = 'Cartman';
         $this->table->removeFilter('search');
         $this->assertEquals(5, $this->table->rows->total());
+    }
+
+    public function test_search_filter_alt_query()
+    {
+        $this->tableAltQuery->filters['search'] = 'Cartman';
+        $this->assertEquals(1, $this->tableAltQuery->rows->total());
+    }
+
+    public function test_search_filter_alt_query_relation()
+    {
+        $this->tableAltQuery->filters['search'] = 'Cat';
+        $this->assertEquals(2, $this->tableAltQuery->rows->total());
     }
 }

--- a/tests/Http/Livewire/PetsAltQueryTable.php
+++ b/tests/Http/Livewire/PetsAltQueryTable.php
@@ -7,16 +7,16 @@ use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 
-class PetsTable extends DataTableComponent
+class PetsAltQueryTable extends DataTableComponent
 {
     /**
      * @return Builder
      */
     public function query() : Builder
     {
-        return Pet::query()
-            ->with('species')
-            ->with('breed');
+        return Pet::query()->select('pets.name', 'pets.age', 'pets.last_visit', 'species.name', 'breeds.name')
+                            ->join('species', 'pets.species_id', '=', 'species.id')
+                            ->join('breeds', 'breed_id', '=', 'breeds.id');
     }
 
     public function columns(): array

--- a/tests/Models/Pet.php
+++ b/tests/Models/Pet.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $last_visit
  * @property int $species_id
  * @property int $breed_id
+ * @property Species $species
+ * @property Breed $breed
  */
 class Pet extends Model
 {
@@ -48,7 +50,7 @@ class Pet extends Model
     ];
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo|Species[]
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo|Species
      */
     public function species()
     {
@@ -56,9 +58,9 @@ class Pet extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo|Breed[]
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo|Breed
      */
-    public function breeds()
+    public function breed()
     {
         return $this->belongsTo(Breed::class);
     }


### PR DESCRIPTION
Follow-up to https://github.com/rappasoft/laravel-livewire-tables/pull/210

* re-added searchable() method to columns
* added applySearchFilter() which applies default search behavior to searchable() columns
* utilities class to replace pre 1.0 trait functionality
* tests


