### PR TITLE
Add checked to a user column selection

### DIFF
--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -12,6 +12,8 @@ trait WithColumnSelect
     public bool $columnSelect = false;
     public array $columnSelectEnabled = [];
 
+    public bool $usesSelect = false;
+
     public function mountWithColumnSelect(): void
     {
         // If the column select is off, make sure to clear the session
@@ -19,9 +21,19 @@ trait WithColumnSelect
             session()->forget($this->getColumnSelectSessionKey());
         }
 
+        $selected = collect($this->columns())
+            ->filter(fn ($column) => $column->isSelected())->count();
+
+        if ($selected > 0) $this->usesSelect = true;
+
         // Get a list of visible default columns that are not excluded
         $columns = collect($this->columns())
-            ->filter(fn ($column) => $column->isVisible() && $column->isSelectable() && $column->isSelected())
+            ->filter(function ($column) {
+                if ($this->usesSelect) {
+                    return $column->isVisible() && $column->isSelectable() && $column->isSelected();
+                }
+                return $column->isVisible() && $column->isSelectable();
+            })
             ->map(fn ($column) => $column->column())
             ->values()
             ->toArray();

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -21,7 +21,7 @@ trait WithColumnSelect
 
         // Get a list of visible default columns that are not excluded
         $columns = collect($this->columns())
-            ->filter(fn ($column) => $column->isVisible() && $column->isSelectable())
+            ->filter(fn ($column) => $column->isVisible() && $column->isSelectable() && $column->isSelected())
             ->map(fn ($column) => $column->column())
             ->values()
             ->toArray();

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -75,6 +75,11 @@ class Column
     public bool $selectable = true;
 
     /**
+     * @var bool
+     */
+    public bool $selected = false;
+
+    /**
      * Column constructor.
      *
      * @param string|null $column
@@ -334,5 +339,23 @@ class Column
     public function isSelectable(): bool
     {
         return $this->selectable === true;
+    }
+
+    /**
+     * @return $this
+     */
+    public function selected(): self
+    {
+        $this->selected = true;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSelected(): bool
+    {
+        return $this->selected;
     }
 }


### PR DESCRIPTION
Add checked to a user column selection.

To reduce large datatables it should be possible to display only selected fields by default and leave rest hidden unless user wants to display them.

```php
Column::make('Name')->selected(),

Column::make('Created At'),
```

This will only show Name column meanwhile Created At stays hidden but still possible to display in columns dropdown.