### PR TITLE
[Fix] Removing a multiselect filter

### DIFF
--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -269,9 +269,17 @@ trait WithFilters
      */
     public function removeFilter($filter): void
     {
-        if (isset($this->filters[$filter])) {
-            $this->filters[$filter] = null;
+        if (! isset($this->filters[$filter])) {
+            return;
         }
+
+        if ($this->filters()[$filter]->isMultiSelect()) {
+            $this->filters[$filter] = [];
+
+            return;
+        }
+
+        $this->filters[$filter] = null;
     }
 
     /**


### PR DESCRIPTION
By default multiselect filter is set to empty array:

![image](https://user-images.githubusercontent.com/14319239/137355586-a99b431d-6684-4c18-a8c1-a52803376c70.png)

Then I select several values, and click a cross to remove the filter:

![image](https://user-images.githubusercontent.com/14319239/137355728-86d13fe7-a9cb-4e2b-98ab-646d187e544e.png)

**Expected result:** I want the multiselect filter to be empty array again.

**Issue:** The mutliselect filter value becomes **null**:

![image](https://user-images.githubusercontent.com/14319239/137355975-c5d5b767-5334-4ecb-8f77-e4ea1e785804.png)

And filter doesn't work anymore, cause array wire:model cannot work with null.

The pull request fixes that behavior.