### PR TITLE
swap inline style with tailwind-class

### DIFF
--- a/resources/views/tailwind/components/table/row.blade.php
+++ b/resources/views/tailwind/components/table/row.blade.php
@@ -7,11 +7,13 @@
 @endif
 
 <tr
-    {{ $attributes->merge($customAttributes) }}
+    $attributes->merge($customAttributes)->class([
+        'h-auto block border-t-4 md:border-t-0 py-4 px-2 md:p-0 md:table-row w-screen',
+        'cursor-pointer' => $url
+    ]) }}
 
     @if ($url)
         onclick="window.open('{{ $url }}', '{{ $target }}')"
-        style="cursor:pointer"
     @endif
 >
     {{ $slot }}


### PR DESCRIPTION
I think it would be better if only Tailwind-classes are used (my CSP thinks so too).


You probably can change line 72 in `resources/views/vendor/livewire-tables/tailwind/includes/table.blade.php` :
```html
<svg xmlns="http://www.w3.org/2000/svg" class="inline" style="width:1em;height:1em;" fill="none" viewBox="0 0 24 24" stroke="currentColor">
```

with
```html
<svg xmlns="http://www.w3.org/2000/svg" class="inline w-1 h-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
```

bu since i don't use reordering, i can not test it. ✌🏼

Changes
---
- changes a inline style `cursor:pointer` with the tailwind-class `cursor-pointer` applied conditionally (if `$url` is set) via the `class`-helper of the component.
