### PR TITLE
Select deselect all columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [column-select-dev] - 2022-05-18
+
+### Added
+
+- Added functionality to select/desect all columns in column selection dropdown
+
 ## [column-select-dev] - 2022-05-16
 
 ### Added

--- a/docs/datatable/available-methods.md
+++ b/docs/datatable/available-methods.md
@@ -353,17 +353,6 @@ public function configure(): void
 }
 ```
 
-### setQueryStringAlias
-
-Set an alias for the query string.
-
-```php
-public function configure(): void
-{
-  $this->setQueryStringAlias('my-custom-alias');
-}
-```
-
 ## Relationships
 
 **Disabled by default**, enable to eager load relationships for all columns in the component.

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -246,6 +246,26 @@
                         >
                             <div class="bg-white rounded-md shadow-xs dark:bg-gray-700 dark:text-white">
                                 <div class="p-2" role="menu" aria-orientation="vertical" aria-labelledby="column-select-menu">
+                                    <div>
+                                        <label
+                                            wire:loading.attr="disabled"
+                                            class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
+                                        >
+                                            <input
+                                                class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                                                @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
+                                                    checked
+                                                    wire:click="deselectAllColumns"
+                                                @else
+                                                    unchecked
+                                                    wire:click="selectAllColumns"
+                                                @endif
+                                                wire:loading.attr="disabled"
+                                                type="checkbox"
+                                            />
+                                            <span class="ml-2">{{ __('All Columns') }}</span>
+                                        </label>
+                                    </div>
                                     @foreach($component->getColumns() as $column)
                                         @if ($column->isVisible() && $column->isSelectable())
                                             <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">
@@ -498,6 +518,25 @@
                             x-bind:class="{'show' : open}"
                             aria-labelledby="columnSelect-{{ $component->getTableName() }}"
                         >
+                            <div>
+                                <label
+                                    wire:loading.attr="disabled"
+                                    class="mb-1"
+                                >
+                                    <input
+                                        @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
+                                            checked
+                                            wire:click="deselectAllColumns"
+                                        @else
+                                            unchecked
+                                            wire:click="selectAllColumns"
+                                        @endif
+                                        wire:loading.attr="disabled"
+                                        type="checkbox"
+                                    />
+                                    <span class="ml-2">{{ __('All Columns') }}</span>
+                                </label>
+                            </div>
                             @foreach($component->getColumns() as $column)
                                 @if ($column->isVisible() && $column->isSelectable())
                                     <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">
@@ -741,6 +780,25 @@
                             x-bind:class="{'show' : open}"
                             aria-labelledby="columnSelect-{{ $component->getTableName() }}"
                         >
+                            <div>
+                                <label
+                                    wire:loading.attr="disabled"
+                                    class="mb-1"
+                                >
+                                    <input
+                                        @if(count($component->selectedColumns) === count($component->getDefaultVisibleColumns()))
+                                            checked
+                                            wire:click="deselectAllColumns"
+                                        @else
+                                            unchecked
+                                            wire:click="selectAllColumns"
+                                        @endif
+                                        wire:loading.attr="disabled"
+                                        type="checkbox"
+                                    />
+                                    <span class="ml-2">{{ __('All Columns') }}</span>
+                                </label>
+                            </div>
                             @foreach($component->getColumns() as $column)
                                 @if ($column->isVisible() && $column->isSelectable())
                                     <div wire:key="columnSelect-{{ $loop->index }}-{{ $component->getTableName() }}">

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -71,7 +71,6 @@ abstract class DataTableComponent extends Component
         
         // Set the filter defaults based on the filter type
         $this->setFilterDefaults();
-        $this->configure();
     }
 
     /**
@@ -79,6 +78,7 @@ abstract class DataTableComponent extends Component
      */
     public function booted(): void
     {
+        $this->configure();
         $this->setTheme();
         $this->setBuilder($this->builder());
         $this->setColumns();


### PR DESCRIPTION
I've notice while working with the column select feature it can get a little tedious having to uncheck and check each column every time.
- This adds functionality to check all and uncheck all columns. 
- Checking all columns just sets it back to the default, so it also clears the "columns" query string (but not the filters, etc).
- Checking all will not select columns that are configured as unselected. Those will have to be checked, or selected, manually, as is the default.
- This adds the feature for all themes
