### PR TITLE
fix results count on tailwind theme

### DIFF
--- a/resources/views/tailwind/includes/pagination.blade.php
+++ b/resources/views/tailwind/includes/pagination.blade.php
@@ -1,5 +1,7 @@
-@if ($paginationEnabled && $showPerPage)
-    <div class="p-6 md:p-0">
+<div class="p-6 md:p-0">
+    @if ($paginationEnabled && $showPerPage && $rows->lastPage() > 1)
         {{ $rows->links() }}
-    </div>
-@endif
+    @else
+        <p class="text-sm text-gray-700 leading-5">Showing {{ $rows->count() }} results</p>
+    @endif
+</div>


### PR DESCRIPTION
Ensures that a results count is displayed even when a) there is less than one page of results and b) pagination is disabled