### PR TITLE
User can now add filters in the config section

### DIFF
--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -49,6 +49,9 @@ abstract class DataTableComponent extends Component
             'filters' => $this->{$this->tableName}['filters'] ?? [],
         ];
 
+        // Set the filter defaults based on the filter type
+        $this->setFilterDefaults();
+        
         // Set the user defined columns to work with
         $this->setColumns();
 
@@ -59,9 +62,6 @@ abstract class DataTableComponent extends Component
         if (! $this->hasPrimaryKey()) {
             throw new DataTableConfigurationException('You must set a primary key using setPrimaryKey in the configure method.');
         }
-
-        // Set the filter defaults based on the filter type
-        $this->setFilterDefaults();
     }
 
     /**


### PR DESCRIPTION
The setFilter function would not work in the configure function, I moved the filterReset above $this->configure();.  Setting the filter now works.


### All Submissions:

* [y] Have you followed the guidelines in our Contributing document?
* [y] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [y and n] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
