### PR TITLE
Column select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [dev-column-select] - 2022-05-14
+
+- Added functionality to bookmark or deep link column selection
+- Added functionality to identify different datatable components as unique in column selection and filter arrays
+
 ## [2.7.0] - 2022-05-07
 
 ### Added

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -33,55 +33,6 @@ If you need the above, you should make them different components like so:
 <livewire:pending-users-table />
 ```
 
-## Introduction
-
-By default, your table has a name of `table`, as well as an internal array called `$table` which saves its state to the query string.
-
-The query string would look like this:
-
-```php
-// Under the hood
-public array $queryString = [
-    'table' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-]
-```
-
-In order to have multiple tables on the same page, you need to tell it how to save the state of each table.
-
-## Setting the table name and data
-
-If you have multiple tables on the same page and you want them to have independent state saved in the query string, you must set a table name and data array.
-
-```php
-public string $tableName = 'users';
-public array $users = [];
-```
-
-The data array must be the same name as the table name. This data array will remain blank, I tried to create it dynamically in the query string but Livewire doesn't support that, so you have to define it yourself. It is a workaround until Livewire supports dynamic properties for the query string.
-
-Your query string will now look like this:
-
-```php
-// Under the hood
-public array $queryString = [
-    'users' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-    // Other tables
-    'roles' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-]
-```
-
 ## Disabling the query string for multiple of the same component
 
 If you must have multiple of the same component on the same page, you should disable the query string for those components so the query string state does not get replaced by one or the other:
@@ -90,5 +41,17 @@ If you must have multiple of the same component on the same page, you should dis
 public function configure(): void
 {
     $this->setQueryStringDisabled();
+}
+```
+
+## Disabling column selection for multiple of the same component
+
+You should also disable the columns selection for those components so the query string and session state does not get replaced by one or the other:
+
+```php
+public function configure(): void
+{
+    $this->setColumnSelectStatus(true);
+    $this->setColumnSelectStatus(false);
 }
 ```

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -51,7 +51,6 @@ You should also disable the columns selection for those components so the query 
 ```php
 public function configure(): void
 {
-    $this->setColumnSelectStatus(true);
     $this->setColumnSelectStatus(false);
 }
 ```

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -33,55 +33,6 @@ If you need the above, you should make them different components like so:
 <livewire:pending-users-table />
 ```
 
-## Introduction
-
-By default, your table has a name of `table`, as well as an internal array called `$table` which saves its state to the query string.
-
-The query string would look like this:
-
-```php
-// Under the hood
-public array $queryString = [
-    'table' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-]
-```
-
-In order to have multiple tables on the same page, you need to tell it how to save the state of each table.
-
-## Setting the table name and data
-
-If you have multiple tables on the same page and you want them to have independent state saved in the query string, you must set a table name and data array.
-
-```php
-public string $tableName = 'users';
-public array $users = [];
-```
-
-The data array must be the same name as the table name. This data array will remain blank, I tried to create it dynamically in the query string but Livewire doesn't support that, so you have to define it yourself. It is a workaround until Livewire supports dynamic properties for the query string.
-
-Your query string will now look like this:
-
-```php
-// Under the hood
-public array $queryString = [
-    'users' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-    // Other tables
-    'roles' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-]
-```
-
 ## Disabling the query string for multiple of the same component
 
 If you must have multiple of the same component on the same page, you should disable the query string for those components so the query string state does not get replaced by one or the other:
@@ -92,3 +43,32 @@ public function configure(): void
     $this->setQueryStringDisabled();
 }
 ```
+
+## Fingerprinting multiple of the same component
+
+If you must have multiple of the same component on the same page, and you also need column selection enabled, you can override `dataTableFingerprint()` for one or more of the components:
+
+```php
+public string $uniqueIdentifier;
+
+public function mount($uniqueIdentifier)
+{
+    $this->uniqueIdentifier = $uniqueIdentifier
+}
+
+/**
+ * returns a unique id for the table, used as an alias to identify one table from another session and query string to prevent conflicts
+ */
+public function dataTableFingerprint(): string
+{
+    return $this->uniqueIdentifier;
+}
+```
+
+```html
+<livewire:users-table status="active" />
+
+<livewire:users-table status="pending" uniqueIdentifier="pending-users" />
+```
+
+The property name `$uniqueIdentifier` here is arbitrary -- you may call it anything you like. It is just being used here as an example of how one may pass in a unique identifier to be returned by the `dataTableFingerprint()` method.

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -66,7 +66,7 @@ public function dataTableFingerprint(): string
 ```
 
 ```html
