### PR TITLE
Column select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,14 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
-## [column-select-dev] - 2022-05-14
+## [column-select-dev] - 2022-05-16
 
 ### Added
 
 - Added functionality to bookmark or deep link column selection
-- Added functionality to identify different datatable components as unique in column selection and filter arrays
-
-### Changed
-
-- Simplified misc/multiple-tables.md in docs where additional steps are no longer needed. (Original steps still work and lead to same result)
+- Added functionality to identify different datatable components as unique in column selection
+- Added Funcitonality to configure query string alias
+- Added Funcitonality to configure session key for column selection (dataTableFingerprint)
 
 ## [2.7.0] - 2022-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [column-select-dev] - 2022-05-18
+
+### Added
+
+- Added functionality to select/desect all columns in column selection dropdown
+
 ## [column-select-dev] - 2022-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [dev-column-select] - 2022-05-14
+
+- Added functionality to bookmark or deep link column selection
+- Added functionality to identify different datatable components as unique in column selection and filter arrays
+
 ## [2.7.0] - 2022-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
-## [column-select-dev] - 2022-05-18
-
-### Added
-
-- Added functionality to select/desect all columns in column selection dropdown
-
 ## [column-select-dev] - 2022-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
-## [dev-column-select] - 2022-05-14
+## [column-select-dev] - 2022-05-14
+
+### Added
 
 - Added functionality to bookmark or deep link column selection
 - Added functionality to identify different datatable components as unique in column selection and filter arrays
+
+### Changed
+
+- Simplified misc/multiple-tables.md in docs where additional steps are no longer needed. (Original steps still work and lead to same result)
 
 ## [2.7.0] - 2022-05-07
 

--- a/docs/columns/column-selection.md
+++ b/docs/columns/column-selection.md
@@ -96,3 +96,18 @@ public function configure(): void
     $this->setRememberColumnSelectionDisabled();
 }
 ```
+
+### setDataTableFingerprint
+
+In order to idenfify each table and prevent conflicts on column selection, each table is given a unique fingerprint.
+This fingerprint is generated using the static::class name of the component. If you are reusing
+the same component in different parts of your application, you may need to set your own custom fingerprint.
+
+```php
+public function configure(): void
+{
+    // Default fingerprint is output of protected method dataTableFingerprint()
+    // Below will prepend the current route name
+    $this->setDataTableFingerprint(route()->getName() . '-' . $this->dataTableFingerprint());
+}
+```

--- a/docs/datatable/available-methods.md
+++ b/docs/datatable/available-methods.md
@@ -353,17 +353,6 @@ public function configure(): void
 }
 ```
 
-### setQueryStringAlias
-
-Set an alias for the query string.
-
-```php
-public function configure(): void
-{
-  $this->setQueryStringAlias('my-custom-alias');
-}
-```
-
 ## Relationships
 
 **Disabled by default**, enable to eager load relationships for all columns in the component.

--- a/docs/datatable/available-methods.md
+++ b/docs/datatable/available-methods.md
@@ -353,6 +353,17 @@ public function configure(): void
 }
 ```
 
+### setQueryStringAlias
+
+Set an alias for the query string.
+
+```php
+public function configure(): void
+{
+  $this->setQueryStringAlias('my-custom-alias');
+}
+```
+
 ## Relationships
 
 **Disabled by default**, enable to eager load relationships for all columns in the component.

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -92,3 +92,14 @@ public function configure(): void
     $this->setQueryStringDisabled();
 }
 ```
