### PR TITLE
Update DataTableComponent.php

### DIFF
--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -33,7 +33,12 @@ abstract class DataTableComponent extends Component
     use WithReordering;
     use WithSearch;
     use WithSorting;
-
+    
+    /**
+    * This property avoids the error
+    * TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given
+    */
+    public array $bulkActions = [];
     /**
      * Dump the filters array for debugging at the top of the datatable
      *


### PR DESCRIPTION
When updates composer all the tables shows this error, just needs to add this property to the Main DataTableComponent to solve it

TypeError
count(): Argument #1 ($value) must be of type Countable|array, null given

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