-<livewire:users-table status="active" />
+<livewire:users-table status="active" uniqueIdentifier="active-users" />
 
 <livewire:users-table status="pending" uniqueIdentifier="pending-users" />
 ```

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -33,6 +33,55 @@ If you need the above, you should make them different components like so:
 <livewire:pending-users-table />
 ```
 
+## Introduction
+
+By default, your table has a name of `table`, as well as an internal array called `$table` which saves its state to the query string.
+
+The query string would look like this:
+
+```php
+// Under the hood
+public array $queryString = [
+    'table' => [
+        'search' => null,
+        'sort' => [],
+        ...
+    ],
+]
+```
+
+In order to have multiple tables on the same page, you need to tell it how to save the state of each table.
+
+## Setting the table name and data
+
+If you have multiple tables on the same page and you want them to have independent state saved in the query string, you must set a table name and data array.
+
+```php
+public string $tableName = 'users';
+public array $users = [];
+```
+
+The data array must be the same name as the table name. This data array will remain blank, I tried to create it dynamically in the query string but Livewire doesn't support that, so you have to define it yourself. It is a workaround until Livewire supports dynamic properties for the query string.
+
+Your query string will now look like this:
+
+```php
+// Under the hood
+public array $queryString = [
+    'users' => [
+        'search' => null,
+        'sort' => [],
+        ...
+    ],
+    // Other tables
+    'roles' => [
+        'search' => null,
+        'sort' => [],
+        ...
+    ],
+]
+```
+
 ## Disabling the query string for multiple of the same component
 
 If you must have multiple of the same component on the same page, you should disable the query string for those components so the query string state does not get replaced by one or the other:
@@ -43,32 +92,3 @@ public function configure(): void
     $this->setQueryStringDisabled();
 }
 ```
-
-## Fingerprinting multiple of the same component
-
-If you must have multiple of the same component on the same page, and you also need column selection enabled, you can override `dataTableFingerprint()` for one or more of the components:
-
-```php
-public ?string $uniqueIdentifier;
-
-public function mount($uniqueIdentifier = null)
-{
-    $this->uniqueIdentifier = $uniqueIdentifier
-}
-
-/**
- * returns a unique id for the table, used as an alias to identify one table from another session and query string to prevent conflicts
- */
-public function dataTableFingerprint(): string
-{
-    return $this->uniqueIdentifier ?? parent::dataTableFingerprint();
-}
-```
-
-```html
-<livewire:users-table status="active" />
-
-<livewire:users-table status="pending" uniqueIdentifier="pending-users" />
-```
-
-The property name `$uniqueIdentifier` here is arbitrary -- you may call it anything you like. It is just being used here as an example of how one may pass in a unique identifier to be returned by the `dataTableFingerprint()` method.

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -49,9 +49,9 @@ public function configure(): void
 If you must have multiple of the same component on the same page, and you also need column selection enabled, you can override `dataTableFingerprint()` for one or more of the components:
 
 ```php
-public string $uniqueIdentifier;
+public ?string $uniqueIdentifier;
 
-public function mount($uniqueIdentifier)
+public function mount($uniqueIdentifier = null)
 {
     $this->uniqueIdentifier = $uniqueIdentifier
 }
@@ -61,12 +61,12 @@ public function mount($uniqueIdentifier)
  */
 public function dataTableFingerprint(): string
 {
-    return $this->uniqueIdentifier;
+    return $this->uniqueIdentifier ?? parent::dataTableFingerprint();
 }
 ```
 
 ```html
