### PR TITLE
add/"themeColor"-Variable to set the color

### DIFF
--- a/resources/views/tailwind/includes/bulk-actions.blade.php
+++ b/resources/views/tailwind/includes/bulk-actions.blade.php
@@ -11,7 +11,7 @@
                     <button
                         x-on:click="open = !open"
                         type="button"
-                        class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
+                        class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
                         id="options-menu"
                         aria-haspopup="true"
                         x-bind:aria-expanded="open"

--- a/resources/views/tailwind/includes/bulk-select-row.blade.php
+++ b/resources/views/tailwind/includes/bulk-select-row.blade.php
@@ -1,5 +1,5 @@
 @if ($bulkActionsEnabled && count($this->bulkActions) && (($selectPage && $rows->total() > $rows->count()) || count($selected)))
-    <x-livewire-tables::table.row wire:key="row-message" class="bg-indigo-50 dark:bg-gray-900 dark:text-white">
+    <x-livewire-tables::table.row wire:key="row-message" class="bg-{{ $this->themeColor }}-50 dark:bg-gray-900 dark:text-white">
         <x-livewire-tables::table.cell :colspan="$colspan">
             @if (count($selected) && !$selectAll && !$selectPage)
                 <div>

--- a/resources/views/tailwind/includes/column-select.blade.php
+++ b/resources/views/tailwind/includes/column-select.blade.php
@@ -11,7 +11,7 @@
                     <button
                         x-on:click="open = !open"
                         type="button"
-                        class="inline-flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 shadow-sm hover:bg-gray-50 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
+                        class="inline-flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 shadow-sm hover:bg-gray-50 focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
                         id="column-select-menu"
                         aria-haspopup="true"
                         x-bind:aria-expanded="open"
@@ -48,7 +48,7 @@
                                         class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
                                     >
                                         <input
-                                            class="text-indigo-600 rounded border-gray-300 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                                            class="text-{{ $this->themeColor }}-600 rounded border-gray-300 shadow-sm transition duration-150 ease-in-out focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
                                             wire:model="columnSelectEnabled"
                                             wire:target="columnSelectEnabled"
                                             wire:loading.attr="disabled"

--- a/resources/views/tailwind/includes/filter-pills.blade.php
+++ b/resources/views/tailwind/includes/filter-pills.blade.php
@@ -7,7 +7,7 @@
                 @if ($key !== 'search' && strlen($value))
                     <span
                         wire:key="filter-pill-{{ $key }}"
-                        class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900"
+                        class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-{{ $this->themeColor }}-100 text-{{ $this->themeColor }}-800 capitalize dark:bg-{{ $this->themeColor }}-200 dark:text-{{ $this->themeColor }}-900"
                     >
                         {{ $filterNames[$key] ?? collect($this->columns())->pluck('text', 'column')->get($key, ucwords(strtr($key, ['_' => ' ', '-' => ' ']))) }}:
                         @if(isset($customFilters[$key]) && method_exists($customFilters[$key], 'options'))
@@ -19,7 +19,7 @@
                         <button
                             wire:click="removeFilter('{{ $key }}')"
                             type="button"
-                            class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:outline-none focus:bg-indigo-500 focus:text-white"
+                            class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-{{ $this->themeColor }}-400 hover:bg-{{ $this->themeColor }}-200 hover:text-{{ $this->themeColor }}-500 focus:outline-none focus:bg-{{ $this->themeColor }}-500 focus:text-white"
                         >
                             <span class="sr-only">@lang('Remove filter option')</span>
                             <svg class="h-2 w-2" stroke="currentColor" fill="none" viewBox="0 0 8 8">

--- a/resources/views/tailwind/includes/filter-type-date.blade.php
+++ b/resources/views/tailwind/includes/filter-type-date.blade.php
@@ -6,6 +6,6 @@
         type="date"
         @if(isset($filter->options['min']) && strlen($filter->options['min'])) min="{{ $filter->options['min'] }}" @endif
         @if(isset($filter->options['max']) && strlen($filter->options['max'])) max="{{ $filter->options['max'] }}" @endif
