### PR TITLE
Column::make: return type static

### DIFF
--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -84,7 +84,7 @@ class Column
      * @param  string  $title
      * @param  string|null  $from
      *
-     * @return Column
+     * @return static
      */
     public static function make(string $title, string $from = null): Column
     {


### PR DESCRIPTION
`LinkColumn::make()->title()` gives currently an error in PHPStan in my project because it expects `LinkColumn::make` to return a `Column` even though it returns a `LinkColumn`.

I saw in your composer.json file that you also maintain compatability with 7.4, so I only changed the return type in the doc block. Ideal would of course be to also have `static` as return type also in the code itself.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
