### PR TITLE
Update WithSorting.php

### DIFF
--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -76,7 +76,7 @@ trait WithSorting
 
             // TODO: Test
             if ($column->hasSortCallback()) {
-                $this->setBuilder(app()->call($column->getSortCallback(), ['builder' => $this->getBuilder(), 'direction' => $direction]));
+                $this->setBuilder(call_user_func($column->getSortCallback(), $this->getBuilder(), $direction));
             } elseif ($column->isBaseColumn()) {
                 $this->setBuilder($this->getBuilder()->orderBy($column->getColumnSelectName(), $direction));
             } else {


### PR DESCRIPTION
### All Submissions:

* [Yes] Have you followed the guidelines in our Contributing document?
* [Yes] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [Not Tested] Does your submission pass tests and did you add any new tests needed for your feature?
2. [Not Applicable] Did you update all templates (if applicable)?
3. [Not Applicable] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended? **You betcha!**

### Changes to Core Features:

* [Not Tested] Have you added an explanation of what your changes do and why you'd like us to include them?
* [Not Tested] Have you written new tests for your core changes, as applicable?
* [Not Tested] Have you successfully ran tests with your changes locally?

Not sure if originally tests for the function exists, as the comment above the function is `//TODO: Test`

Not sure why, but on latest 
PHP `v8.1.5` 
Laravel `v9.16.0`
[laravel-livewire-tables](https://github.com/rappasoft/laravel-livewire-tables) `v2.7.0`

if you invoke the sortable callback on any column such as
```
Column::make('User', 'last_name')
    ->sortable(function(Builder $query, string $direction) {
        return $query->orderBy('last_name', $direction);
    })
    ->view('some.column.view)
```

**OR** 

```
Column::make('Department', 'agency_id')
->sortable(
  function(Builder $query, string $direction) {
      return $query->join('agencies', 'users.agency_id', '=', 'agencies.id')
          ->orderBy('agencies.name', 'ASC');
      }
  )
```

You will be met with this **error** when trying to sort.
![image](https://user-images.githubusercontent.com/30511153/172768823-ec97309c-07e8-4c04-aef5-5024d7ebde7c.png)

Error relates to an `app()->call()` within `WithSorting.php`
```
// TODO: Test
            if ($column->hasSortCallback()) {
                //this one returns a query to the server that is ONLY the call back
                $this->setBuilder(app()->call($column->getSortCallback(), ['builder' => $this->getBuilder(), 'direction' => $direction]));
                // This one work
                 $this->setBuilder(call_user_func($column->getSortCallback(), $this->getBuilder(), $direction));
            } elseif ($column->isBaseColumn()) {
                $this->setBuilder($this->getBuilder()->orderBy($column->getColumnSelectName(), $direction));
            } else {
                $this->setBuilder($this->getBuilder()->orderByRaw('"'.$column->getColumnSelectName().'"' . ' ' . $direction));
            }
```
not sure 100% the ramifcations of using `app()->call()` vs `call_user_func` but whatever is going on with `app()->call()` is not working. 