+
+## Disabling column selection for multiple of the same component
+
+You should also disable the columns selection for those components so the column selection state does not get replaced by one or the other:
+
+```php
+public function configure(): void
+{
+    $this->setColumnSelectStatus(false);
+}
+```

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -33,6 +33,55 @@ If you need the above, you should make them different components like so:
 <livewire:pending-users-table />
 ```
 
+## Introduction
+
+By default, your table has a name of `table`, as well as an internal array called `$table` which saves its state to the query string.
+
+The query string would look like this:
+
+```php
+// Under the hood
+public array $queryString = [
+    'table' => [
+        'search' => null,
+        'sort' => [],
+        ...
+    ],
+]
+```
+
+In order to have multiple tables on the same page, you need to tell it how to save the state of each table.
+
+## Setting the table name and data
+
+If you have multiple tables on the same page and you want them to have independent state saved in the query string, you must set a table name and data array.
+
+```php
+public string $tableName = 'users';
+public array $users = [];
+```
+
+The data array must be the same name as the table name. This data array will remain blank, I tried to create it dynamically in the query string but Livewire doesn't support that, so you have to define it yourself. It is a workaround until Livewire supports dynamic properties for the query string.
+
+Your query string will now look like this:
+
+```php
+// Under the hood
+public array $queryString = [
+    'users' => [
+        'search' => null,
+        'sort' => [],
+        ...
+    ],
+    // Other tables
+    'roles' => [
+        'search' => null,
+        'sort' => [],
+        ...
+    ],
+]
+```
+
 ## Disabling the query string for multiple of the same component
 
 If you must have multiple of the same component on the same page, you should disable the query string for those components so the query string state does not get replaced by one or the other:
@@ -41,16 +90,5 @@ If you must have multiple of the same component on the same page, you should dis
 public function configure(): void
 {
     $this->setQueryStringDisabled();
-}
-```
-
-## Disabling column selection for multiple of the same component
-
-You should also disable the columns selection for those components so the query string and session state does not get replaced by one or the other:
-
-```php
-public function configure(): void
-{
-    $this->setColumnSelectStatus(false);
 }
 ```

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -33,55 +33,6 @@ If you need the above, you should make them different components like so:
 <livewire:pending-users-table />
 ```
 
-## Introduction
-
-By default, your table has a name of `table`, as well as an internal array called `$table` which saves its state to the query string.
-
-The query string would look like this:
-
-```php
-// Under the hood
-public array $queryString = [
-    'table' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-]
-```
-
-In order to have multiple tables on the same page, you need to tell it how to save the state of each table.
-
-## Setting the table name and data
-
-If you have multiple tables on the same page and you want them to have independent state saved in the query string, you must set a table name and data array.
-
-```php
-public string $tableName = 'users';
-public array $users = [];
-```
-
-The data array must be the same name as the table name. This data array will remain blank, I tried to create it dynamically in the query string but Livewire doesn't support that, so you have to define it yourself. It is a workaround until Livewire supports dynamic properties for the query string.
-
-Your query string will now look like this:
-
-```php
-// Under the hood
-public array $queryString = [
-    'users' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-    // Other tables
-    'roles' => [
-        'search' => null,
-        'sort' => [],
-        ...
-    ],
-]
-```
-
 ## Disabling the query string for multiple of the same component
 
 If you must have multiple of the same component on the same page, you should disable the query string for those components so the query string state does not get replaced by one or the other:
@@ -90,5 +41,17 @@ If you must have multiple of the same component on the same page, you should dis
 public function configure(): void
 {
     $this->setQueryStringDisabled();
+}
+```
+
+## Disabling column selection for multiple of the same component
+
+You should also disable the columns selection for those components so the query string and session state does not get replaced by one or the other:
+
+```php
+public function configure(): void
+{
+    $this->setColumnSelectStatus(true);
+    $this->setColumnSelectStatus(false);
 }
 ```

--- a/docs/misc/multiple-tables.md
+++ b/docs/misc/multiple-tables.md
@@ -51,7 +51,6 @@ You should also disable the columns selection for those components so the query 
 ```php
 public function configure(): void
 {
-    $this->setColumnSelectStatus(true);
     $this->setColumnSelectStatus(false);
 }
 ```

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -246,6 +246,26 @@
                         >
                             <div class="bg-white rounded-md shadow-xs dark:bg-gray-700 dark:text-white">
                                 <div class="p-2" role="menu" aria-orientation="vertical" aria-labelledby="column-select-menu">
+                                    <div>
+                                        <label
+                                            wire:loading.attr="disabled"
+                                            class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
+                                        >
+                                            <input
+                                                class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                                                @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
+                                                    checked
+                                                    wire:click="deselectAllColumns"
+                                                @else
+                                                    unchecked
+                                                    wire:click="selectAllColumns"
+                                                @endif
+                                                wire:loading.attr="disabled"
+                                                type="checkbox"
+                                            />
+                                            <span class="ml-2">{{ __('All Columns') }}</span>
+                                        </label>
+                                    </div>
                                     @foreach($component->getColumns() as $column)
                                         @if ($column->isVisible() && $column->isSelectable())
                                             <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">
@@ -498,6 +518,25 @@
                             x-bind:class="{'show' : open}"
                             aria-labelledby="columnSelect-{{ $component->getTableName() }}"
                         >
+                            <div>
+                                <label
+                                    wire:loading.attr="disabled"
+                                    class="mb-1"
+                                >
+                                    <input
+                                        @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
+                                            checked
+                                            wire:click="deselectAllColumns"
+                                        @else
+                                            unchecked
+                                            wire:click="selectAllColumns"
+                                        @endif
+                                        wire:loading.attr="disabled"
+                                        type="checkbox"
+                                    />
+                                    <span class="ml-2">{{ __('All Columns') }}</span>
+                                </label>
+                            </div>
                             @foreach($component->getColumns() as $column)
                                 @if ($column->isVisible() && $column->isSelectable())
                                     <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">
@@ -741,6 +780,25 @@
                             x-bind:class="{'show' : open}"
                             aria-labelledby="columnSelect-{{ $component->getTableName() }}"
                         >
+                            <div>
+                                <label
+                                    wire:loading.attr="disabled"
+                                    class="mb-1"
+                                >
+                                    <input
+                                        @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
+                                            checked
+                                            wire:click="deselectAllColumns"
+                                        @else
+                                            unchecked
+                                            wire:click="selectAllColumns"
+                                        @endif
+                                        wire:loading.attr="disabled"
+                                        type="checkbox"
+                                    />
+                                    <span class="ml-2">{{ __('All Columns') }}</span>
+                                </label>
+                            </div>
                             @foreach($component->getColumns() as $column)
                                 @if ($column->isVisible() && $column->isSelectable())
                                     <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -246,26 +246,6 @@
                         >
                             <div class="bg-white rounded-md shadow-xs dark:bg-gray-700 dark:text-white">
                                 <div class="p-2" role="menu" aria-orientation="vertical" aria-labelledby="column-select-menu">
