### PR TITLE
extracts just the field name from primaryKey in case the primaryKey i…

### DIFF
--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -99,7 +99,7 @@
                         <div class="flex rounded-md shadow-sm">
                             <input
                                 wire:model="selected"
-                                value="{{ $row->{$primaryKey} }}"
+                                value="{{ $row->{\Rappasoft\LaravelLivewireTables\Utilities\ColumnUtilities::parseField($primaryKey)} }}"
                                 onclick="event.stopPropagation();return true;"
                                 type="checkbox"
                                 class="rounded-md shadow-sm border-gray-300 block transition duration-150 ease-in-out sm:text-sm sm:leading-5"


### PR DESCRIPTION
This minor patch uses ColumnUtilities::parseField when referencing the primaryKey of the row while setting the bulk select checkbox value. This is necessary for instance when primaryKey must have the table name / alias / relation specified to prevent ambiguous references.