-        class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-800 dark:text-white dark:border-gray-600"
+        class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-800 dark:text-white dark:border-gray-600"
     />
 </div>

--- a/resources/views/tailwind/includes/filter-type-select.blade.php
+++ b/resources/views/tailwind/includes/filter-type-select.blade.php
@@ -3,7 +3,7 @@
         wire:model.stop="filters.{{ $key }}"
         wire:key="filter-{{ $key }}"
         id="filter-{{ $key }}"
-        class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-800 dark:text-white dark:border-gray-600"
+        class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-800 dark:text-white dark:border-gray-600"
     >
         @foreach($filter->options() as $key => $value)
             <option value="{{ $key }}">{{ $value }}</option>

--- a/resources/views/tailwind/includes/filters.blade.php
+++ b/resources/views/tailwind/includes/filters.blade.php
@@ -8,7 +8,7 @@
         <div>
             <button
                 type="button"
-                class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
+                class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
                 id="filters-menu"
                 x-on:click="open = !open"
                 aria-haspopup="true"
@@ -18,7 +18,7 @@
                 @lang('Filters')
 
                 @if (count($this->getFiltersWithoutSearch()))
-                    <span class="ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900">
+                    <span class="ml-1 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-{{ $this->themeColor }}-100 text-{{ $this->themeColor }}-800 capitalize dark:bg-{{ $this->themeColor }}-200 dark:text-{{ $this->themeColor }}-900">
                        {{ count($this->getFiltersWithoutSearch()) }}
                     </span>
                 @endif
@@ -73,7 +73,7 @@
                             wire:click.prevent="resetFilters"
                             x-on:click="open = false"
                             type="button"
-                            class="w-full inline-flex items-center justify-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-800 dark:border-gray-600 dark:text-white dark:hover:border-gray-500"
+                            class="w-full inline-flex items-center justify-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-800 dark:border-gray-600 dark:text-white dark:hover:border-gray-500"
                         >
                             @lang('Clear')
                         </button>

--- a/resources/views/tailwind/includes/per-page.blade.php
+++ b/resources/views/tailwind/includes/per-page.blade.php
@@ -3,7 +3,7 @@
         <select
             wire:model="perPage"
             id="perPage"
-            class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600"
+            class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600"
         >
             @foreach ($perPageAccepted as $item)
                 <option value="{{ $item }}">{{ $item === -1 ? __('All') : $item }}</option>

--- a/resources/views/tailwind/includes/reorder.blade.php
+++ b/resources/views/tailwind/includes/reorder.blade.php
@@ -2,7 +2,7 @@
     <button
         wire:click="{{ $reordering ? 'disableReordering' : 'enableReordering' }}"
         type="button"
-        class="inline-flex justify-center items-center w-full md:w-auto px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:text-gray-500 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 active:bg-gray-50 active:text-gray-800 transition ease-in-out duration-150 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
+        class="inline-flex justify-center items-center w-full md:w-auto px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:text-gray-500 focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 active:bg-gray-50 active:text-gray-800 transition ease-in-out duration-150 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
     >
         @if ($reordering)
             @lang('Done Reordering')

--- a/resources/views/tailwind/includes/search.blade.php
+++ b/resources/views/tailwind/includes/search.blade.php
@@ -4,7 +4,7 @@
             wire:model{{ $this->searchFilterOptions }}="filters.search"
             placeholder="{{ __('Search') }}"
             type="text"
-            class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 dark:bg-gray-700 dark:text-white dark:border-gray-600 @if (isset($filters['search']) && strlen($filters['search'])) rounded-none rounded-l-md focus:ring-0 focus:border-gray-300 @else focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md @endif"
+            class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 dark:bg-gray-700 dark:text-white dark:border-gray-600 @if (isset($filters['search']) && strlen($filters['search'])) rounded-none rounded-l-md focus:ring-0 focus:border-gray-300 @else focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 rounded-md @endif"
         />
 
         @if (isset($filters['search']) && strlen($filters['search']))

--- a/resources/views/tailwind/includes/sorting-pills.blade.php
+++ b/resources/views/tailwind/includes/sorting-pills.blade.php
@@ -6,14 +6,14 @@
             @foreach($sorts as $col => $dir)
                 <span
                     wire:key="sorting-pill-{{ $col }}"
