### PR TITLE
additional attributes for column (table header)

### DIFF
--- a/resources/views/bootstrap-4/components/table/heading.blade.php
+++ b/resources/views/bootstrap-4/components/table/heading.blade.php
@@ -6,14 +6,28 @@
     'text' => null,
 ])
 
+@php
+$headerAttributesList = [];
+$headerAttributesList[] = ['class' => $attributes->get('class')];
+$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
+
+$headerAttributes = '';
+collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
+    if(count($item)) {
+        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
+    }
+});
+
+@endphp
+
 @unless ($sortingEnabled && $sortable)
-    <th {{ $attributes->only('class') }}>
+    <th {!! $headerAttributes !!}>
         {{ $text ?? $slot }}
     </th>
 @else
     <th
         wire:click="sortBy('{{ $column }}', '{{ $text ?? $column }}')"
-        {{ $attributes->only('class') }}
+        {!! $headerAttributes !!}
         style="cursor:pointer;"
     >
         <div class="d-flex align-items-center">

--- a/resources/views/bootstrap-4/includes/table.blade.php
+++ b/resources/views/bootstrap-4/includes/table.blade.php
@@ -27,6 +27,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
+                        :extraAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/resources/views/bootstrap-5/components/table/heading.blade.php
+++ b/resources/views/bootstrap-5/components/table/heading.blade.php
@@ -6,14 +6,28 @@
     'text' => null,
 ])
 
+@php
+$headerAttributesList = [];
+$headerAttributesList[] = ['class' => $attributes->get('class')];
+$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
+
+$headerAttributes = '';
+collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
+    if(count($item)) {
+        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
+    }
+});
+
+@endphp
+
 @unless ($sortingEnabled && $sortable)
-    <th {{ $attributes->only('class') }}>
+    <th {!! $headerAttributes !!}>
         {{ $text ?? $slot }}
     </th>
 @else
     <th
         wire:click="sortBy('{{ $column }}', '{{ $text ?? $column }}')"
-        {{ $attributes->only('class') }}
+        {!! $headerAttributes !!}
         style="cursor:pointer;"
     >
         <div class="d-flex align-items-center">

--- a/resources/views/bootstrap-5/includes/table.blade.php
+++ b/resources/views/bootstrap-5/includes/table.blade.php
@@ -28,6 +28,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
+                        :extraAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/resources/views/tailwind/components/table/heading.blade.php
+++ b/resources/views/tailwind/components/table/heading.blade.php
@@ -6,9 +6,21 @@
     'text' => null,
 ])
 
-<th
-    {{ $attributes->merge(['class' => 'px-3 py-2 md:px-6 md:py-3 bg-gray-50'])->only('class') }}
->
+@php
+$headerAttributesList = [];
+$headerAttributesList[] = ['class' => 'px-3 py-2 md:px-6 md:py-3 bg-gray-50 ' . $attributes->get('class')];
+$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
+
+$headerAttributes = '';
+collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
+    if(count($item)) {
+        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
+    }
+});
+
+@endphp
+
+<th {!! $headerAttributes !!}>
     @unless ($sortingEnabled && $sortable)
         <span class="block text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
             {{ $text ?? $slot }}

--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -30,6 +30,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
+                        :extraAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -20,6 +20,11 @@ class Column
     public ?string $text = null;
 
     /**
+     * @var array
+     */
+    public array $attributes = [];
+
+    /**
      * @var bool
      */
     public bool $sortable = false;
@@ -171,6 +176,18 @@ class Column
     }
 
     /**
+     * @param array $attributes
+     *
+     * @return $this
+     */
+    public function addAttributes(array $attributes): self
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    /**
      * @return Column
      */
     public function asHtml(): Column
@@ -202,6 +219,14 @@ class Column
     public function text(): ?string
     {
         return $this->text;
+    }
+
+    /**
+     * @return array
+     */
+    public function attributes(): array
+    {
+        return $this->attributes;
     }
 
     /**


### PR DESCRIPTION
Sometimes it is useful to use some additional attributes for the table header, for example if the column name is too long we may limit the string character & display a tooltip when hover.

users can add additional attributes as:
```php
Column::make('Candidate', 'fname')
->addClass('foobar')
->addAttributes(['data-toggle' => 'tooltip', 'data-placement' => 'top', 'title' => 'Tooltip on top'])
```

with the addition of `addAttributes()` method the `addClass()` method becomes useless but for backward compatibility this can be removed on future major release.