### PR TITLE
v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [1.10.3] - 2021-06-22
+
+### Added
+
+- When reordering, the last known state of the table is now saved in the session so when you're done reordering you are back where you left off and no filters/sorts/search is lost.
+
+### Changed
+
+- Fixed query string getting wiped out on reload
+
 ## [1.10.2] - 2021-06-21
 
 ### Changed
@@ -398,7 +408,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Initial release
 
-[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.2...development
+[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.3...development
+[1.10.3]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.2...v1.10.3
 [1.10.2]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.9.0...v1.10.0

--- a/src/Traits/WithReordering.php
+++ b/src/Traits/WithReordering.php
@@ -16,8 +16,6 @@ trait WithReordering
         if (! $this->reorderEnabled && $this->hasReorderingSession()) {
             $this->forgetReorderingSession();
         }
-
-        $this->setReorderingProperties();
     }
 
     public function enableReordering(): void
@@ -51,6 +49,9 @@ trait WithReordering
     {
         if ($this->hasReorderingSession()) {
             $this->reordering = true;
+
+            $this->setReorderingBackup();
+
             $this->bulkActionsEnabled = false;
             $this->selectPage = false;
             $this->selectAll = false;
@@ -68,6 +69,7 @@ trait WithReordering
             $this->resetPage();
         } else {
             $this->reordering = false;
+
             $this->reset([
                 'bulkActionsEnabled',
                 'selectPage',
@@ -84,11 +86,66 @@ trait WithReordering
                 'perPageAll',
                 'perPage',
             ]);
+
+            $this->getReorderingBackup();
         }
     }
 
     private function getReorderingSessionKey(): string
     {
         return $this->tableName.'-reordering';
+    }
+
+    private function getReorderingBackupSessionKey(): string
+    {
+        return $this->tableName.'-reordering-backup';
+    }
+
+    private function setReorderingBackup(): void
+    {
+        if (session()->has($this->getReorderingBackupSessionKey())) {
+            session()->forget($this->getReorderingBackupSessionKey());
+        }
+
+        session([$this->getReorderingBackupSessionKey() => [
+            'bulkActionsEnabled' => $this->bulkActionsEnabled,
+            'selectPage' => $this->selectPage,
+            'selectAll' => $this->selectAll,
+            'selected' => $this->selected,
+            'showSorting' => $this->showSorting,
+            'sortingEnabled' => $this->sortingEnabled,
+            'filtersEnabled' => $this->filtersEnabled,
+            'sorts' => $this->sorts,
+            'filters' => $this->filters,
+            'showPagination' => $this->showPagination,
+            'showPerPage' => $this->showPerPage,
+            'showSearch' => $this->showSearch,
+            'perPageAll' => $this->perPageAll,
+            'perPage' => $this->perPage,
+            'page' => $this->page,
+        ]]);
+    }
+
+    private function getReorderingBackup(): void
+    {
+        if (session()->has($this->getReorderingBackupSessionKey())) {
+            $save = session()->get($this->getReorderingBackupSessionKey());
+            $this->bulkActionsEnabled = $save['bulkActionsEnabled'] ?? false;
+            $this->selectPage = $save['selectPage'] ?? false;
+            $this->selectAll = $save['selectAll'] ?? false;
+            $this->selected = $save['selected'] ?? [];
+            $this->showSorting = $save['showSorting'] ?? false;
+            $this->sortingEnabled = $save['sortingEnabled'] ?? false;
+            $this->filtersEnabled = $save['filtersEnabled'] ?? false;
+            $this->sorts = $save['sorts'] ?? [];
+            $this->filters = $save['filters'] ?? [];
+            $this->showPagination = $save['showPagination'] ?? false;
+            $this->showPerPage = $save['showPerPage'] ?? false;
+            $this->showSearch = $save['showSearch'] ?? false;
+            $this->perPageAll = $save['perPageAll'] ?? true;
+            $this->perPage = $save['perPage'] ?? -1;
+            $this->page = $save['page'] ?? 1;
+            session()->forget($this->getReorderingBackupSessionKey());
+        }
     }
 }


### PR DESCRIPTION
### Added

- When reordering, the last known state of the table is now saved in the session so when you're done reordering you are back where you left off and no filters/sorts/search is lost.

### Changed

- Fixed query string getting wiped out on reload