### PR TITLE
Add bulk actions function

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,7 @@ name: run-tests
 
 on: [push, pull_request]
 
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/resources/views/bootstrap-4/includes/bulk-actions.blade.php
+++ b/resources/views/bootstrap-4/includes/bulk-actions.blade.php
@@ -6,12 +6,12 @@
             </button>
 
             <div class="dropdown-menu dropdown-menu-right w-100" aria-labelledby="bulkActions">
-                @foreach($bulkActions as $action => $title)
+                @foreach($this->bulkActions as $action => $title)
                     <a
                         href="#"
-                       wire:click.prevent="{{ $action }}"
-                       wire:key="bulk-action-{{ $action }}"
-                       class="dropdown-item"
+                        wire:click.prevent="{{ $action }}"
+                        wire:key="bulk-action-{{ $action }}"
+                        class="dropdown-item"
                     >
                         {{ $title }}
                     </a>

--- a/resources/views/bootstrap-4/includes/bulk-select-row.blade.php
+++ b/resources/views/bootstrap-4/includes/bulk-select-row.blade.php
@@ -1,4 +1,4 @@
-@if ($bulkActionsEnabled && count($bulkActions) && (($selectPage && $rows->total() > $rows->count()) || count($selected)))
+@if ($bulkActionsEnabled && count($this->bulkActions) && (($selectPage && $rows->total() > $rows->count()) || count($selected)))
     <x-livewire-tables::bs4.table.row wire:key="row-message">
         <x-livewire-tables::bs4.table.cell colspan="{{ $colspan }}">
             @if (count($selected) && !$selectAll && !$selectPage)

--- a/resources/views/bootstrap-4/includes/table.blade.php
+++ b/resources/views/bootstrap-4/includes/table.blade.php
@@ -4,7 +4,7 @@
             <x-livewire-tables::bs4.table.heading />
         @endif
 
-        @if ($bulkActionsEnabled && count($bulkActions))
+        @if ($bulkActionsEnabled && count($this->bulkActions))
             <x-livewire-tables::bs4.table.heading>
                 <input
                     wire:model="selectPage"
@@ -37,7 +37,7 @@
     <x-slot name="body">
         @php
             $colspan = count($columns);
-            if ($bulkActionsEnabled && count($bulkActions)) $colspan++;
+            if ($bulkActionsEnabled && count($this->bulkActions)) $colspan++;
             if ($reordering) $colspan++;
         @endphp
 
@@ -62,7 +62,7 @@
                     </x-livewire-tables::bs4.table.cell>
                 @endif
 
-                @if ($bulkActionsEnabled && count($bulkActions))
+                @if ($bulkActionsEnabled && count($this->bulkActions))
                     <x-livewire-tables::bs4.table.cell>
                         <input
                             wire:model="selected"

--- a/resources/views/bootstrap-5/includes/bulk-actions.blade.php
+++ b/resources/views/bootstrap-5/includes/bulk-actions.blade.php
@@ -6,7 +6,7 @@
             </button>
 
             <div class="dropdown-menu dropdown-menu-end w-100" aria-labelledby="bulkActions">
-                @foreach($bulkActions as $action => $title)
+                @foreach($this->bulkActions as $action => $title)
                     <a
                         href="#"
                         wire:click.prevent="{{ $action }}"

--- a/resources/views/bootstrap-5/includes/bulk-select-row.blade.php
+++ b/resources/views/bootstrap-5/includes/bulk-select-row.blade.php
@@ -1,4 +1,4 @@
-@if ($bulkActionsEnabled && count($bulkActions) && (($selectPage && $rows->total() > $rows->count()) || count($selected)))
+@if ($bulkActionsEnabled && count($this->bulkActions) && (($selectPage && $rows->total() > $rows->count()) || count($selected)))
     <x-livewire-tables::bs5.table.row wire:key="row-message">
         <x-livewire-tables::bs5.table.cell colspan="{{ $colspan }}">
             @if (count($selected) && !$selectAll && !$selectPage)

--- a/resources/views/bootstrap-5/includes/table.blade.php
+++ b/resources/views/bootstrap-5/includes/table.blade.php
@@ -4,7 +4,7 @@
             <x-livewire-tables::bs5.table.heading />
         @endif
 
-        @if ($bulkActionsEnabled && count($bulkActions))
+        @if ($bulkActionsEnabled && count($this->bulkActions))
             <x-livewire-tables::bs5.table.heading>
                 <input
                     wire:model="selectPage"
@@ -38,7 +38,7 @@
     <x-slot name="body">
         @php
             $colspan = count($columns);
-            if ($bulkActionsEnabled && count($bulkActions)) $colspan++;
+            if ($bulkActionsEnabled && count($this->bulkActions)) $colspan++;
             if ($reordering) $colspan++;
         @endphp
 
@@ -63,7 +63,7 @@
                     </x-livewire-tables::bs5.table.cell>
                 @endif
 
-                @if ($bulkActionsEnabled && count($bulkActions))
+                @if ($bulkActionsEnabled && count($this->bulkActions))
                     <x-livewire-tables::bs5.table.cell class="align-middle">
                         <input
                             wire:model="selected"