-                                    <div>
-                                        <label
-                                            wire:loading.attr="disabled"
-                                            class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
-                                        >
-                                            <input
-                                                class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
-                                                @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
-                                                    checked
-                                                    wire:click="deselectAllColumns"
-                                                @else
-                                                    unchecked
-                                                    wire:click="selectAllColumns"
-                                                @endif
-                                                wire:loading.attr="disabled"
-                                                type="checkbox"
-                                            />
-                                            <span class="ml-2">{{ __('All Columns') }}</span>
-                                        </label>
-                                    </div>
                                     @foreach($component->getColumns() as $column)
                                         @if ($column->isVisible() && $column->isSelectable())
                                             <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">
@@ -518,25 +498,6 @@
                             x-bind:class="{'show' : open}"
                             aria-labelledby="columnSelect-{{ $component->getTableName() }}"
                         >
-                            <div>
-                                <label
-                                    wire:loading.attr="disabled"
-                                    class="mb-1"
-                                >
-                                    <input
-                                        @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
-                                            checked
-                                            wire:click="deselectAllColumns"
-                                        @else
-                                            unchecked
-                                            wire:click="selectAllColumns"
-                                        @endif
-                                        wire:loading.attr="disabled"
-                                        type="checkbox"
-                                    />
-                                    <span class="ml-2">{{ __('All Columns') }}</span>
-                                </label>
-                            </div>
                             @foreach($component->getColumns() as $column)
                                 @if ($column->isVisible() && $column->isSelectable())
                                     <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">
@@ -780,25 +741,6 @@
                             x-bind:class="{'show' : open}"
                             aria-labelledby="columnSelect-{{ $component->getTableName() }}"
                         >
-                            <div>
-                                <label
-                                    wire:loading.attr="disabled"
-                                    class="mb-1"
-                                >
-                                    <input
-                                        @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
-                                            checked
-                                            wire:click="deselectAllColumns"
-                                        @else
-                                            unchecked
-                                            wire:click="selectAllColumns"
-                                        @endif
-                                        wire:loading.attr="disabled"
-                                        type="checkbox"
-                                    />
-                                    <span class="ml-2">{{ __('All Columns') }}</span>
-                                </label>
-                            </div>
                             @foreach($component->getColumns() as $column)
                                 @if ($column->isVisible() && $column->isSelectable())
                                     <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -260,7 +260,7 @@
                                                         wire:target="selectedColumns"
                                                         wire:loading.attr="disabled"
                                                         type="checkbox"
-                                                        value="{{ $column->getHash() }}"
+                                                        value="{{ $column->getField() }}"
                                                     />
                                                     <span class="ml-2">{{ $column->getTitle() }}</span>
                                                 </label>
@@ -511,7 +511,7 @@
                                                 wire:target="selectedColumns"
                                                 wire:loading.attr="disabled"
                                                 type="checkbox"
-                                                value="{{ $column->getHash() }}"
+                                                value="{{ $column->getField() }}"
                                             />
                                             <span class="ml-2">{{ $column->getTitle() }}</span>
                                         </label>
@@ -754,7 +754,7 @@
                                                 wire:target="selectedColumns"
                                                 wire:loading.attr="disabled"
                                                 type="checkbox"
-                                                value="{{ $column->getHash() }}"
+                                                value="{{ $column->getField() }}"
                                             />
                                             <span class="ml-2">{{ $column->getTitle() }}</span>
                                         </label>

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -260,7 +260,7 @@
                                                         wire:target="selectedColumns"
                                                         wire:loading.attr="disabled"
                                                         type="checkbox"
-                                                        value="{{ $column->getField() }}"
+                                                        value="{{ $column->getSlug() }}"
                                                     />
                                                     <span class="ml-2">{{ $column->getTitle() }}</span>
                                                 </label>
@@ -511,7 +511,7 @@
                                                 wire:target="selectedColumns"
                                                 wire:loading.attr="disabled"
                                                 type="checkbox"
-                                                value="{{ $column->getField() }}"
+                                                value="{{ $column->getSlug() }}"
                                             />
                                             <span class="ml-2">{{ $column->getTitle() }}</span>
                                         </label>

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -754,7 +754,7 @@
                                                 wire:target="selectedColumns"
                                                 wire:loading.attr="disabled"
                                                 type="checkbox"
-                                                value="{{ $column->getField() }}"
+                                                value="{{ $column->getSlug() }}"
                                             />
                                             <span class="ml-2">{{ $column->getTitle() }}</span>
                                         </label>

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -71,7 +71,6 @@ abstract class DataTableComponent extends Component
         
         // Set the filter defaults based on the filter type
         $this->setFilterDefaults();
