### PR TITLE
Allows to use Relation instead of Builder to generate data

### DIFF
--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
@@ -99,9 +100,9 @@ abstract class DataTableComponent extends Component
     /**
      * The base query with search and filters for the table.
      *
-     * @return Builder
+     * @return Builder|Relation
      */
-    abstract public function query(): Builder;
+    abstract public function query();
 
     /**
      * TableComponent constructor.
@@ -124,9 +125,9 @@ abstract class DataTableComponent extends Component
     /**
      * Get the rows query builder with sorting applied.
      *
-     * @return Builder
+     * @return Builder|Relation
      */
-    public function rowsQuery(): Builder
+    public function rowsQuery()
     {
         $this->cleanFilters();
 

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -3,6 +3,7 @@
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**
  * Trait WithBulkActions.
@@ -58,13 +59,19 @@ trait WithBulkActions
         $this->selected = [];
     }
 
-    public function selectedRowsQuery(): Builder
+    /**
+     * @return Builder|Relation
+     */
+    public function selectedRowsQuery()
     {
         return (clone $this->rowsQuery())
             ->unless($this->selectAll, fn ($query) => $query->whereIn($this->primaryKey, $this->selected));
     }
 
-    public function getSelectedRowsQueryProperty(): Builder
+    /**
+     * @return Builder|Relation
+     */
+    public function getSelectedRowsQueryProperty()
     {
         return $this->selectedRowsQuery();
     }

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\Utilities\ColumnUtilities;
 use Rappasoft\LaravelLivewireTables\Views\Column;
@@ -253,10 +254,10 @@ trait WithFilters
     /**
      * Apply Search Filter
      *
-     * @param Builder $query
-     * @return Builder
+     * @param Builder|Relation $query
+     * @return Builder|Relation
      */
-    public function applySearchFilter(Builder $query): Builder
+    public function applySearchFilter($query)
     {
         $searchableColumns = $this->getSearchableColumns();
 

--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -34,7 +35,12 @@ trait WithSorting
         return null;
     }
 
-    public function applySorting(Builder $query): Builder
+    /**
+     * @param  Builder|Relation  $query
+     *
+     * @return Builder|Relation
+     */
+    public function applySorting($query)
     {
         foreach ($this->sorts as $field => $direction) {
             if (optional($this->getColumn($field))->hasSortCallback()) {

--- a/tests/Http/Livewire/CatsTable.php
+++ b/tests/Http/Livewire/CatsTable.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
+
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+
+class CatsTable extends DataTableComponent
+{
+    public function query(): Relation
+    {
+        /** @var Species $dogSpecimen */
+        $dogSpecimen = Species::query()->where('name', 'Cat')->first();
+
+        return $dogSpecimen->pets()->with('species')->with('breed');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('Name', 'name')
+                ->searchable(),
+            Column::make('Age', 'age')
+                ->searchable(function (Builder $query, $search) {
+                    $query->orWhere('age', '=', $search);
+                }),
+            Column::make('Last Visit', 'last_visit')
+                ->searchable(),
+            Column::make('Species', 'species.name')
+                ->searchable(),
+            Column::make('Breed', 'breed.name')
+                ->searchable(),
+        ];
+    }
+}

--- a/tests/Models/Species.php
+++ b/tests/Models/Species.php
@@ -3,6 +3,7 @@
 namespace Rappasoft\LaravelLivewireTables\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property int $id
@@ -38,4 +39,9 @@ class Species extends Model
         'id',
         'name',
     ];
+
+    public function pets(): HasMany
+    {
+        return $this->hasMany(Pet::class);
+    }
 }

--- a/tests/RelationshipDataTableComponentTest.php
+++ b/tests/RelationshipDataTableComponentTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\CatsTable;
+
+class RelationshipDataTableComponentTest extends TestCase
+{
+    protected DataTableComponent $table;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->table = new CatsTable();
+    }
+
+    /** @test */
+    public function bootstrap_test_datatable(): void
+    {
+        $this->assertInstanceOf(DataTableComponent::class, $this->table);
+    }
+
+    /** @test */
+    public function columns(): void
+    {
+        $columns = $this->table->columns();
+
+        $this->assertCount(5, $columns);
+    }
+
+    /** @test */
+    public function rows(): void
+    {
+        $rows = $this->table->rows;
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $rows);
+        $this->assertEquals(2, $this->table->getRowsProperty()->total());
+    }
+
+    /** @test */
+    public function pagination_default(): void
+    {
+        $this->assertInstanceOf(LengthAwarePaginator::class, $this->table->rows);
+        $this->assertEquals(10, $this->table->perPage);
+        $this->assertTrue($this->table->paginationEnabled);
+        $this->assertTrue($this->table->showPerPage);
+    }
+
+    /** @test */
+    public function pagination(): void
+    {
+        $this->table->perPage = 1;
+        $this->assertEquals(1, $this->table->rows->currentPage());
+        $this->assertEquals(1, $this->table->rows->count());
+        $this->assertEquals(2, $this->table->rows->lastPage());
+    }
+
+    /** @test */
+    public function pagination_disabled(): void
+    {
+        $this->table->paginationEnabled = false;
+        $this->table->perPage = 2;
+        $this->assertInstanceOf(Collection::class, $this->table->rows);
+        $this->assertCount(2, $this->table->rows);
+    }
+
+    /** @test */
+    public function search_filter(): void
+    {
+        $this->table->filters['search'] = 'Cartman';
+        $this->assertEquals(1, $this->table->getRowsProperty()->total());
+    }
+
+    /** @test */
+    public function search_filter_reset(): void
+    {
+        $this->table->filters['search'] = 'Cartman';
+        $this->table->resetFilters();
+        $this->assertEquals(1, $this->table->rows->total());
+    }
+
+    /** @test */
+    public function search_filter_remove(): void
+    {
+        $this->table->filters['search'] = 'Cartman';
+        $this->table->removeFilter('search');
+        $this->assertEquals(2, $this->table->rows->total());
+    }
+
+    /** @test */
+    public function search_filter_callback(): void
+    {
+        $this->table->filters['search'] = '22';
+        $this->assertEquals(1, $this->table->getRowsProperty()->total());
+    }
+}


### PR DESCRIPTION
During my development using this awesome package, I needed to display a table taking data from a many to many relationship:

Course <=> Subscription <=> Student

in order to render a table to display all students of a specific course, I used laravel-livewire-tables and tried to take data this way

```php
class StudentstTable extends DataTableComponent
{
   //.....

   public function query(): Builder
    {
        return $this->course->students()->getQuery();
    }

  //.....
}
```

I thought everything worked until I tried to take one of the row's ID and found that it was not the ID of the Student, but the ID of the pivot table (Subscription)

that's because getQuery() of a many to many relationship mixes columns of both tables

an elegant solution would be to return an `Illuminate\Database\Eloquent\Relations\Relation` instead of the Builder:

```php
class StudentstTable extends DataTableComponent
{
   //.....

   public function query(): Builder|Relation
    {
        return $this->course->students();
    }

  //.....
}
```

but this is not possible because of the strict return type checking of the query() method's signature


this PR slightly changes the code in order to loose the strict type checking, allowing to return a Relation. 

every test runs smoothly without any change and this is a non breaking change: removing typechecking from parent method allows to still use typechecking on the classes extending it.

I could not use union types because of the php7.4 requirement, maybe this would be a nice additional PR in a future version as the php7.4 requirement will be dropped


@rappasoft sorry for my english, I'm not a native speaker. I hope to have well explained my goal with this pull request

and thanks for you awesome work! You saved me a lot of code!


edit: **added tests**