### PR TITLE
v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 - Added default empty message to lang file.
 - [Fix people messing with sort direction from URL](https://github.com/rappasoft/laravel-livewire-tables/pull/389)
 - [Check to make sure column exists before sorting](https://github.com/rappasoft/laravel-livewire-tables/pull/390)
+- Removed ability to alter per page dropdown select to bypass allowed values.
 
 ## [1.10.4] - 2021-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Increased minimum Livewire version
 - Added default empty message to lang file.
+- [Fix people messing with sort direction from URL](https://github.com/rappasoft/laravel-livewire-tables/pull/389)
 
 ## [1.10.4] - 2021-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
-## [1.10.5] - 2021-07-10
+## [1.11.0] - 2021-07-10
+
+### Added
+
+- [Added `addAttributes` method to column headers](https://github.com/rappasoft/laravel-livewire-tables/pull/379)
 
 ### Changed
 
@@ -421,8 +425,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Initial release
 
-[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.5...development
-[1.10.5]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.4...v1.10.5
+[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.11.0...development
+[1.11.0]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.4...v1.11.0
 [1.10.4]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.3...v1.10.4
 [1.10.3]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.2...v1.10.3
 [1.10.2]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.1...v1.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 - Increased minimum Livewire version
 - Added default empty message to lang file.
 - [Fix people messing with sort direction from URL](https://github.com/rappasoft/laravel-livewire-tables/pull/389)
+- [Check to make sure column exists before sorting](https://github.com/rappasoft/laravel-livewire-tables/pull/390)
 
 ## [1.10.4] - 2021-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [1.10.5] - 2021-07-10
+
+### Changed
+
+- Increased minimum Livewire version
+- Added default empty message to lang file.
+
 ## [1.10.4] - 2021-06-23
 
 ### Added
@@ -414,7 +421,8 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Initial release
 
-[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.4...development
+[Unreleased]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.5...development
+[1.10.5]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.4...v1.10.5
 [1.10.4]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.3...v1.10.4
 [1.10.3]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.2...v1.10.3
 [1.10.2]: https://github.com/rappasoft/laravel-livewire-tables/compare/v1.10.1...v1.10.2

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "livewire/livewire": "^2.0",
+        "livewire/livewire": "^2.5.3",
         "spatie/laravel-package-tools": "^1.4.3",
         "illuminate/contracts": "^8.0"
     },

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -21,5 +21,6 @@
     "results": "results",
     "rows": "rows",
     "rows, do you want to select all": "rows, do you want to select all",
+    "No items found. Try narrowing your search.": "No items found. Try narrowing your search.",
     "to": "to"
 }

--- a/resources/views/bootstrap-4/components/table/heading.blade.php
+++ b/resources/views/bootstrap-4/components/table/heading.blade.php
@@ -4,30 +4,17 @@
     'sortable' => null,
     'direction' => null,
     'text' => null,
+    'customAttributes' => [],
 ])
 
-@php
-$headerAttributesList = [];
-$headerAttributesList[] = ['class' => $attributes->get('class')];
-$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
-
-$headerAttributes = '';
-collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
-    if(count($item)) {
-        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
-    }
-});
-
-@endphp
-
 @unless ($sortingEnabled && $sortable)
-    <th {!! $headerAttributes !!}>
+    <th {{ $attributes->merge($customAttributes) }}>
         {{ $text ?? $slot }}
     </th>
 @else
     <th
         wire:click="sortBy('{{ $column }}', '{{ $text ?? $column }}')"
-        {!! $headerAttributes !!}
+        {{ $attributes->merge($customAttributes) }}
         style="cursor:pointer;"
     >
         <div class="d-flex align-items-center">

--- a/resources/views/bootstrap-4/components/table/heading.blade.php
+++ b/resources/views/bootstrap-4/components/table/heading.blade.php
@@ -6,14 +6,28 @@
     'text' => null,
 ])
 
+@php
+$headerAttributesList = [];
+$headerAttributesList[] = ['class' => $attributes->get('class')];
+$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
+
+$headerAttributes = '';
+collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
+    if(count($item)) {
+        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
+    }
+});
+
+@endphp
+
 @unless ($sortingEnabled && $sortable)
