### PR TITLE
reduces horizontal spacing in Tailwind responsive view

### DIFF
--- a/resources/views/tailwind/datatable.blade.php
+++ b/resources/views/tailwind/datatable.blade.php
@@ -20,7 +20,7 @@
             @include('livewire-tables::tailwind.includes.filter-pills')
 
             <div class="space-y-4">
-                <div class="md:flex md:justify-between p-6 md:p-0">
+                <div class="md:flex md:justify-between px-6 py-2 md:p-0">
                     <div class="w-full mb-4 md:mb-0 md:w-2/4 md:flex space-y-4 md:space-y-0 md:space-x-2">
                         @include('livewire-tables::tailwind.includes.reorder')
                         @include('livewire-tables::tailwind.includes.search')

--- a/resources/views/tailwind/includes/filter-pills.blade.php
+++ b/resources/views/tailwind/includes/filter-pills.blade.php
@@ -1,6 +1,6 @@
 <div>
     @if ($showFilters && count($this->getFiltersWithoutSearch()))
-        <div class="mb-4 p-6 md:p-0">
+        <div class="md:mb-4 px-6 py-2 md:p-0">
             <small class="text-gray-700 dark:text-white">@lang('Applied Filters'):</small>
 
             @foreach($filters as $key => $value)

--- a/resources/views/tailwind/includes/pagination.blade.php
+++ b/resources/views/tailwind/includes/pagination.blade.php
@@ -1,5 +1,5 @@
 @if ($showPagination)
-    <div class="p-6 md:p-0">
+    <div class="px-6 py-2 md:p-0">
         @if ($paginationEnabled && $rows->lastPage() > 1)
             {{ $rows->links('livewire-tables::tailwind.includes.partials.pagination') }}
         @else

--- a/resources/views/tailwind/includes/sorting-pills.blade.php
+++ b/resources/views/tailwind/includes/sorting-pills.blade.php
@@ -1,6 +1,6 @@
 <div>
     @if ($showSorting && count($sorts))
-        <div class="mb-4 p-6 md:p-0">
+        <div class="md:mb-4 px-6 py-2 md:p-0">
             <small class="text-gray-700 dark:text-white">@lang('Applied Sorting'):</small>
 
             @foreach($sorts as $col => $dir)


### PR DESCRIPTION
This PR reduces the horizontal spacing in the responsive view of Tailwind.

Before:
<img src="https://user-images.githubusercontent.com/44020272/134524510-c2e6e707-db8b-47e7-b06f-f8362396c40c.png" width="50%" height="50%">

After:
<img src="https://user-images.githubusercontent.com/44020272/134524514-090c9796-59f5-4649-b01b-d7ac66d617a5.png" width="50%" height="50%">