### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 7.4]
-        laravel: [8.*]
+        php: [8.1, 8.0, 7.4]
+        laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,12 +10,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1, 8.0]
-        laravel: [8.*, 9.*]
+        laravel: [^8.71, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
+          - laravel: ^8.71
             testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0, 7.4]
+        php: [8.1, 8.0]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.4|^8.0",
         "livewire/livewire": "^2.6",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^8.0"
+        "illuminate/contracts": "^8.0|^9.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "orchestra/testbench": "^6.13",
+        "orchestra/testbench": "^6.13|^7.0",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
         "vimeo/psalm": "^4.4"


### PR DESCRIPTION
Hello @rappasoft!

This PR allows the package to be installed in Laravel 9.
Additionally, it updates the test suite for running on PHP 8.1 and Laravel 9.

Note: Tests on PHP 7.4 are disabled as it is time to move forward.
The minimum required version of Laravel is now `8.71` (because early versions of Laravel 8 don't support PHP 8.1).