### PR TITLE
Pills fallback value

### DIFF
--- a/resources/views/bootstrap-4/components/table/row.blade.php
+++ b/resources/views/bootstrap-4/components/table/row.blade.php
@@ -1,6 +1,6 @@
 @props(['url' => null, 'target' => '_self', 'reordering' => false, 'customAttributes' => []])
 
-@if (!$reordering && $attributes->has('wire:sortable.item'))
+@if (!$reordering && (method_exists($attributes, 'has') ? $attributes->has('wire:sortable.item') : array_key_exists('wire:sortable.item', $attributes->getAttributes())))
     @php
         $attributes = $attributes->filter(fn ($value, $key) => $key !== 'wire:sortable.item');
     @endphp

--- a/resources/views/bootstrap-4/includes/filter-pills.blade.php
+++ b/resources/views/bootstrap-4/includes/filter-pills.blade.php
@@ -9,7 +9,7 @@
                         wire:key="filter-pill-{{ $key }}"
                         class="badge badge-pill badge-info d-inline-flex align-items-center"
                     >
-                        {{ $filterNames[$key] ?? collect($this->columns())->pluck('text', 'column')->get($key, ucwords(strtr($key, ['_' => ' ', '-' => ' ']))) }}:
+                        {{ $filterNames[$key] ?? collect($this->columns())->pluck('text', 'column')->get($key, isset($customFilters[$key]) && property_exists($customFilters[$key], 'name') ? $customFilters[$key]->name : ucwords(strtr($key, ['_' => ' ', '-' => ' ']))) }}:
                         @if(isset($customFilters[$key]) && method_exists($customFilters[$key], 'options'))
                             @if(is_array($value))
                                 @foreach($value as $selectedValue)

--- a/resources/views/bootstrap-5/components/table/row.blade.php
+++ b/resources/views/bootstrap-5/components/table/row.blade.php
@@ -1,6 +1,6 @@
 @props(['url' => null, 'target' => '_self', 'reordering' => false, 'customAttributes' => []])
 
-@if (!$reordering && $attributes->has('wire:sortable.item'))
+@if (!$reordering && (method_exists($attributes, 'has') ? $attributes->has('wire:sortable.item') : array_key_exists('wire:sortable.item', $attributes->getAttributes())))
     @php
         $attributes = $attributes->filter(fn ($value, $key) => $key !== 'wire:sortable.item');
     @endphp

--- a/resources/views/bootstrap-5/includes/filter-pills.blade.php
+++ b/resources/views/bootstrap-5/includes/filter-pills.blade.php
@@ -9,7 +9,7 @@
                         wire:key="filter-pill-{{ $key }}"
                         class="badge rounded-pill bg-info d-inline-flex align-items-center"
                     >
-                        {{ $filterNames[$key] ?? collect($this->columns())->pluck('text', 'column')->get($key, ucwords(strtr($key, ['_' => ' ', '-' => ' ']))) }}:
+                        {{ $filterNames[$key] ?? collect($this->columns())->pluck('text', 'column')->get($key, isset($customFilters[$key]) && property_exists($customFilters[$key], 'name') ? $customFilters[$key]->name : ucwords(strtr($key, ['_' => ' ', '-' => ' ']))) }}:
                         @if(isset($customFilters[$key]) && method_exists($customFilters[$key], 'options'))
                             @if(is_array($value))
                                 @foreach($value as $selectedValue)

--- a/resources/views/tailwind/components/table/row.blade.php
+++ b/resources/views/tailwind/components/table/row.blade.php
@@ -7,7 +7,7 @@
 @endif
 
 <tr
-    {{ $attributes->merge($customAttributes)->class(['cursor-pointer' => $url]) }}
+    {{ $attributes->merge($customAttributes)->merge(['class' => $url ? 'cursor-pointer' : '']) }}
 
     @if ($url)
         onclick="window.open('{{ $url }}', '{{ $target }}')"

--- a/resources/views/tailwind/components/table/row.blade.php
+++ b/resources/views/tailwind/components/table/row.blade.php
@@ -1,6 +1,6 @@
 @props(['url' => null, 'target' => '_self', 'reordering' => false, 'customAttributes' => []])
 
-@if (!$reordering && $attributes->has('wire:sortable.item'))
+@if (!$reordering && (method_exists($attributes, 'has') ? $attributes->has('wire:sortable.item') : array_key_exists('wire:sortable.item', $attributes->getAttributes())))
     @php
         $attributes = $attributes->filter(fn ($value, $key) => $key !== 'wire:sortable.item');
     @endphp

