### PR TITLE
Fix format callback

### DIFF
--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -260,7 +260,7 @@ class Column
         $value = data_get($row, $columnName);
 
         if ($this->formatCallback) {
-            return app()->call($this->formatCallback, ['value' => $value, 'column' => $column, 'row' => $row]);
+            $value = call_user_func($this->formatCallback, $value, $row, $column);
         }
 
         return $value;


### PR DESCRIPTION
Related to Issue #381 

Now this thing works properly and does not require parameter containing row value to be called `$value`.

```php
Column::make('Thing')->format(fn ($thing) => view('components.show-thing', compact('thing'))
```