--- a/resources/views/tailwind/includes/bulk-actions.blade.php
+++ b/resources/views/tailwind/includes/bulk-actions.blade.php
@@ -39,7 +39,7 @@
             >
                 <div class="rounded-md bg-white shadow-xs dark:bg-gray-700 dark:text-white">
                     <div class="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
-                        @foreach($bulkActions as $action => $title)
+                        @foreach($this->bulkActions as $action => $title)
                             <button
                                 wire:click="{{ $action }}"
                                 wire:key="bulk-action-{{ $action }}"

--- a/resources/views/tailwind/includes/bulk-select-row.blade.php
+++ b/resources/views/tailwind/includes/bulk-select-row.blade.php
@@ -1,4 +1,4 @@
-@if ($bulkActionsEnabled && count($bulkActions) && (($selectPage && $rows->total() > $rows->count()) || count($selected)))
+@if ($bulkActionsEnabled && count($this->bulkActions) && (($selectPage && $rows->total() > $rows->count()) || count($selected)))
     <x-livewire-tables::table.row wire:key="row-message" class="bg-indigo-50 dark:bg-gray-900 dark:text-white">
         <x-livewire-tables::table.cell :colspan="$colspan">
             @if (count($selected) && !$selectAll && !$selectPage)

--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -4,7 +4,7 @@
             <x-livewire-tables::table.heading />
         @endif
 
-        @if ($bulkActionsEnabled && count($bulkActions))
+        @if ($bulkActionsEnabled && count($this->bulkActions))
             <x-livewire-tables::table.heading>
                 <div class="inline-flex rounded-md shadow-sm">
                     <input
@@ -40,7 +40,7 @@
     <x-slot name="body">
         @php
             $colspan = count($columns);
-            if ($bulkActionsEnabled && count($bulkActions)) $colspan++;
+            if ($bulkActionsEnabled && count($this->bulkActions)) $colspan++;
             if ($reordering) $colspan++;
         @endphp
 
@@ -71,7 +71,7 @@
                     </x-livewire-tables::table.cell>
                 @endif
 
-                @if ($bulkActionsEnabled && count($bulkActions))
+                @if ($bulkActionsEnabled && count($this->bulkActions))
                     <x-livewire-tables::table.cell>
                         <div class="inline-flex rounded-md shadow-sm">
                             <input

--- a/src/Traits/WithBulkActions.php
+++ b/src/Traits/WithBulkActions.php
@@ -15,7 +15,7 @@ trait WithBulkActions
     public bool $selectPage = false;
     public bool $selectAll = false;
     public $selected = [];
-    public array $bulkActions = [];
+
     public bool $hideBulkActionsOnEmpty = false;
 
     public function renderingWithBulkActions(): void
@@ -91,12 +91,26 @@ trait WithBulkActions
         return $this->selectedKeys();
     }
 
+    public function getBulkActionsProperty(): array
+    {
+        return $this->bulkActions();
+    }
+
+    public function bulkActions(): array
+    {
+        if (property_exists($this, 'bulkActions')) {
+            return $this->bulkActions;
+        }
+
+        return [];
+    }
+
     public function getShowBulkActionsDropdownProperty(): bool
     {
         $showBulkActions = false;
 
         if ($this->bulkActionsEnabled) {
-            if (count($this->bulkActions)) {
+            if (count($this->bulkActions())) {
                 $showBulkActions = true;
             }
 

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -114,4 +114,11 @@ class DataTableComponentTest extends TestCase
         $this->tableAltQuery->filters['search'] = 'Cat';
         $this->assertEquals(2, $this->tableAltQuery->rows->total());
     }
+
+    /** @test */
+    public function bulk_actions_defined_with_function()
+    {
+        $this->table->selected[] = 1;
+        $this->assertEquals(1, $this->table->count());
+    }
 }

--- a/tests/Http/Livewire/PetsTable.php
+++ b/tests/Http/Livewire/PetsTable.php
@@ -9,6 +9,11 @@ use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class PetsTable extends DataTableComponent
 {
+    public function bulkActions(): array
+    {
+        return [ 'count' => 'Count selected'];
+    }
+
     /**
      * @return Builder
      */
@@ -35,5 +40,10 @@ class PetsTable extends DataTableComponent
             Column::make('Breed', 'breed.name')
                 ->searchable(),
         ];
+    }
+
+    public function count(): int
+    {
+        return $this->selectedRowsQuery()->count();
     }
 }


### PR DESCRIPTION
hi @rappasoft!

this PR would add the capability to define bulkActions inside a function, this wil allow to generate them dynamically (for example using translation functions) or switching actions based on context

the old way of defining bulkActions will remain enabled:

```php
class Table extends DataTableComponent
{
    //...
    public array $bulkActions = [  ... ]

```

but with this PR you could write this, as an alternative:

```php
class Table extends DataTableComponent
{
    //...
    public function bulkActions(): array
    {
        return [
              'count' => __('pets.count'),
        ]
    }
```