### PR TITLE
customSortButtonAttributes except wire:key

### DIFF
--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -25,7 +25,7 @@
                 {{ 
                     $attributes->merge($customSortButtonAttributes)
                         ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider group focus:outline-none dark:text-gray-400' => $customSortButtonAttributes['default'] ?? true])
-                        ->except('default')
+                        ->except(['default', 'wire:key'])
                 }}
             >
                 <span>{{ $column->getTitle() }}</span>


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:
1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

Reproduce: Go to the [Demo page](https://tables.laravel-boilerplate.com/tailwind) and deselect the name or another column. It will looks like

![Screenshot 2022-05-03 at 13-03-17 Tailwind 2 Tables](https://user-images.githubusercontent.com/34892532/166442699-764d0201-2d0d-436a-a619-d6c67931d799.png)

I can't explain exactly why removing wire:key is the solution. I looked for the last changes of the file. At the commit setThSortButtonAttributes was the hardcoded classes replaced with customSortButtonAttributes and this work added wire:key to the button. Maybe this issue comes because the same wire:key is set on tow html tags (th and button). 

