### PR TITLE
Set "selectAll", if the current count is all

### DIFF
--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -44,6 +44,8 @@ trait WithBulkActions
     public function selectPageRows(): void
     {
         $this->selected = $this->rows->pluck($this->primaryKey)->map(fn ($key) => (string) $key);
+
+        $this->selectAll = count($this->selected) === $this->rows->count();
     }
 
     public function selectAll(): void


### PR DESCRIPTION
Hello @rappasoft,

I've noticed the bulk message being incorrect if there is only one page of entries:

![image](https://user-images.githubusercontent.com/8433587/116850218-4e16e480-ac01-11eb-9ee9-cdf36c0f86c3.png)

This PR should fix this.

Cheers,
Peter