### PR TITLE
Suggestion: adding .stop to select filters

### DIFF
--- a/resources/views/bootstrap-4/includes/filters.blade.php
+++ b/resources/views/bootstrap-4/includes/filters.blade.php
@@ -24,8 +24,7 @@
                                 </label>
 
                                 <select
-                                    onclick="event.stopPropagation();"
-                                    wire:model.prevent="filters.{{ $key }}"
+                                    wire:model.stop="filters.{{ $key }}"
                                     id="filter-{{ $key }}"
                                     class="form-control"
                                 >

--- a/resources/views/bootstrap-4/includes/filters.blade.php
+++ b/resources/views/bootstrap-4/includes/filters.blade.php
@@ -25,7 +25,7 @@
 
                                 <select
                                     onclick="event.stopPropagation();"
-                                    wire:model="filters.{{ $key }}"
+                                    wire:model.prevent="filters.{{ $key }}"
                                     id="filter-{{ $key }}"
                                     class="form-control"
                                 >

--- a/resources/views/bootstrap-5/includes/filters.blade.php
+++ b/resources/views/bootstrap-5/includes/filters.blade.php
@@ -24,8 +24,7 @@
                                 </label>
 
                                 <select
-                                    onclick="event.stopPropagation();"
-                                    wire:model.prevent="filters.{{ $key }}"
+                                    wire:model.stop="filters.{{ $key }}"
                                     id="filter-{{ $key }}"
                                     class="form-select"
                                 >

--- a/resources/views/bootstrap-5/includes/filters.blade.php
+++ b/resources/views/bootstrap-5/includes/filters.blade.php
@@ -25,7 +25,7 @@
 
                                 <select
                                     onclick="event.stopPropagation();"
-                                    wire:model="filters.{{ $key }}"
+                                    wire:model.prevent="filters.{{ $key }}"
                                     id="filter-{{ $key }}"
                                     class="form-select"
                                 >

--- a/resources/views/tailwind/includes/filters.blade.php
+++ b/resources/views/tailwind/includes/filters.blade.php
@@ -50,7 +50,7 @@
 
                                 <div class="mt-1 relative rounded-md shadow-sm">
                                     <select
-                                        wire:model.prevent="filters.{{ $key }}"
+                                        wire:model.stop="filters.{{ $key }}"
                                         wire:key="filter-{{ $key }}"
                                         id="filter-{{ $key }}"
                                         class="rounded-md shadow-sm block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:border-indigo-300 focus:shadow-outline-indigo sm:text-sm sm:leading-5"

--- a/resources/views/tailwind/includes/filters.blade.php
+++ b/resources/views/tailwind/includes/filters.blade.php
@@ -50,7 +50,7 @@
 
                                 <div class="mt-1 relative rounded-md shadow-sm">
                                     <select
-                                        wire:model="filters.{{ $key }}"
+                                        wire:model.prevent="filters.{{ $key }}"
                                         wire:key="filter-{{ $key }}"
                                         id="filter-{{ $key }}"
                                         class="rounded-md shadow-sm block w-full pl-3 pr-10 py-2 text-base leading-6 border-gray-300 focus:outline-none focus:border-indigo-300 focus:shadow-outline-indigo sm:text-sm sm:leading-5"


### PR DESCRIPTION
First off @rappasoft - great work on this package! I've been using this and learning a lot from it.

I realized that when applying a filter in the dropdown component, the dropdown would close. I would suggest generally that often times multiple filters may get applied so it doesn't make sense that it closes on each change of the select box.

I'm proposing adding the ".stop" modifier on the select boxes. I wasn't sure if the Bootstrap templates needed that extra `onclick="event.stopPropagation();"` so I removed then in this commit.