### PR TITLE
Fix: Removed :mixed return type hint as it requires PHP8.0

### DIFF
--- a/src/Views/Traits/Helpers/FilterHelpers.php
+++ b/src/Views/Traits/Helpers/FilterHelpers.php
@@ -43,7 +43,7 @@ trait FilterHelpers
      * @param  string  $key
      * @return mixed
      */
-    public function getConfig(string $key): mixed
+    public function getConfig(string $key)
     {
         return $this->config[$key] ?? null;
     }


### PR DESCRIPTION
### Explanation
This change removes the :mixed return type hint for PHP7.4 Compatibility (as it was introduced in PHP8.0)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