-        $this->configure();
     }
 
     /**
@@ -79,6 +78,7 @@ abstract class DataTableComponent extends Component
      */
     public function booted(): void
     {
+        $this->configure();
         $this->setTheme();
         $this->setBuilder($this->builder());
         $this->setColumns();

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -48,6 +48,17 @@ abstract class DataTableComponent extends Component
     ];
 
     /**
+     * returns a unique id for the table, used as an alias to identify one table from another session and query string to prevent conflicts
+     */
+    public function dataTableFingerprint(): string
+    {
+        $className = str_split(static::class);
+        $crc32 = sprintf('%u', crc32(serialize($className)));
+
+        return base_convert($crc32, 10, 36);
+    }
+
+    /**
      * Runs on every request, immediately after the component is instantiated, but before any other lifecycle methods are called
      */
     public function boot(): void

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -68,9 +68,10 @@ abstract class DataTableComponent extends Component
             'filters' => $this->{$this->tableName}['filters'] ?? [],
             'columns' => $this->{$this->tableName}['columns'] ?? [],
         ];
-
+        
         // Set the filter defaults based on the filter type
         $this->setFilterDefaults();
+        $this->configure();
     }
 
     /**
@@ -78,7 +79,6 @@ abstract class DataTableComponent extends Component
      */
     public function booted(): void
     {
-        $this->configure();
         $this->setTheme();
         $this->setBuilder($this->builder());
         $this->setColumns();

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -66,6 +66,7 @@ abstract class DataTableComponent extends Component
         $this->{$this->tableName} = [
             'sorts' => $this->{$this->tableName}['sorts'] ?? [],
             'filters' => $this->{$this->tableName}['filters'] ?? [],
+            'columns' => $this->{$this->tableName}['columns'] ?? [],
         ];
 
         // Set the filter defaults based on the filter type

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -50,7 +50,7 @@ abstract class DataTableComponent extends Component
     /**
      * returns a unique id for the table, used as an alias to identify one table from another session and query string to prevent conflicts
      */
-    public function dataTableFingerprint(): string
+    protected function dataTableFingerprint(): string
     {
         $className = str_split(static::class);
         $crc32 = sprintf('%u', crc32(serialize($className)));

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -14,6 +14,7 @@ trait ComponentUtilities
 
     public array $table = [];
     public $theme = null;
+    public array $userSelectedColumns = [];
     protected Builder $builder;
     protected $model;
     protected $primaryKey;
@@ -56,7 +57,8 @@ trait ComponentUtilities
     {
         if ($this->queryStringIsEnabled()) {
             return [
-                $this->getTableName() => ['except' => null],
+                $this->getTableName() => ['except' => null, 'as' => $this->dataTableFingerprint()],
+                'userSelectedColumns' => ['except' => null, 'as' => $this->dataTableFingerprint() . '-c'],
             ];
         }
 

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -56,7 +56,7 @@ trait ComponentUtilities
     {
         if ($this->queryStringIsEnabled()) {
             return [
-                $this->getTableName() => ['except' => null, 'as' => $this->dataTableFingerprint()],
+                $this->getTableName() => ['except' => null, 'as' => $this->getQueryStringAlias()],
             ];
         }
 

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -14,7 +14,6 @@ trait ComponentUtilities
 
     public array $table = [];
     public $theme = null;
-    public array $userSelectedColumns = [];
     protected Builder $builder;
     protected $model;
     protected $primaryKey;
@@ -58,7 +57,6 @@ trait ComponentUtilities
         if ($this->queryStringIsEnabled()) {
             return [
                 $this->getTableName() => ['except' => null, 'as' => $this->dataTableFingerprint()],
-                'userSelectedColumns' => ['except' => null, 'as' => $this->dataTableFingerprint() . '-c'],
             ];
         }
 

--- a/src/Traits/Configuration/ComponentConfiguration.php
+++ b/src/Traits/Configuration/ComponentConfiguration.php
@@ -369,5 +369,4 @@ trait ComponentConfiguration
 
         return $this;
     }
-
 }

--- a/src/Traits/Configuration/ComponentConfiguration.php
+++ b/src/Traits/Configuration/ComponentConfiguration.php
@@ -355,4 +355,19 @@ trait ComponentConfiguration
 
         return $this;
     }
+
+    public function setDataTableFingerprint(string $dataTableFingerprint): self
+    {
+        $this->dataTableFingerprint = $dataTableFingerprint;
+
+        return $this;
+    }
+
+    public function setQueryStringAlias(string $queryStringAlias): self
+    {
+        $this->queryStringAlias = $queryStringAlias;
+
+        return $this;
+    }
+
 }

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -65,7 +65,7 @@ trait ColumnSelectHelpers
      */
     public function columnSelectIsEnabledForColumn($column): bool
     {
-        return in_array($column instanceof Column ? $column->getField() : $column, $this->selectedColumns, true);
+        return in_array($column instanceof Column ? $column->getSlug() : $column, $this->selectedColumns, true);
     }
 
     /**

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -82,6 +82,6 @@ trait ColumnSelectHelpers
      */
     protected function getColumnSelectSessionKey()
     {
-        return $this->dataTableFingerprint().'-columnSelectEnabled';
+        return $this->getDataTableFingerprint().'-columnSelectEnabled';
     }
 }

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -65,7 +65,7 @@ trait ColumnSelectHelpers
      */
     public function columnSelectIsEnabledForColumn($column): bool
     {
-        return in_array($column instanceof Column ? $column->getHash() : $column, $this->selectedColumns, true);
+        return in_array($column instanceof Column ? $column->getField() : $column, $this->selectedColumns, true);
     }
 
     /**
@@ -82,6 +82,6 @@ trait ColumnSelectHelpers
      */
     protected function getColumnSelectSessionKey()
     {
-        return $this->getTableName().'-columnSelectEnabled';
+        return $this->dataTableFingerprint().'-columnSelectEnabled';
     }
 }

