### PR TITLE
Fix ambiguous column id when using Relation instead of Builder

### DIFF
--- a/database/migrations/create_test_tables.php.stub
+++ b/database/migrations/create_test_tables.php.stub
@@ -35,5 +35,17 @@ class CreateTestTables extends Migration
             $table->foreign('species_id')->references('id')->on('species');
             $table->foreign('breed_id')->references('id')->on('breeds');
         });
+
+        Schema::create('veterinaries', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->index();
+            $table->string('phone')->index();
+        });
+
+        Schema::create('pet_veterinary', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pet_id')->constrained();
+            $table->foreignId('veterinary_id')->constrained();
+        });
     }
 }

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -65,7 +65,7 @@ trait WithBulkActions
     public function selectedRowsQuery()
     {
         return (clone $this->rowsQuery())
-            ->unless($this->selectAll, fn ($query) => $query->whereIn($this->primaryKey, $this->selected));
+            ->unless($this->selectAll, fn ($query) => $query->whereIn($query->qualifyColumn($this->primaryKey), $this->selected));
     }
 
     /**
@@ -78,7 +78,7 @@ trait WithBulkActions
 
     public function selectedKeys(): array
     {
-        return $this->selectedRowsQuery()->pluck($this->primaryKey)->toArray();
+        return $this->selectedRowsQuery()->pluck($this->rowsQuery()->qualifyColumn($this->primaryKey))->toArray();
     }
 
     public function getSelectedKeysProperty(): array

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -65,7 +65,7 @@ trait WithBulkActions
     public function selectedRowsQuery()
     {
         return (clone $this->rowsQuery())
-            ->unless($this->selectAll, fn ($query) => $query->whereIn($query->qualifyColumn($this->primaryKey), $this->selected));
+            ->unless($this->selectAll, fn ($query) => $query->whereIn($this->primaryKey, $this->selected));
     }
 
     /**

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -65,7 +65,7 @@ trait WithBulkActions
     public function selectedRowsQuery()
     {
         return (clone $this->rowsQuery())
-            ->unless($this->selectAll, fn ($query) => $query->whereIn($this->primaryKey, $this->selected));
+            ->unless($this->selectAll, fn ($query) => $query->whereIn($query->qualifyColumn($this->primaryKey), $this->selected));
     }
 
     /**

--- a/tests/Http/Livewire/CatsTable.php
+++ b/tests/Http/Livewire/CatsTable.php
@@ -11,6 +11,10 @@ use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class CatsTable extends DataTableComponent
 {
+    public array $bulkActions = [
+        'feed' => 'Feed selected',
+    ];
+
     public function query(): Relation
     {
         /** @var Species $dogSpecimen */
@@ -35,5 +39,9 @@ class CatsTable extends DataTableComponent
             Column::make('Breed', 'breed.name')
                 ->searchable(),
         ];
+    }
+
+    public function feed(): int{
+        return $this->selectedRowsQuery()->count();
     }
 }

--- a/tests/Http/Livewire/PetVeterinariesTable.php
+++ b/tests/Http/Livewire/PetVeterinariesTable.php
@@ -6,21 +6,21 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 
-class CatsTable extends DataTableComponent
+class PetVeterinariesTable extends DataTableComponent
 {
+    public Pet $pet;
+
     public array $bulkActions = [
-        'feed' => 'Feed selected',
+        'count' => 'Count selected',
     ];
 
     public function query(): Relation
     {
-        /** @var Species $dogSpecimen */
-        $dogSpecimen = Species::query()->where('name', 'Cat')->first();
-
-        return $dogSpecimen->pets()->with('species')->with('breed');
+        return $this->pet->veterinaries();
     }
 
     public function columns(): array
@@ -28,20 +28,14 @@ class CatsTable extends DataTableComponent
         return [
             Column::make('Name', 'name')
                 ->searchable(),
-            Column::make('Age', 'age')
+            Column::make('Phone', 'phone')
                 ->searchable(function (Builder $query, $search) {
-                    $query->orWhere('age', '=', $search);
+                    $query->orWhere('phone', '=', $search);
                 }),
-            Column::make('Last Visit', 'last_visit')
-                ->searchable(),
-            Column::make('Species', 'species.name')
-                ->searchable(),
-            Column::make('Breed', 'breed.name')
-                ->searchable(),
         ];
     }
 
-    public function feed(): int{
+    public function count(): int{
         return $this->selectedRowsQuery()->count();
     }
 }

--- a/tests/Models/Pet.php
+++ b/tests/Models/Pet.php
@@ -3,6 +3,7 @@
 namespace Rappasoft\LaravelLivewireTables\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property int $id
@@ -63,5 +64,9 @@ class Pet extends Model
     public function breed()
     {
         return $this->belongsTo(Breed::class);
+    }
+
+    public function veterinaries(): BelongsToMany{
+        return $this->belongsToMany(Veterinary::class);
     }
 }

--- a/tests/Models/Veterinary.php
+++ b/tests/Models/Veterinary.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Models;
+
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Veterinary extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'veterinaries';
+
+    /**
+     * The primary key for the model.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'name',
+        'phone',
+    ];
+
+    public function pets(): BelongsToMany{
+        return $this->belongsToMany(Pet::class);
+    }
+}

--- a/tests/RelationshipDataTableComponentTest.php
+++ b/tests/RelationshipDataTableComponentTest.php
@@ -6,7 +6,8 @@ use Amp\ByteStream\StreamException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\CatsTable;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetVeterinariesTable;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 
 class RelationshipDataTableComponentTest extends TestCase
 {
@@ -16,7 +17,8 @@ class RelationshipDataTableComponentTest extends TestCase
     {
         parent::setUp();
 
-        $this->table = new CatsTable();
+        $this->table = new PetVeterinariesTable();
+        $this->table->pet = Pet::find(1);
     }
 
     /** @test */
