### PR TITLE
fix bulk actions breaking change

### DIFF
--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -223,6 +223,7 @@ abstract class DataTableComponent extends Component
                 'customFilters' => $this->filters(),
                 'rows' => $this->rows,
                 'modalsView' => $this->modalsView(),
+                'bulkActions' => $this->bulkActions
             ]);
     }
 

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -223,7 +223,7 @@ abstract class DataTableComponent extends Component
                 'customFilters' => $this->filters(),
                 'rows' => $this->rows,
                 'modalsView' => $this->modalsView(),
-                'bulkActions' => $this->bulkActions
+                'bulkActions' => $this->bulkActions,
             ]);
     }
 


### PR DESCRIPTION
@rappasoft  this PR will fix issues in project with custom views after adding the `bulkActions()` function support see (#467 and #517)

custom views that use old `$bulkActions` notation instead of `$this->bulkActions` (needed for computed property) are breaking (I think this is why we ended adding and removing $bulkActions property multiple times)

for explanation of the issue, see #533 

the fix is to pass a `$bulkActions` attribute to the rendered view in order to allow the old notation to work

this can be eventually removed in a future major version