--- a/src/Traits/Helpers/ComponentHelpers.php
+++ b/src/Traits/Helpers/ComponentHelpers.php
@@ -13,23 +13,9 @@ trait ComponentHelpers
         return $this->dataTableFingerprint ?? $this->dataTableFingerprint();
     }
 
-    public function setDataTableFingerprint(string $dataTableFingerprint): self
-    {
-        $this->dataTableFingerprint = $dataTableFingerprint;
-
-        return $this;
-    }
-
     public function getQueryStringAlias(): string
     {
         return $this->queryStringAlias ?? $this->getTableName();
-    }
-
-    public function setQueryStringAlias(string $queryStringAlias): self
-    {
-        $this->queryStringAlias = $queryStringAlias;
-
-        return $this;
     }
 
     /**

--- a/src/Traits/Helpers/ComponentHelpers.php
+++ b/src/Traits/Helpers/ComponentHelpers.php
@@ -8,6 +8,30 @@ use Rappasoft\LaravelLivewireTables\Views\Column;
 
 trait ComponentHelpers
 {
+    public function getDataTableFingerprint(): string
+    {
+        return $this->dataTableFingerprint ?? $this->dataTableFingerprint();
+    }
+
+    public function setDataTableFingerprint(string $dataTableFingerprint): self
+    {
+        $this->dataTableFingerprint = $dataTableFingerprint;
+
+        return $this;
+    }
+
+    public function getQueryStringAlias(): string
+    {
+        return $this->queryStringAlias ?? $this->getTableName();
+    }
+
+    public function setQueryStringAlias(string $queryStringAlias): self
+    {
+        $this->queryStringAlias = $queryStringAlias;
+
+        return $this;
+    }
+
     /**
      * @param Builder
      */

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -31,7 +31,7 @@ trait WithColumnSelect
             ->filter(function ($column) {
                 return $column->isVisible() && $column->isSelectable() && $column->isSelected();
             })
-            ->map(fn ($column) => $column->getField())
+            ->map(fn ($column) => $column->getSlug())
             ->values()
             ->toArray();
 
@@ -42,8 +42,8 @@ trait WithColumnSelect
 
         // Check to see if there are any excluded that are already stored in the enabled and remove them
         foreach ($this->getColumns() as $column) {
-            if (! $column->isSelectable() && ! in_array($column->getField(), $this->selectedColumns, true)) {
-                $this->selectedColumns[] = $column->getField();
+            if (! $column->isSelectable() && ! in_array($column->getSlug(), $this->selectedColumns, true)) {
+                $this->selectedColumns[] = $column->getSlug();
                 session([$this->getColumnSelectSessionKey() => $this->selectedColumns]);
             }
         }

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -31,17 +31,19 @@ trait WithColumnSelect
             ->filter(function ($column) {
                 return $column->isVisible() && $column->isSelectable() && $column->isSelected();
             })
-            ->map(fn ($column) => $column->getHash())
+            ->map(fn ($column) => $column->getField())
             ->values()
             ->toArray();
 
         // Set to either the default set or what is stored in the session
-        $this->selectedColumns = session()->get($this->getColumnSelectSessionKey(), $columns);
+        $this->selectedColumns = count($this->userSelectedColumns) > 0 ?
+            $this->userSelectedColumns :
+            session()->get($this->getColumnSelectSessionKey(), $columns);
 
         // Check to see if there are any excluded that are already stored in the enabled and remove them
         foreach ($this->getColumns() as $column) {
-            if (! $column->isSelectable() && ! in_array($column->getHash(), $this->selectedColumns, true)) {
-                $this->selectedColumns[] = $column->getHash();
+            if (! $column->isSelectable() && ! in_array($column->getField(), $this->selectedColumns, true)) {
+                $this->selectedColumns[] = $column->getField();
                 session([$this->getColumnSelectSessionKey() => $this->selectedColumns]);
             }
         }
@@ -49,6 +51,7 @@ trait WithColumnSelect
 
     public function updatedSelectedColumns(): void
     {
-        session([$this->getColumnSelectSessionKey() => $this->selectedColumns]);
+        $this->userSelectedColumns = $this->selectedColumns;
+        session([$this->getColumnSelectSessionKey() => $this->userSelectedColumns]);
     }
 }

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -36,8 +36,8 @@ trait WithColumnSelect
             ->toArray();
 
         // Set to either the default set or what is stored in the session
-        $this->selectedColumns = count($this->userSelectedColumns) > 0 ?
-            $this->userSelectedColumns :
+        $this->selectedColumns = (isset($this->{$this->tableName}['columns']) && count($this->{$this->tableName}['columns']) > 0) ?
+            $this->{$this->tableName}['columns'] :
             session()->get($this->getColumnSelectSessionKey(), $columns);
 
         // Check to see if there are any excluded that are already stored in the enabled and remove them
@@ -51,7 +51,7 @@ trait WithColumnSelect
 
     public function updatedSelectedColumns(): void
     {
-        $this->userSelectedColumns = $this->selectedColumns;
-        session([$this->getColumnSelectSessionKey() => $this->userSelectedColumns]);
+        $this->{$this->tableName}['columns'] = $this->selectedColumns;
+        session([$this->getColumnSelectSessionKey() => $this->{$this->tableName}['columns']]);
     }
 }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -4,6 +4,7 @@ namespace Rappasoft\LaravelLivewireTables\Views\Traits\Helpers;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Views\Column;