-    <th {{ $attributes->only('class') }}>
+    <th {!! $headerAttributes !!}>
         {{ $text ?? $slot }}
     </th>
 @else
     <th
         wire:click="sortBy('{{ $column }}', '{{ $text ?? $column }}')"
-        {{ $attributes->only('class') }}
+        {!! $headerAttributes !!}
         style="cursor:pointer;"
     >
         <div class="d-flex align-items-center">

--- a/resources/views/bootstrap-4/includes/table.blade.php
+++ b/resources/views/bootstrap-4/includes/table.blade.php
@@ -27,7 +27,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
-                        :extraAttributes="$column->attributes()"
+                        :customAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/resources/views/bootstrap-4/includes/table.blade.php
+++ b/resources/views/bootstrap-4/includes/table.blade.php
@@ -27,6 +27,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
+                        :extraAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/resources/views/bootstrap-5/components/table/heading.blade.php
+++ b/resources/views/bootstrap-5/components/table/heading.blade.php
@@ -4,30 +4,17 @@
     'sortable' => null,
     'direction' => null,
     'text' => null,
+    'customAttributes' => [],
 ])
 
-@php
-$headerAttributesList = [];
-$headerAttributesList[] = ['class' => $attributes->get('class')];
-$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
-
-$headerAttributes = '';
-collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
-    if(count($item)) {
-        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
-    }
-});
-
-@endphp
-
 @unless ($sortingEnabled && $sortable)
-    <th {!! $headerAttributes !!}>
+    <th {{ $attributes->merge($customAttributes) }}>
         {{ $text ?? $slot }}
     </th>
 @else
     <th
         wire:click="sortBy('{{ $column }}', '{{ $text ?? $column }}')"
-        {!! $headerAttributes !!}
+        {{ $attributes->merge($customAttributes) }}
         style="cursor:pointer;"
     >
         <div class="d-flex align-items-center">

--- a/resources/views/bootstrap-5/components/table/heading.blade.php
+++ b/resources/views/bootstrap-5/components/table/heading.blade.php
@@ -6,14 +6,28 @@
     'text' => null,
 ])
 
+@php
+$headerAttributesList = [];
+$headerAttributesList[] = ['class' => $attributes->get('class')];
+$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
+
+$headerAttributes = '';
+collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
+    if(count($item)) {
+        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
+    }
+});
+
+@endphp
+
 @unless ($sortingEnabled && $sortable)
-    <th {{ $attributes->only('class') }}>
+    <th {!! $headerAttributes !!}>
         {{ $text ?? $slot }}
     </th>
 @else
     <th
         wire:click="sortBy('{{ $column }}', '{{ $text ?? $column }}')"
-        {{ $attributes->only('class') }}
+        {!! $headerAttributes !!}
         style="cursor:pointer;"
     >
         <div class="d-flex align-items-center">

--- a/resources/views/bootstrap-5/includes/table.blade.php
+++ b/resources/views/bootstrap-5/includes/table.blade.php
@@ -28,7 +28,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
-                        :extraAttributes="$column->attributes()"
+                        :customAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/resources/views/bootstrap-5/includes/table.blade.php
+++ b/resources/views/bootstrap-5/includes/table.blade.php
@@ -28,6 +28,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
+                        :extraAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/resources/views/tailwind/components/table/heading.blade.php
+++ b/resources/views/tailwind/components/table/heading.blade.php
@@ -6,9 +6,21 @@
     'text' => null,
 ])
 
-<th
-    {{ $attributes->merge(['class' => 'px-3 py-2 md:px-6 md:py-3 bg-gray-50'])->only('class') }}
->
+@php
+$headerAttributesList = [];
+$headerAttributesList[] = ['class' => 'px-3 py-2 md:px-6 md:py-3 bg-gray-50 ' . $attributes->get('class')];
+$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
+
+$headerAttributes = '';
+collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
+    if(count($item)) {
+        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
+    }
+});
+
+@endphp
+
+<th {!! $headerAttributes !!}>
     @unless ($sortingEnabled && $sortable)
         <span class="block text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
             {{ $text ?? $slot }}

--- a/resources/views/tailwind/components/table/heading.blade.php
+++ b/resources/views/tailwind/components/table/heading.blade.php
@@ -4,23 +4,12 @@
     'sortable' => null,
     'direction' => null,
     'text' => null,