-                    class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900"
+                    class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-{{ $this->themeColor }}-100 text-{{ $this->themeColor }}-800 capitalize dark:bg-{{ $this->themeColor }}-200 dark:text-{{ $this->themeColor }}-900"
                 >
                     {{ $sortNames[$col] ?? collect($this->columns())->pluck('text', 'column')->get($col, ucwords(strtr($col, ['_' => ' ', '-' => ' ']))) }}: {{ $dir === 'asc' ? ($sortDirectionNames[$col]['asc'] ?? 'A-Z') : ($sortDirectionNames[$col]['desc'] ?? 'Z-A') }}
 
                     <button
                         wire:click="removeSort('{{ $col }}')"
                         type="button"
-                        class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:outline-none focus:bg-indigo-500 focus:text-white"
+                        class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-{{ $this->themeColor }}-400 hover:bg-{{ $this->themeColor }}-200 hover:text-{{ $this->themeColor }}-500 focus:outline-none focus:bg-{{ $this->themeColor }}-500 focus:text-white"
                     >
                         <span class="sr-only">@lang('Remove sort option')</span>
                         <svg class="h-2 w-2" stroke="currentColor" fill="none" viewBox="0 0 8 8">

--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -14,7 +14,7 @@
                     <input
                         wire:model="selectPage"
                         type="checkbox"
-                        class="rounded border-gray-300 text-indigo-600 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600"
+                        class="rounded border-gray-300 text-{{ $this->themeColor }}-600 shadow-sm transition duration-150 ease-in-out focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600"
                     />
                 </div>
             </x-livewire-tables::table.heading>
@@ -84,7 +84,7 @@
                                 value="{{ $row->{$primaryKey} }}"
                                 onclick="event.stopPropagation();return true;"
                                 type="checkbox"
-                                class="rounded border-gray-300 text-indigo-600 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600"
+                                class="rounded border-gray-300 text-{{ $this->themeColor }}-600 shadow-sm transition duration-150 ease-in-out focus:border-{{ $this->themeColor }}-300 focus:ring focus:ring-{{ $this->themeColor }}-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600"
                             />
                         </div>
                     </x-livewire-tables::table.cell>

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -78,6 +78,13 @@ abstract class DataTableComponent extends Component
     public bool $responsive = true;
 
     /**
+     * The Theme-color of the tables (default: indigo)
+     *
+     * @var string
+     */
+    public string $themeColor = 'indigo';
+
+    /**
      * Name of the page parameter for pagination
      * Good to change the default if you have more than one datatable on a page.
      *


### PR DESCRIPTION
Hi mate,

first, thanks for this great package and the quick development 🙌🏼

What does this PR do:
It allows the user to easily (without modifying the published views) change the _themecolor name_ (`indigo`).


I wanted to adjust the theming a bit and replaced the colors in the views. Because of the fast development I had to republish these several times (to make use of the new features) and my color adjustments were gone.

⚠️ Because the colors are generated _dynamically_ [**purgecss** from Tailwind](https://tailwindcss.com/docs/optimizing-for-production) will not work with these colors.
Maybe there should be a warning to add these colors to allow list:
* bg-[color]-50
* bg-[color]-100
* bg-[color]-200
* bg-[color]-300
* ring-[color]-100
* border-[color]-300
* text-[color]-600
* text-[color]-800
* bg-[color]-900
* text-[color]-400
* text-[color]-500


```js
// tailwind.config.js
module.exports = {
  purge: {
    content: ['./src/**/*.html'],
    safelist: [
     'bg-[color]-50',
    'bg-[color]-100',
    'bg-[color]-200',
    'bg-[color]-300',
    'ring-[color]-100',
    'border-[color]-300',
    'text-[color]-600',
    'text-[color]-800',
    'bg-[color]-900',
    'text-[color]-400',
    'text-[color]-500'
      // ...
      'lg:text-right',
    ]
  },
  // ...
}
```


Changes
---
- replaces the `indigo`-color with the `themeColor`-Property
- replaces every color with the new dynamic color-name