@@ -42,6 +43,14 @@ trait ColumnHelpers
     public function getTitle(): string
     {
         return $this->title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug(): string
+    {
+        return Str::slug($this->title);
     }
 
     /**

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -21,16 +21,6 @@ trait ColumnHelpers
     }
 
     /**
-     * @param  DataTableComponent  $component
-     *
-     * @return $this
-     */
-    public function getHash(): string
-    {
-        return $this->hash;
-    }
-
-    /**
      * @return bool
      */
     public function hasFrom(): bool

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -40,4 +40,52 @@ class DataTableComponentTest extends TestCase
 //            ->call('setPrimaryKey', null)
 //            ->call('setSearch', 'abcd');
     }
+
+    /** @test */
+    public function fingerprint_will_always_be_the_same_for_same_datatable(): void
+    {
+        $this->assertSame(
+            [
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+            ],
+            [
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->dataTableFingerprint(),
+            ]
+        );
+        $this->assertSame($this->basicTable->dataTableFingerprint(), $this->fingerprintingAlgo($this->basicTable::class));
+    }
+
+    /** @test */
+    public function datatable_fingerprints_will_be_different_for_each_table(): void
+    {
+        $mockTable = new class() extends PetsTable {
+        };
+
+        $this->assertNotSame($this->basicTable->dataTableFingerprint(), $mockTable->dataTableFingerprint());
+    }
+
+    /** @test */
+    public function fingerprint_will_be_url_friendy(): void
+    {
+        $mocks = [];
+        for ($i = 0; $i < 9; $i++) {
+            $mocks[$i] = new class() extends PetsTable {
+            };
+            $this->assertFalse(filter_var('http://'.$mocks[$i]->dataTableFingerprint().'.dev', FILTER_VALIDATE_URL) === false);
+        }
+        // control
+        $this->assertTrue(filter_var('http://[9/$].dev', FILTER_VALIDATE_URL) === false);
+    }
+
+    protected function fingerPrintingAlgo($className)
+    {
+        $className = str_split($className);
+        $crc32 = sprintf('%u', crc32(serialize($className)));
+
+        return base_convert($crc32, 10, 36);
+    }
 }

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -42,50 +42,42 @@ class DataTableComponentTest extends TestCase
     }
 
     /** @test */
-    public function fingerprint_will_always_be_the_same_for_same_datatable(): void
+    public function default_fingerprint_will_always_be_the_same_for_same_datatable(): void
     {
         $this->assertSame(
             [
-                $this->basicTable->dataTableFingerprint(),
-                $this->basicTable->dataTableFingerprint(),
-                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->getDataTableFingerprint(),
+                $this->basicTable->getDataTableFingerprint(),
+                $this->basicTable->getDataTableFingerprint(),
             ],
             [
-                $this->basicTable->dataTableFingerprint(),
-                $this->basicTable->dataTableFingerprint(),
-                $this->basicTable->dataTableFingerprint(),
+                $this->basicTable->getDataTableFingerprint(),
+                $this->basicTable->getDataTableFingerprint(),
+                $this->basicTable->getDataTableFingerprint(),
             ]
         );
-        $this->assertSame($this->basicTable->dataTableFingerprint(), $this->fingerprintingAlgo($this->basicTable::class));
+        $this->assertSame($this->basicTable->getDataTableFingerprint(), $this->defaultFingerprintingAlgo($this->basicTable::class));
     }
 
     /** @test */
-    public function datatable_fingerprints_will_be_different_for_each_table(): void
+    public function default_datatable_fingerprints_will_be_different_for_each_table(): void
     {
         $mockTable = new class() extends PetsTable {
         };
 
-        $this->assertNotSame($this->basicTable->dataTableFingerprint(), $mockTable->dataTableFingerprint());
+        $this->assertNotSame($this->basicTable->getDataTableFingerprint(), $mockTable->getDataTableFingerprint());
     }
 
     /** @test */
