### PR TITLE
Add wireclick to bootstrap 4 and 5 rows blade

### DIFF
--- a/resources/views/bootstrap-4/components/table/row.blade.php
+++ b/resources/views/bootstrap-4/components/table/row.blade.php
@@ -7,11 +7,12 @@
 @endif
 
 <tr
-    {{ $attributes->merge($customAttributes) }}
+    {{ $attributes->merge($customAttributes)->merge(['style' => ($url || $wireclick) ? 'cursor: pointer;' : '']) }}
 
     @if ($url)
         onclick="window.open('{{ $url }}', '{{ $target }}')"
-        style="cursor:pointer"
+    @elseif ($wireclick)
+        wire:click="{{ $wireclick }}"
     @endif
 >
     {{ $slot }}

--- a/resources/views/bootstrap-5/components/table/row.blade.php
+++ b/resources/views/bootstrap-5/components/table/row.blade.php
@@ -7,11 +7,12 @@
 @endif
 
 <tr
-    {{ $attributes->merge($customAttributes) }}
+    {{ $attributes->merge($customAttributes)->merge(['style' => ($url || $wireclick) ? 'cursor: pointer;' : '']) }}
 
     @if ($url)
         onclick="window.open('{{ $url }}', '{{ $target }}')"
-        style="cursor:pointer"
+    @elseif ($wireclick)
+        wire:click="{{ $wireclick }}"
     @endif
 >
     {{ $slot }}


### PR DESCRIPTION
I and my coworker @lucaspinheiro13 found that wireclick was not implemented to bootstrap 4 and bootstrap 5.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


This MR copy tailwind wireclick behavior to bootstrap blade, respecting that when there is an action the cursor will become a pointer.