### PR TITLE
Support virtual columns (only add table-prefix if column exists on table)

### DIFF
--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -3,11 +3,12 @@
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
 use DateTime;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Rappasoft\LaravelLivewireTables\Utilities\ColumnUtilities;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Filter;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Rappasoft\LaravelLivewireTables\Utilities\ColumnUtilities;
 
 /**
  * Trait WithFilters.
@@ -316,7 +317,8 @@ trait WithFilters
 
                         // TODO: Skip Aggregates
                         if (! $hasRelation) {
-                            $whereColumn = $query->getModel()->getTable() . '.' . $whereColumn;
+                            $whereColumn = Schema::hasColumn($query->getModel()->getTable(), $whereColumn) ? $query->getModel()->getTable() . '.' . $whereColumn : $whereColumn;
+
                         }
 
                         // We can use a simple where clause


### PR DESCRIPTION
Hey,

I was working on a project with a **kind of complex query** which powers the _livewire-table_. In the end, the values of three **virtual columns** are being displayed.
Since the package automatically adds the **table prefix** from the table of the query (`src/Traits/WithFilters.php`- `320`), the **search function** does not work, because the virtual columns **do only exist without the prefix**.
So I added checking if the **column name exists on the given table** via the `Schema`-Facade.

The functionality should be the same + **supporting virtual columns**.


Extends the `applySearchFilter($query)`-function to check if the name of the `$whereColumn` exists on the (parent) schema. If the column (name) exists, add the table-name as a prefix `[tableName].[columnName]` just like before. If the column name does not exist, just take the column name `[columnName]`. If it still does not exists (as a **virtual column**), it will fail just like before.