-    public function fingerprint_will_be_url_friendy(): void
+    public function default_fingerprint_will_be_url_friendy(): void
     {
         $mocks = [];
         for ($i = 0; $i < 9; $i++) {
             $mocks[$i] = new class() extends PetsTable {
             };
-            $this->assertFalse(filter_var('http://'.$mocks[$i]->dataTableFingerprint().'.dev', FILTER_VALIDATE_URL) === false);
+            $this->assertFalse(filter_var('http://'.$mocks[$i]->getDataTableFingerprint().'.dev', FILTER_VALIDATE_URL) === false);
         }
         // control
         $this->assertTrue(filter_var('http://[9/$].dev', FILTER_VALIDATE_URL) === false);
-    }
-
-    protected function fingerPrintingAlgo($className)
-    {
-        $className = str_split($className);
-        $crc32 = sprintf('%u', crc32(serialize($className)));
-
-        return base_convert($crc32, 10, 36);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -93,4 +93,12 @@ class TestCase extends Orchestra
 
         config()->set('app.key', Encrypter::generateKey(config('app.cipher')));
     }
+
+    protected function defaultFingerPrintingAlgo($className)
+    {
+        $className = str_split($className);
+        $crc32 = sprintf('%u', crc32(serialize($className)));
+
+        return base_convert($crc32, 10, 36);
+    }
 }

--- a/tests/Traits/Configuration/FingerprintConfigurationTest.php
+++ b/tests/Traits/Configuration/FingerprintConfigurationTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Configuration;
+
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+class FingerprintConfigurationTest extends TestCase
+{
+    /** @test */
+    public function can_set_fingerprint(): void
+    {
+        $this->assertSame('test', $this->basicTable->setDataTableFingerprint('test')->getDataTableFingerprint());
+    }
+}

--- a/tests/Traits/Configuration/FingerprintConfigurationTest.php
+++ b/tests/Traits/Configuration/FingerprintConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Configuration;
 
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 class FingerprintConfigurationTest extends TestCase
@@ -11,4 +12,22 @@ class FingerprintConfigurationTest extends TestCase
     {
         $this->assertSame('test', $this->basicTable->setDataTableFingerprint('test')->getDataTableFingerprint());
     }
+
+    /** @test */
+    public function can_set_fingerprint_in_configure_method(): void
+    {
+        $mock = new class extends PetsTable {
+            public function configure(): void
+            {
+                $this->setDataTableFingerprint('test');
+            }
+        };
+
+        $mock->configure();
+        $mock->boot();
+
+        $this->assertSame('test', $mock->getDataTableFingerprint());
+    }
+
+
 }

--- a/tests/Traits/Configuration/QueryStringAliasConfigurationTest.php
+++ b/tests/Traits/Configuration/QueryStringAliasConfigurationTest.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Configuration;
 
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 class QueryStringAliasConfigurationTest extends TestCase
@@ -11,4 +12,20 @@ class QueryStringAliasConfigurationTest extends TestCase
     {
         $this->assertSame('test', $this->basicTable->setQueryStringAlias('test')->getQueryStringAlias());
     }
+
+        /** @test */
+        public function can_set_query_string_in_configure_method(): void
+        {
+            $mock = new class extends PetsTable {
+                public function configure(): void
+                {
+                    $this->setQueryStringAlias('test');
+                }
+            };
+    
+            $mock->configure();
+            $mock->boot();
+    
+            $this->assertSame('test', $mock->getQueryStringAlias());
+        }
 }

--- a/tests/Traits/Configuration/QueryStringAliasConfigurationTest.php
+++ b/tests/Traits/Configuration/QueryStringAliasConfigurationTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Configuration;
+
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+class QueryStringAliasConfigurationTest extends TestCase
+{
+    /** @test */
+    public function can_set_query_string_alias(): void
+    {
+        $this->assertSame('test', $this->basicTable->setQueryStringAlias('test')->getQueryStringAlias());
+    }
+}

--- a/tests/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Traits/Helpers/ComponentHelpersTest.php
@@ -225,4 +225,16 @@ class ComponentHelpersTest extends TestCase
 
         $this->assertFalse($this->basicTable->hideConfigurableAreasWhenReorderingIsDisabled());
     }
+
+    /** @test */
+    public function can_get_dataTable_fingerprint(): void
+    {
+        $this->assertSame($this->defaultFingerPrintingAlgo($this->basicTable::class), $this->basicTable->getDataTableFingerprint());
+    }
+
+    /** @test */
+    public function can_get_query_string_alias_and_it_will_be_the_same_as_table_name_by_default(): void
+    {
+        $this->assertSame($this->basicTable->getTableName(), $this->basicTable->getQueryStringAlias());
+    }
 }

--- a/tests/Traits/Visuals/ReorderingVisualsTest.php
+++ b/tests/Traits/Visuals/ReorderingVisualsTest.php
@@ -89,7 +89,7 @@ class ReorderingVisualsTest extends TestCase
             ->call('setReorderEnabled')
             ->assertSet('sortingStatus', true)
             ->call('sortBy', 'id')
