### PR TITLE
patch searchCallback

### DIFF
--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -256,7 +256,6 @@ trait WithFilters
                     }
                 }
             });
-
         }
 
         return $query;

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -230,7 +230,7 @@ trait WithFilters
                     if ($column->searchCallback) {
 
                         // call the callback
-                        ($column->searchCallback)($query, $search);
+                        ($column->searchCallback)($subQuery, $search);
 
                     // if the column isn't a relation or if it was previously selected
                     } elseif (! $hasRelation || $selectedColumn) {
@@ -256,6 +256,7 @@ trait WithFilters
                     }
                 }
             });
+
         }
 
         return $query;

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -94,6 +94,13 @@ class DataTableComponentTest extends TestCase
         $this->assertEquals(5, $this->table->rows->total());
     }
 
+    /** @test */
+    public function test_search_filter_callback(): void
+    {
+        $this->table->filters['search'] = '2';
+        $this->assertEquals(1, $this->table->getRowsProperty()->total());
+    }
+
     public function test_search_filter_alt_query()
     {
         $this->tableAltQuery->filters['search'] = 'Cartman';

--- a/tests/Http/Livewire/PetsTable.php
+++ b/tests/Http/Livewire/PetsTable.php
@@ -25,7 +25,7 @@ class PetsTable extends DataTableComponent
             Column::make('Name', 'name')
                 ->searchable(),
             Column::make('Age', 'age')
-                ->searchable(function(Builder $query, $search){
+                ->searchable(function (Builder $query, $search) {
                     $query->orWhere('age', '=', $search);
                 }),
             Column::make('Last Visit', 'last_visit')

--- a/tests/Http/Livewire/PetsTable.php
+++ b/tests/Http/Livewire/PetsTable.php
@@ -25,7 +25,9 @@ class PetsTable extends DataTableComponent
             Column::make('Name', 'name')
                 ->searchable(),
             Column::make('Age', 'age')
-                ->searchable(),
+                ->searchable(function(Builder $query, $search){
+                    $query->orWhere('age', '=', $search);
+                }),
             Column::make('Last Visit', 'last_visit')
                 ->searchable(),
             Column::make('Species', 'species.name')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,7 +40,7 @@ class TestCase extends Orchestra
         Pet::insert([
             [ 'id' => 1, 'name' => 'Cartman', 'age' => 22, 'species_id' => 1, 'breed_id' => 4 ],
             [ 'id' => 2, 'name' => 'Tux', 'age' => 8, 'species_id' => 1, 'breed_id' => 4 ],
-            [ 'id' => 3, 'name' => 'May', 'age' => 3, 'species_id' => 2, 'breed_id' => 102 ],
+            [ 'id' => 3, 'name' => 'May', 'age' => 2, 'species_id' => 2, 'breed_id' => 102 ],
             [ 'id' => 4, 'name' => 'Ben', 'age' => 5, 'species_id' => 3, 'breed_id' => 200 ],
             [ 'id' => 5, 'name' => 'Chico', 'age' => 7, 'species_id' => 3, 'breed_id' => 202 ],
         ]);


### PR DESCRIPTION
searchCallback was being passed the wrong query parameter. This was resulting in issues where the callback clauses were competing with other (i.e. searchable()) clauses.