### PR TITLE
Apply default sort order column and direction

### DIFF
--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -15,6 +15,8 @@ trait WithSorting
     public array $sorts = [];
     public array $sortNames = [];
     public array $sortDirectionNames = [];
+    public string $defaultSortColumn = '';
+    public string $defaultSortDirection = 'asc';
 
     public function sortBy(string $field): ?string
     {
@@ -42,6 +44,10 @@ trait WithSorting
      */
     public function applySorting($query)
     {
+        if (! empty($this->defaultSortColumn) && empty($this->sorts)) {
+            return $query->orderBy($this->defaultSortColumn, $this->defaultSortDirection);
+        }
+
         foreach ($this->sorts as $field => $direction) {
             if (optional($this->getColumn($field))->hasSortCallback()) {
                 $query = app()->call($this->getColumn($field)->getSortCallback(), ['query' => $query, 'direction' => $direction]);


### PR DESCRIPTION
Apply a default sort column and direction to the datatable.

Add the following to the datatable as properties.  For example, to order by latest you should

```php
public string $defaultSortColumn = 'created_at';
public string $defaultSortDirection = 'desc';
```

This order by will only apply if `$defaultSortColumn` is not empty, and no other column is being sorted.  i.e. `$this->sorts` is empty.