### PR TITLE
Allow query for other column types

### DIFF
--- a/docs/columns/other-column-types.md
+++ b/docs/columns/other-column-types.md
@@ -79,6 +79,11 @@ ImageColumn::make('Avatar')
     ->location(function($row) {
         return storage_path('app/public/avatars/' . $row->id . '.jpg');
     })
+// Or if you want to query a column instead of using primary key
+ImageColumn::make('Avatar', 'avatar')
+    ->location(function($row) {
+        return $row->avatar;
+    })
 ```
 
 You may also pass an array of attributes to apply to the image tag:
@@ -104,6 +109,10 @@ Link columns provide a way to display HTML links in your table without having to
 LinkColumn::make('Action')
     ->title(fn($row) => 'Edit')
     ->location(fn($row) => route('admin.users.edit', $row))
+// Or if you want to query a column instead of using primary key
+LinkColumn::make('Link', 'link')
+    ->title(fn($row) => 'Link')
+    ->location(fn($row) => $row->link)
 ```
 
 You may also pass an array of attributes to apply to the `a` tag:

--- a/docs/examples/advanced-example.md
+++ b/docs/examples/advanced-example.md
@@ -73,6 +73,15 @@ class UsersTable extends DataTableComponent
                         'class' => 'w-8 h-8 rounded-full',
                     ];
                 }),
+            ImageColumn::make('Avatar', 'image')
+                ->location(function($row) {
+                    return $row->image;
+                })
+                ->attributes(function($row) {
+                    return [
+                        'class' => 'w-8 h-8 rounded-full',
+                    ];
+                }),
             Column::make('Order', 'sort')
                 ->sortable()
                 ->collapseOnMobile()

--- a/src/Views/Columns/ImageColumn.php
+++ b/src/Views/Columns/ImageColumn.php
@@ -17,11 +17,11 @@ class ImageColumn extends Column
     protected $locationCallback;
     protected $attributesCallback;
 
-    public function __construct(string $title, string $from = null, bool $query = false)
+    public function __construct(string $title, string $from = null)
     {
         parent::__construct($title, $from);
 
-        if (! $query) {
+        if (is_null($from)) {
             $this->label(fn () => null);
         }
     }

--- a/src/Views/Columns/ImageColumn.php
+++ b/src/Views/Columns/ImageColumn.php
@@ -17,11 +17,13 @@ class ImageColumn extends Column
     protected $locationCallback;
     protected $attributesCallback;
 
-    public function __construct(string $title, string $from = null)
+    public function __construct(string $title, string $from = null, bool $query = false)
     {
         parent::__construct($title, $from);
 
-        $this->label(fn () => null);
+        if (! $query) {
+            $this->label(fn () => null);
+        }
     }
 
     public function getContents(Model $row)

--- a/src/Views/Columns/LinkColumn.php
+++ b/src/Views/Columns/LinkColumn.php
@@ -22,7 +22,9 @@ class LinkColumn extends Column
     {
         parent::__construct($title, $from);
 
-        $this->label(fn () => null);
+        if (is_null($from)) {
+            $this->label(fn () => null);
+        }
     }
 
     public function getContents(Model $row)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

In case the ImageColumn or LinkColumn is **not** supposed to use the primary key of the row ImageColumn and LinkColumn can not be used right now, their field value is completely irrelevant. Added a check for field so that it will be queried too if set (why else would you set it for these columns):
```php
            (new ImageColumn('Image', 'image'))
                ->location(function($row) {
                    return $row->image;
                })
                ->attributes(function($row) {
                    return [
                        'class' => 'w-8 h-8 rounded-full',
                    ];
                })
```