### PR TITLE
Fix BulkActions Dropdown Bootstrap

### DIFF
--- a/resources/views/bootstrap-4/includes/bulk-actions.blade.php
+++ b/resources/views/bootstrap-4/includes/bulk-actions.blade.php
@@ -1,5 +1,5 @@
 @if ($this->showBulkActionsDropdown)
-    <div class="mb-3 mb-md-0">
+    <div class="mb-3 mb-md-0" id="bulkActionsWrapper">
         <div class="dropdown d-block d-md-inline">
             <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button" id="bulkActions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 @lang('Bulk Actions')

--- a/resources/views/bootstrap-5/includes/bulk-actions.blade.php
+++ b/resources/views/bootstrap-5/includes/bulk-actions.blade.php
@@ -1,5 +1,5 @@
 @if ($this->showBulkActionsDropdown)
-    <div class="mb-3 mb-md-0">
+    <div class="mb-3 mb-md-0" id="bulkActionsWrapper">
         <div class="dropdown d-block d-md-inline">
             <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button" id="bulkActions" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 @lang('Bulk Actions')


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?
Yep.

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

I have added an id to the dropdown content element to prevent it from re-rendering and breaking the dropdown function.

![bulk](https://user-images.githubusercontent.com/36576423/137929638-32463845-8461-4a33-b302-1f912357a80d.gif)