@@ -30,7 +32,7 @@ class RelationshipDataTableComponentTest extends TestCase
     {
         $columns = $this->table->columns();
 
-        $this->assertCount(5, $columns);
+        $this->assertCount(2, $columns);
     }
 
     /** @test */
@@ -72,14 +74,14 @@ class RelationshipDataTableComponentTest extends TestCase
     /** @test */
     public function search_filter(): void
     {
-        $this->table->filters['search'] = 'Cartman';
+        $this->table->filters['search'] = 'John';
         $this->assertEquals(1, $this->table->getRowsProperty()->total());
     }
 
     /** @test */
     public function search_filter_reset(): void
     {
-        $this->table->filters['search'] = 'Cartman';
+        $this->table->filters['search'] = 'John';
         $this->table->resetFilters();
         $this->assertEquals(1, $this->table->rows->total());
     }
@@ -87,7 +89,7 @@ class RelationshipDataTableComponentTest extends TestCase
     /** @test */
     public function search_filter_remove(): void
     {
-        $this->table->filters['search'] = 'Cartman';
+        $this->table->filters['search'] = 'John';
         $this->table->removeFilter('search');
         $this->assertEquals(2, $this->table->rows->total());
     }
@@ -95,13 +97,13 @@ class RelationshipDataTableComponentTest extends TestCase
     /** @test */
     public function search_filter_callback(): void
     {
-        $this->table->filters['search'] = '22';
+        $this->table->filters['search'] = '123456798';
         $this->assertEquals(1, $this->table->getRowsProperty()->total());
     }
 
     /** @test */
     public function bulk_actions(){
         $this->table->selected[] = 1;
-        $this->assertEquals(1, $this->table->feed());
+        $this->assertEquals(1, $this->table->count());
     }
 }

--- a/tests/RelationshipDataTableComponentTest.php
+++ b/tests/RelationshipDataTableComponentTest.php
@@ -2,7 +2,6 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests;
 
-use Amp\ByteStream\StreamException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;

--- a/tests/RelationshipDataTableComponentTest.php
+++ b/tests/RelationshipDataTableComponentTest.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests;
 
+use Amp\ByteStream\StreamException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
@@ -96,5 +97,11 @@ class RelationshipDataTableComponentTest extends TestCase
     {
         $this->table->filters['search'] = '22';
         $this->assertEquals(1, $this->table->getRowsProperty()->total());
+    }
+
+    /** @test */
+    public function bulk_actions(){
+        $this->table->selected[] = 1;
+        $this->assertEquals(1, $this->table->feed());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,14 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests;
 
+use DB;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Rappasoft\LaravelLivewireTables\LaravelLivewireTablesServiceProvider;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Breed;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Veterinary;
+use Symfony\Component\Console\Helper\Table;
 
 class TestCase extends Orchestra
 {
@@ -43,6 +46,19 @@ class TestCase extends Orchestra
             [ 'id' => 3, 'name' => 'May', 'age' => 2, 'species_id' => 2, 'breed_id' => 102 ],
             [ 'id' => 4, 'name' => 'Ben', 'age' => 5, 'species_id' => 3, 'breed_id' => 200 ],
             [ 'id' => 5, 'name' => 'Chico', 'age' => 7, 'species_id' => 3, 'breed_id' => 202 ],
+        ]);
+
+        Veterinary::insert([
+            ['id' => 1, 'name' => 'Dr John Smith', 'phone' => "123456798"],
+            ['id' => 2, 'name' => 'Dr Fabio Ivona', 'phone' => "789456123"],
+            ['id' => 3, 'name' => 'Dr Anthony Rappa', 'phone' => "987654321"],
+        ]);
+
+        DB::table('pet_veterinary')->insert([
+            ['id' => 1, 'pet_id' => 1, 'veterinary_id' => 1],
+            ['id' => 2, 'pet_id' => 1, 'veterinary_id' => 2],
+            ['id' => 3, 'pet_id' => 2, 'veterinary_id' => 1],
+            ['id' => 4, 'pet_id' => 2, 'veterinary_id' => 3],
         ]);
     }
 


### PR DESCRIPTION
@rappasoft I noticed a slight issue when using bulk actions with a many to many Relation to generate data:

if the pivot table has an **id** field, the query will generate an _integrity constraint violation_ when using the **id** column to filter data:

```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in field list is ambiguous (SQL: select `id` from `students` inner join `subscriptions` on `students`.`id` = `subscriptions`.`student_id` where `subscriptions`.`edition_id` = 3 and `students`.`id` in (3) order by `students`.`last_name` asc)
```

this happens when executing the `WithBulkActions::selectedRowsQuery()` and `WithBulkActions::selectedKeys()` methods and can be avoided by letting laravel to qualify the _primaryKey_ column:

`$this->primaryKey //id` 

would become:

`$query->qualifyColumn($this->primaryKey) //students.id`  


this is a very rare case, but could happen