### PR TITLE
Patch add attributes to filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rappasoft/laravel-livewire-tables",
+    "name": "deltasystems/laravel-livewire-tables",
     "description": "A dynamic table component for Laravel Livewire",
     "keywords": [
         "rappasoft",

--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -96,7 +96,7 @@
         @forelse ($rows as $index => $row)
             <x-livewire-tables::table.row
                 wire:loading.class.delay="opacity-50 dark:bg-gray-900 dark:opacity-60"
-                wire:key="table-row-{{ $row->{$primaryKey} }}"
+                wire:key="table-row-{{ md5(rand()) }}-{{ $row->{\Rappasoft\LaravelLivewireTables\Utilities\ColumnUtilities::parseField($primaryKey)} }}"
                 wire:sortable.item="{{ $row->{$primaryKey} }}"
                 :reordering="$reordering"
                 :url="method_exists($this, 'getTableRowUrl') ? $this->getTableRowUrl($row) : ''"

--- a/src/Views/Filter.php
+++ b/src/Views/Filter.php
@@ -29,13 +29,19 @@ class Filter
     public array $options = [];
 
     /**
+     * @var array
+     */
+    public array $attributes = [];
+
+    /**
      * Filter constructor.
      *
      * @param string $name
      */
-    public function __construct(string $name)
+    public function __construct(string $name, ?array $attributes = [])
     {
         $this->name = $name;
+        $this->attributes = $attributes;
     }
 
     /**
@@ -43,9 +49,9 @@ class Filter
      *
      * @return Filter
      */
-    public static function make(string $name): Filter
+    public static function make(string $name, ?array $attributes = []): Filter
     {
-        return new static($name);
+        return new static($name, $attributes);
     }
 
     /**


### PR DESCRIPTION
This PR adds a new $attributes property to filters. This allows for custom attributes to be added to a filter when calling __construct() or make(). Presently, this it to accommodate custom usage of filters() (i.e. rendering on a dashboard search with multiple filters) and doesn't affect any of the built-in filter rendering.

While this has no effect on the current usage of filters, if approved, it would allow us to make a later PR that adds support for rendering attributes on the filter resources. For example, we can merge CSS classes defined with Filter::make() into the rendering of that filter.