### PR TITLE
Added feature to simplify adding wire:click functionality to row elements

### DIFF
--- a/docs/rows/clickable-rows.md
+++ b/docs/rows/clickable-rows.md
@@ -53,3 +53,21 @@ public function redirectToModel(string $name, array $parameters = [], $absolute 
 ```
 
 Now the blank space of the row should have its action, while your links go to their own action.
+
+## Working with `wire:click` on rows
+
+You can add the row-level livewire clicks by utilising the following method.
+
+```php
+public function getTableRowWireClick($row): ?string
+{
+    return "doSomething(" . $row->id . ")";
+}
+
+public function doSomething()
+{
+    // ...
+}
+```
+
+Adding a URL (using `getTableRowUrl`) to a row dismisses the option to use `getTableRowWireClick`, you cannot state both, the URL will supersede.

--- a/docs/rows/clickable-rows.md
+++ b/docs/rows/clickable-rows.md
@@ -70,4 +70,4 @@ public function doSomething()
 }
 ```
 
-Adding a URL (using `getTableRowUrl`) to a row dismisses the option to use `getTableRowWireClick`, you cannot state both, the URL will supersede.
+If you state both `getTableRowUrl` & `getTableRowWireClick`, the URL will supersede when a non-null value is supplied.

--- a/resources/views/bootstrap-4/includes/table.blade.php
+++ b/resources/views/bootstrap-4/includes/table.blade.php
@@ -98,6 +98,7 @@
                 :reordering="$reordering"
                 :url="method_exists($this, 'getTableRowUrl') ? $this->getTableRowUrl($row) : ''"
                 :target="method_exists($this, 'getTableRowUrlTarget') ? $this->getTableRowUrlTarget($row) : '_self'"
+                :wireclick="method_exists($this, 'getTableRowWireClick') ? $this->getTableRowWireClick($row) : ''"
                 :class="method_exists($this, 'setTableRowClass') ? ' ' . $this->setTableRowClass($row) : ''"
                 :id="method_exists($this, 'setTableRowId') ? $this->setTableRowId($row) : ''"
                 :customAttributes="method_exists($this, 'setTableRowAttributes') ? $this->setTableRowAttributes($row) : []"

--- a/resources/views/bootstrap-5/includes/table.blade.php
+++ b/resources/views/bootstrap-5/includes/table.blade.php
@@ -99,6 +99,7 @@
                 :reordering="$reordering"
                 :url="method_exists($this, 'getTableRowUrl') ? $this->getTableRowUrl($row) : ''"
                 :target="method_exists($this, 'getTableRowUrlTarget') ? $this->getTableRowUrlTarget($row) : '_self'"
+                :wireclick="method_exists($this, 'getTableRowWireClick') ? $this->getTableRowWireClick($row) : ''"
                 :class="method_exists($this, 'setTableRowClass') ? ' ' . $this->setTableRowClass($row) : ''"
                 :id="method_exists($this, 'setTableRowId') ? $this->setTableRowId($row) : ''"
                 :customAttributes="method_exists($this, 'setTableRowAttributes') ? $this->setTableRowAttributes($row) : []"

--- a/resources/views/tailwind/components/table/row.blade.php
+++ b/resources/views/tailwind/components/table/row.blade.php
@@ -11,7 +11,7 @@
 
     @if ($url)
         onclick="window.open('{{ $url }}', '{{ $target }}')"
-    @elseif ($wire)
+    @elseif ($wireclick)
         wire:click="{{ $wireclick }}"
     @endif
 >

--- a/resources/views/tailwind/components/table/row.blade.php
+++ b/resources/views/tailwind/components/table/row.blade.php
@@ -7,7 +7,7 @@
 @endif
 
 <tr
-    {{ $attributes->merge($customAttributes)->merge(['class' => ($url || $wire) ? 'cursor-pointer' : '']) }}
+    {{ $attributes->merge($customAttributes)->merge(['class' => ($url || $wireclick) ? 'cursor-pointer' : '']) }}
 
     @if ($url)
         onclick="window.open('{{ $url }}', '{{ $target }}')"

--- a/resources/views/tailwind/components/table/row.blade.php
+++ b/resources/views/tailwind/components/table/row.blade.php
@@ -1,4 +1,4 @@
-@props(['url' => null, 'target' => '_self', 'reordering' => false, 'customAttributes' => []])
+@props(['url' => null, 'wireclick' => null, 'target' => '_self', 'reordering' => false, 'customAttributes' => []])
 
 @if (!$reordering && (method_exists($attributes, 'has') ? $attributes->has('wire:sortable.item') : array_key_exists('wire:sortable.item', $attributes->getAttributes())))
     @php
@@ -7,10 +7,12 @@
 @endif
 
 <tr
-    {{ $attributes->merge($customAttributes)->merge(['class' => $url ? 'cursor-pointer' : '']) }}
+    {{ $attributes->merge($customAttributes)->merge(['class' => ($url || $wire) ? 'cursor-pointer' : '']) }}
 
     @if ($url)
         onclick="window.open('{{ $url }}', '{{ $target }}')"
+    @elseif ($wire)
+        wire:click="{{ $wireclick }}"
     @endif
 >
     {{ $slot }}

--- a/resources/views/tailwind/includes/table.blade.php
+++ b/resources/views/tailwind/includes/table.blade.php
@@ -101,6 +101,7 @@
                 :reordering="$reordering"
                 :url="method_exists($this, 'getTableRowUrl') ? $this->getTableRowUrl($row) : ''"
                 :target="method_exists($this, 'getTableRowUrlTarget') ? $this->getTableRowUrlTarget($row) : '_self'"
+                :wireclick="method_exists($this, 'getTableRowWireClick') ? $this->getTableRowWireClick($row) : ''"
                 :class="
                     ($index % 2 === 0 ?
                     'bg-white dark:bg-gray-700 dark:text-white' . (method_exists($this, 'getTableRowUrl') ? ' hover:bg-gray-100' : '') :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


This pull request adds the ability to add a "wire:click" to your row element, an alternative to a URL & Target, for if/when you're making a SPA.

No automated tests have been included - testing has been done manually, no conflicts could be found, and the table continues to work with and without the use of the added feature.