-            ->assertSet('table', ['sorts' => ['id' => 'asc'], 'filters' => ['breed' => []]])
+            ->assertSet('table', ['sorts' => ['id' => 'asc'], 'filters' => ['breed' => []], 'columns' => []])
             ->assertSeeHtml('wire:click="sortBy(\'id\')"')
             ->call('enableReordering')
             ->assertSet('sortingStatus', false)
@@ -97,7 +97,7 @@ class ReorderingVisualsTest extends TestCase
             ->assertDontSeeHtml('wire:click="sortBy(\'id\')"')
             ->call('disableReordering')
             ->assertSet('sortingStatus', true)
-            ->assertSet('table', ['sorts' => ['id' => 'asc'], 'filters' => ['breed' => []]])
+            ->assertSet('table', ['sorts' => ['id' => 'asc'], 'filters' => ['breed' => []], 'columns' => []])
             ->assertSeeHtml('wire:click="sortBy(\'id\')"');
     }
 
@@ -264,7 +264,7 @@ class ReorderingVisualsTest extends TestCase
             ->call('setReorderEnabled')
             ->assertSet('filtersStatus', true)
             ->set('table.filters.breed', [1])
-            ->assertSet('table', ['filters' => ['breed' => [1]], 'sorts' => []])
+            ->assertSet('table', ['filters' => ['breed' => [1]], 'sorts' => [], 'columns' => []])
             ->assertSee('Filters')
             ->call('enableReordering')
             ->assertSet('filtersStatus', false)
@@ -272,7 +272,7 @@ class ReorderingVisualsTest extends TestCase
             ->assertDontSeeHtml('Filters')
             ->call('disableReordering')
             ->assertSet('filtersStatus', true)
-            ->assertSet('table', ['filters' => ['breed' => [1]], 'sorts' => []])
+            ->assertSet('table', ['filters' => ['breed' => [1]], 'sorts' => [], 'columns' => []])
             ->assertSeeHtml('Filters');
     }
 
@@ -282,7 +282,7 @@ class ReorderingVisualsTest extends TestCase
         Livewire::test(PetsTable::class)
             ->call('setReorderEnabled')
             ->set('table.filters.breed', [1])
-            ->assertSet('table', ['filters' => ['breed' => [1]], 'sorts' => []])
+            ->assertSet('table', ['filters' => ['breed' => [1]], 'sorts' => [], 'columns' => []])
             ->assertSee('Applied Filters')
             ->call('enableReordering')
             ->assertDontSee('Applied Filters');

--- a/tests/Views/Traits/Helpers/ColumnHelpersTest.php
+++ b/tests/Views/Traits/Helpers/ColumnHelpersTest.php
@@ -321,14 +321,6 @@ class ColumnHelpersTest extends TestCase
     }
 
     /** @test */
-    public function can_get_column_hash(): void
-    {
-        $column = Column::make('Name');
-
-        $this->assertSame($column->getHash(), md5('name'));
-    }
-
-    /** @test */
     public function can_check_if_column_has_secondary_header(): void
     {
         $column = Column::make('ID', 'id');


### PR DESCRIPTION
This feature uniquely identifies each table for column selections stored in the session. It also allows for columns selections to be put into the query string, so that selections can be bookmarked.

The tldr; is that we now have a fingerprinting method that uses `static::class` to generate a key, or slug for each component, to be used as an alias for `$tableName` in the session and query string arrays, which is always the same for the same component, and always different for another.

```php
    /**
     * returns a unique id for the table, used as an alias to identify one table from another session and query string to prevent conflicts
     */
    public function dataTableFingerprint(): string
    {
        $className = str_split(static::class);
        $crc32 = sprintf('%u', crc32(serialize($className)));

        return base_convert($crc32, 10, 36);
    }
```

```php
    /**
     * Set the custom query string array for this specific table
     *
     * @return array|\null[][]
     */
    public function queryString(): array
    {
        if ($this->queryStringIsEnabled()) {
            return [
                $this->getTableName() => ['except' => null, 'as' => $this->dataTableFingerprint()],
                'userSelectedColumns' => ['except' => null, 'as' => $this->dataTableFingerprint() . '-c']
            ];
        }

        return [];
    }
```

This produces urls that look something like this:
`http://table-demo.test/?11mbmzx[filters][year]=2022&11mbmzx-c[0]=year`

Where `11mbmzx` is the `fingerprint`, or unique `alias` for the component.

The dynamic link above will apply a filter with the key of `year` and value `2022` and select to only have the `year` column displayed.

checking only the `year` column in the columns▼ dropdown on a table fingerprinted `11mbmzx` will put `11mbmzx-c[0]=year` into the query string. it will also put the following array into the session:

 `11mbmzx-columnSelectEnabled` => array:1 [▼
    0 => `year`
  ]

Query strings will be evaluated first to determined which columns should be displayed, after that the session, followed by the default.

closes #760 