--- a/resources/views/tailwind/includes/filter-pills.blade.php
+++ b/resources/views/tailwind/includes/filter-pills.blade.php
@@ -9,7 +9,7 @@
                         wire:key="filter-pill-{{ $key }}"
                         class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900"
                     >
-                        {{ $filterNames[$key] ?? collect($this->columns())->pluck('text', 'column')->get($key, ucwords(strtr($key, ['_' => ' ', '-' => ' ']))) }}:
+                        {{ $filterNames[$key] ?? collect($this->columns())->pluck('text', 'column')->get($key, isset($customFilters[$key]) && property_exists($customFilters[$key], 'name') ? $customFilters[$key]->name : ucwords(strtr($key, ['_' => ' ', '-' => ' ']))) }}:
                         @if(isset($customFilters[$key]) && method_exists($customFilters[$key], 'options'))
                             @if(is_array($value))
                                 @foreach($value as $selectedValue)

--- a/tests/Http/Livewire/PetsTable.php
+++ b/tests/Http/Livewire/PetsTable.php
@@ -6,9 +6,30 @@ use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Filter;
 
 class PetsTable extends DataTableComponent
 {
+    public function filters(): array
+    {
+        return [
+            'species.name' => Filter::make('Filter Species')->select([
+                '' => 'All',
+                1  => 'Cat',
+                2  => 'Dog',
+                3  => 'Horse',
+                4  => 'Bird',
+            ]),
+            'breed_id'     => Filter::make('Filter Breed')->select([
+                '' => 'All',
+                1  => 'American Shorthair',
+                2  => 'Maine Coon',
+                3  => 'Persian',
+                4  => 'Norwegian Forest',
+            ]),
+        ];
+    }
+
     public function bulkActions(): array
     {
         return ['count' => 'Count selected'];
@@ -17,11 +38,13 @@ class PetsTable extends DataTableComponent
     /**
      * @return Builder
      */
-    public function query() : Builder
+    public function query(): Builder
     {
         return Pet::query()
             ->with('species')
-            ->with('breed');
+            ->with('breed')
+            ->when($this->getFilter('species.name'), fn (Builder $query, $specimen_id) => $query->where('species_id', $specimen_id))
+            ->when($this->getFilter('breed_id'), fn (Builder $query, $breed_id) => $query->where('breed_id', $breed_id));
     }
 
     public function columns(): array


### PR DESCRIPTION
Hi @rappasoft 

this PR will add a new way to generate filter pills fallback value:

at this time a filter pill label is computed as follow, using the first non-empty value:

1. Use the label set up in $filterNames property
2. Search for a Column with the same `column` value as the filter `key` and uses its `Text`
3. Manually computes the pill label from the filter key `ucwords(strtr($key, ['_' => ' ', '-' => ' ']))`

with this implementation a new step is inserted between 2 and 3:

1. Use the label set up in $filterNames property
2. Search for a Column with the same `column` value as the filter `key` and uses its `Text`
3. **Uses the filter `name` property**
4. Manually computes the pill label from the filter key `ucwords(strtr($key, ['_' => ' ', '-' => ' ']))`

This way, if a filter is defined using a key that doesn't match a column name, the filter label is used for its pill value

eg. a filter is defined like this one:

```php
'breed_id'     => Filter::make('Filter Breed')->select([
      '' => 'All',
      1  => 'American Shorthair',
      2  => 'Maine Coon',
      3  => 'Persian',
      4  => 'Norwegian Forest',
  ]),
```

there is not a matching column, the pill will be rendered as `Filter Breed` instead of  `Breed Id` (that is meaningless for the end user)


**Implementation**

- I updated the three `filter-pills.blade.php` templates in order to use the filter name before falling back to its key
- I added tests in order to check that the pills are rendered with the right label

**IMPORTANT**

As in filter tests now the actual Livewire render method is called, in tests workflows with prefer-stable options some issues come up because lowest versions of Laravel don't support `->has()` and `->class()` methods in `ComponentAttributeBag`.

This could cause errors on projects that use older versions of Laravel. I fixed this by replacing these calls with the old methods. Let me know what do you think about it.

**notes**

- this implementation is backward compatible, when views are published they will keep using the old fallback method instead of the filter label

- I added tests for filters, which I've seen are missing:

![image](https://user-images.githubusercontent.com/8792274/139839285-1a77f985-e0e4-4e1e-b6f6-b4ad57c7a1af.png)
