### PR TITLE
Fix tailwind style for div containing checkbox

### DIFF
--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="head">
         @if (count($bulkActions))
             <x-livewire-tables::table.heading>
-                <div class="flex rounded-md shadow-sm">
+                <div class="inline-flex rounded-md shadow-sm">
                     <input
                         wire:model="selectPage"
                         type="checkbox"
@@ -41,7 +41,7 @@
             >
                 @if (count($bulkActions))
                     <x-livewire-tables::table.cell>
-                        <div class="flex rounded-md shadow-sm">
+                        <div class="inline-flex rounded-md shadow-sm">
                             <input
                                 wire:model="selected"
                                 wire:loading.attr.delay="disabled"


### PR DESCRIPTION
When there are not a lot of columns and  the first column is wider than the checkbox the shadow extends to the whole width of the column as in screenshot below:
![2021-06-03-15-20-canaship bc](https://user-images.githubusercontent.com/4259699/120700640-e7931980-c47f-11eb-9723-42a91856e3d8.png)
Changing `flex` -> `inline-flex` fixes this issue

