### PR TITLE
hide filters when $showFilters is false

### DIFF
--- a/resources/views/tailwind/includes/filters.blade.php
+++ b/resources/views/tailwind/includes/filters.blade.php
@@ -1,4 +1,4 @@
-@if ($filtersView || count($customFilters))
+@if ($showFilters && ($filtersView || count($customFilters)))
     <div
         x-data="{ open: false }"
         @keydown.escape.stop="open = false"


### PR DESCRIPTION
Pretty much the title. 

Scenario is that you have a table with filters (e.g. controlled via query parameters or another form) but you don't want the filters to show. I would expect $showFilters to hide the filters dropdown, but it currently doesn't.