### PR TITLE
Change formatting of relational column to allow proper sorting.

### DIFF
--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -80,7 +80,7 @@ trait WithSorting
             } elseif ($column->isBaseColumn()) {
                 $this->setBuilder($this->getBuilder()->orderBy($column->getColumnSelectName(), $direction));
             } else {
-                $this->setBuilder($this->getBuilder()->orderByRaw('"'.$column->getColumnSelectName().'"' . ' ' . $direction));
+                $this->setBuilder($this->getBuilder()->orderByRaw('`'.$column->getColumnSelectName().'`' . ' ' . $direction));
             }
         }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?


When sorting a relational column, the table wouldn't actually sort. Changing the query to use a backquote (`) instead of a double quote (") seems to fix this.