-<livewire:users-table status="active" uniqueIdentifier="active-users" />
+<livewire:users-table status="active" />
 
 <livewire:users-table status="pending" uniqueIdentifier="pending-users" />
 ```

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -260,7 +260,7 @@
                                                         wire:target="selectedColumns"
                                                         wire:loading.attr="disabled"
                                                         type="checkbox"
-                                                        value="{{ $column->getHash() }}"
+                                                        value="{{ $column->getField() }}"
                                                     />
                                                     <span class="ml-2">{{ $column->getTitle() }}</span>
                                                 </label>
@@ -511,7 +511,7 @@
                                                 wire:target="selectedColumns"
                                                 wire:loading.attr="disabled"
                                                 type="checkbox"
-                                                value="{{ $column->getHash() }}"
+                                                value="{{ $column->getField() }}"
                                             />
                                             <span class="ml-2">{{ $column->getTitle() }}</span>
                                         </label>
@@ -754,7 +754,7 @@
                                                 wire:target="selectedColumns"
                                                 wire:loading.attr="disabled"
                                                 type="checkbox"
-                                                value="{{ $column->getHash() }}"
+                                                value="{{ $column->getField() }}"
                                             />
                                             <span class="ml-2">{{ $column->getTitle() }}</span>
                                         </label>

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -48,6 +48,16 @@ abstract class DataTableComponent extends Component
     ];
 
     /**
+     * returns a unique id for the table, used as an alias to identify one table from another session and query string to prevent conflicts
+     */
+    public function dataTableFingerprint(): string
+    {
+        $className = str_split(static::class);
+        $crc32 = sprintf('%u', crc32(serialize($className)));
+        return base_convert($crc32, 10, 36);
+    }
+
+    /**
      * Runs on every request, immediately after the component is instantiated, but before any other lifecycle methods are called
      */
     public function boot(): void

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -54,6 +54,7 @@ abstract class DataTableComponent extends Component
     {
         $className = str_split(static::class);
         $crc32 = sprintf('%u', crc32(serialize($className)));
+
         return base_convert($crc32, 10, 36);
     }
 

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -15,6 +15,7 @@ trait ComponentUtilities
     public array $table = [];
     public $theme = null;
     protected Builder $builder;
+    public $userSelectedColumns = [];
     protected $model;
     protected $primaryKey;
     protected string $tableName = 'table';
@@ -56,7 +57,8 @@ trait ComponentUtilities
     {
         if ($this->queryStringIsEnabled()) {
             return [
-                $this->getTableName() => ['except' => null],
+                $this->getTableName() => ['except' => null, 'as' => $this->dataTableFingerprint()],
+                'userSelectedColumns' => ['except' => null, 'as' => $this->dataTableFingerprint() . '-c']
             ];
         }
 

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -14,8 +14,8 @@ trait ComponentUtilities
 
     public array $table = [];
     public $theme = null;
+    public array $userSelectedColumns = [];
     protected Builder $builder;
-    public $userSelectedColumns = [];
     protected $model;
     protected $primaryKey;
     protected string $tableName = 'table';

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -58,7 +58,7 @@ trait ComponentUtilities
         if ($this->queryStringIsEnabled()) {
             return [
                 $this->getTableName() => ['except' => null, 'as' => $this->dataTableFingerprint()],
-                'userSelectedColumns' => ['except' => null, 'as' => $this->dataTableFingerprint() . '-c']
+                'userSelectedColumns' => ['except' => null, 'as' => $this->dataTableFingerprint() . '-c'],
             ];
         }
 

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -65,7 +65,7 @@ trait ColumnSelectHelpers
      */
     public function columnSelectIsEnabledForColumn($column): bool
     {
-        return in_array($column instanceof Column ? $column->getHash() : $column, $this->selectedColumns, true);
+        return in_array($column instanceof Column ? $column->getField() : $column, $this->selectedColumns, true);
     }
 
     /**
@@ -82,6 +82,6 @@ trait ColumnSelectHelpers
      */
     protected function getColumnSelectSessionKey()
     {
-        return $this->getTableName().'-columnSelectEnabled';
+        return $this->dataTableFingerprint().'-columnSelectEnabled';
     }
 }

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -36,8 +36,8 @@ trait WithColumnSelect
             ->toArray();
 
         // Set to either the default set or what is stored in the session
-        $this->selectedColumns = count($this->userSelectedColumns) > 0 ? 
-            $this->userSelectedColumns : 
+        $this->selectedColumns = count($this->userSelectedColumns) > 0 ?
+            $this->userSelectedColumns :
             session()->get($this->getColumnSelectSessionKey(), $columns);
 
         // Check to see if there are any excluded that are already stored in the enabled and remove them

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -31,17 +31,19 @@ trait WithColumnSelect
             ->filter(function ($column) {
                 return $column->isVisible() && $column->isSelectable() && $column->isSelected();
             })
-            ->map(fn ($column) => $column->getHash())
+            ->map(fn ($column) => $column->getField())
             ->values()
             ->toArray();
 
         // Set to either the default set or what is stored in the session
-        $this->selectedColumns = session()->get($this->getColumnSelectSessionKey(), $columns);
+        $this->selectedColumns = count($this->userSelectedColumns) > 0 ? 
+            $this->userSelectedColumns : 
+            session()->get($this->getColumnSelectSessionKey(), $columns);
 
         // Check to see if there are any excluded that are already stored in the enabled and remove them
         foreach ($this->getColumns() as $column) {
-            if (! $column->isSelectable() && ! in_array($column->getHash(), $this->selectedColumns, true)) {
-                $this->selectedColumns[] = $column->getHash();
+            if (! $column->isSelectable() && ! in_array($column->getField(), $this->selectedColumns, true)) {
+                $this->selectedColumns[] = $column->getField();
                 session([$this->getColumnSelectSessionKey() => $this->selectedColumns]);
             }
         }
@@ -49,6 +51,7 @@ trait WithColumnSelect
 
     public function updatedSelectedColumns(): void
     {
-        session([$this->getColumnSelectSessionKey() => $this->selectedColumns]);
+        $this->userSelectedColumns = $this->selectedColumns;
+        session([$this->getColumnSelectSessionKey() => $this->userSelectedColumns]);
     }
 }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -21,16 +21,6 @@ trait ColumnHelpers
     }
 
     /**
-     * @param  DataTableComponent  $component
-     *
-     * @return $this
-     */
-    public function getHash(): string
-    {
-        return $this->hash;
-    }
-
-    /**
      * @return bool
      */
     public function hasFrom(): bool

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -40,4 +40,52 @@ class DataTableComponentTest extends TestCase
 //            ->call('setPrimaryKey', null)
 //            ->call('setSearch', 'abcd');
     }
+
+    /** @test */
+    public function fingerprint_will_always_be_the_same_for_same_datatable(): void
+    {
+        $this->assertSame(
+            [
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+            ],
+            [
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+            ]
+        );
+        $this->assertSame($this->basicTable->dataTableFingerprint(), $this->fingerprintingAlgo($this->basicTable::class));
+    }
+
+    /** @test */
+    public function datatable_fingerprints_will_be_different_for_each_table(): void
+    {
+        $mockTable = new class() extends PetsTable {
+        };
+
+        $this->assertNotSame($this->basicTable->dataTableFingerprint(), $mockTable->dataTableFingerprint());
+    }
+
+    /** @test */
+    public function fingerprint_will_be_url_friendy(): void
+    {
+        $mocks = [];
+        for ($i = 0; $i < 9; $i++) {
+            $mocks[$i] = new class() extends PetsTable {
+            };
+            $this->assertFalse(filter_var('http://'.$mocks[$i]->dataTableFingerprint().'.dev', FILTER_VALIDATE_URL) === false);
+        }
+        // control
+        $this->assertTrue(filter_var('http://[9/$].dev', FILTER_VALIDATE_URL) === false);
+    }
+
+    protected function fingerPrintingAlgo($className)
+    {
+        $className = str_split($className);
+        $crc32 = sprintf('%u', crc32(serialize($className)));
+
+        return base_convert($crc32, 10, 36);
+    }
 }

--- a/tests/Views/Traits/Helpers/ColumnHelpersTest.php
+++ b/tests/Views/Traits/Helpers/ColumnHelpersTest.php
@@ -321,14 +321,6 @@ class ColumnHelpersTest extends TestCase
     }
 
     /** @test */
-    public function can_get_column_hash(): void
-    {
-        $column = Column::make('Name');
-
-        $this->assertSame($column->getHash(), md5('name'));
-    }
-
-    /** @test */
     public function can_check_if_column_has_secondary_header(): void
     {
         $column = Column::make('ID', 'id');


### PR DESCRIPTION
This feature uniquely identifies each table for column selections stored in the session. It also allows for columns selections to be put into the query string, so that selections can be bookmarked.

The tldr; is that we now have a fingerprinting method that uses `static::class` to generate a key, or slug for each component, to be used as an alias for `$tableName` in the session and query string arrays, which is always the same for the same component, and always different for another.

```php
    /**
     * returns a unique id for the table, used as an alias to identify one table from another session and query string to prevent conflicts
     */
    public function dataTableFingerprint(): string
    {
        $className = str_split(static::class);
        $crc32 = sprintf('%u', crc32(serialize($className)));

        return base_convert($crc32, 10, 36);
    }
```

```php
    /**
     * Set the custom query string array for this specific table
     *
     * @return array|\null[][]
     */
    public function queryString(): array
    {
        if ($this->queryStringIsEnabled()) {
            return [
                $this->getTableName() => ['except' => null, 'as' => $this->dataTableFingerprint()],
                'userSelectedColumns' => ['except' => null, 'as' => $this->dataTableFingerprint() . '-c']
            ];
        }

        return [];
    }
```

This produces urls that look something like this:
`http://table-demo.test/?11mbmzx[filters][year]=2022&11mbmzx-c[0]=year`

Where `11mbmzx` is the `fingerprint`, or unique `alias` for the component.

The dynamic link above will apply a filter with the key of `year` and value `2022` and select to only have the `year` column displayed.

checking only the `year` column in the columns▼ dropdown on a table fingerprinted `11mbmzx` will put `11mbmzx-c[0]=year` into the query string. it will also put the following array into the session:

 `11mbmzx-columnSelectEnabled` => array:1 [▼
    0 => `year`
  ]

Query strings will be evaluated first to determined which columns should be displayed, after that the session, followed by the default.

closes #760 