+    'customAttributes' => [],
 ])
 
-@php
-$headerAttributesList = [];
-$headerAttributesList[] = ['class' => 'px-3 py-2 md:px-6 md:py-3 bg-gray-50 ' . $attributes->get('class')];
-$headerAttributesList[] = $attributes->get('extraAttributes') ?? [];
-
-$headerAttributes = '';
-collect($headerAttributesList)->each(function($item) use(&$headerAttributes) {
-    if(count($item)) {
-        $headerAttributes .= collect($item)->map(fn($value, $key) => $key . '="' . $value . '"')->implode(' ');
-    }
-});
-
-@endphp
-
-<th {!! $headerAttributes !!}>
+<th
+    {{ $attributes->merge(array_merge(['class' => 'px-3 py-2 md:px-6 md:py-3 bg-gray-50'], $customAttributes)) }}
+>
     @unless ($sortingEnabled && $sortable)
         <span class="block text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
             {{ $text ?? $slot }}

--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -30,6 +30,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
+                        :extraAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -30,7 +30,7 @@
                         :direction="$column->column() ? $sorts[$column->column()] ?? null : null"
                         :text="$column->text() ?? ''"
                         :class="$column->class() ?? ''"
-                        :extraAttributes="$column->attributes()"
+                        :customAttributes="$column->attributes()"
                     />
                 @endif
             @endif

--- a/src/Traits/WithPerPagePagination.php
+++ b/src/Traits/WithPerPagePagination.php
@@ -29,6 +29,10 @@ trait WithPerPagePagination
 
     public function updatedPerPage($value): void
     {
+        if (! in_array($value, $this->perPageAccepted, false)) {
+            $value = $this->perPage = $this->perPageAccepted[0] ?? 10;
+        }
+
         if (in_array(session()->get($this->getPerPagePaginationSessionKey(), $this->perPage), $this->perPageAccepted, true)) {
             session()->put($this->getPerPagePaginationSessionKey(), (int) $value);
         } else {

--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -58,7 +58,13 @@ trait WithSorting
                 $direction = 'desc';
             }
 
-            if (optional($this->getColumn($field))->hasSortCallback()) {
+            $column = $this->getColumn($field);
+
+            if (is_null($column)) {
+                continue;
+            }
+
+            if ($column->hasSortCallback()) {
                 $query = app()->call($this->getColumn($field)->getSortCallback(), ['query' => $query, 'direction' => $direction]);
             } else {
                 $query->orderBy($field, $direction);

--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -54,6 +54,10 @@ trait WithSorting
         }
 
         foreach ($this->sorts as $field => $direction) {
+            if (! in_array($direction, ['asc', 'desc'])) {
+                $direction = 'desc';
+            }
+
             if (optional($this->getColumn($field))->hasSortCallback()) {
                 $query = app()->call($this->getColumn($field)->getSortCallback(), ['query' => $query, 'direction' => $direction]);
             } else {

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -20,6 +20,11 @@ class Column
     public ?string $text = null;
 
     /**
+     * @var array
+     */
+    public array $attributes = [];
+
+    /**
      * @var bool
      */
     public bool $sortable = false;
@@ -171,6 +176,18 @@ class Column
     }
 
     /**
+     * @param array $attributes
+     *
+     * @return $this
+     */
+    public function addAttributes(array $attributes): self
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    /**
      * @return Column
      */
     public function asHtml(): Column
@@ -202,6 +219,14 @@ class Column
     public function text(): ?string
     {
         return $this->text;
+    }
+
+    /**
+     * @return array
+     */
+    public function attributes(): array
+    {
+        return $this->attributes;
     }
 
     /**


### PR DESCRIPTION
### Added

- [Added `addAttributes` method to column headers](https://github.com/rappasoft/laravel-livewire-tables/pull/379)

### Changed

- Increased minimum Livewire version
- Added default empty message to lang file.
- [Fix people messing with sort direction from URL](https://github.com/rappasoft/laravel-livewire-tables/pull/389)
- [Check to make sure column exists before sorting](https://github.com/rappasoft/laravel-livewire-tables/pull/390)
- Removed ability to alter per page dropdown select to bypass allowed values.