### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,20 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 7.4]
-        laravel: [8.*]
+        php: [8.1, 8.0, 7.4]
+        laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
+        exclude:
+          - laravel: 9.*
+            php: 7.4
+          - laravel: 8.*
+            php: 8.1
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
         "php": "^7.4|^8.0",
         "livewire/livewire": "^2.6",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^8.0"
+        "illuminate/contracts": "^8.0|^9.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "orchestra/testbench": "^6.13",
+        "orchestra/testbench": "^6.13|^7.0",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
         "vimeo/psalm": "^4.4"


### PR DESCRIPTION
Hello @rappasoft!

This PR allows the package to be installed in Laravel 9.
It also updates the test suite for running on PHP 8.1 and Laravel 9.

Compared to #646 the only difference is that this does not remove PHP 7.4 support for Laravel 8 in the test suite.