### PR TITLE
ComponentColumn Added

### DIFF
--- a/src/Views/Columns/ComponentColumn.php
+++ b/src/Views/Columns/ComponentColumn.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Views\Columns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
+use Illuminate\View\ComponentAttributeBag;
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Traits\Configuration\ComponentColumnConfiguration;
+use Rappasoft\LaravelLivewireTables\Views\Traits\Helpers\ComponentColumnHelpers;
+
+class ComponentColumn extends Column
+{
+    use ComponentColumnHelpers,
+        ComponentColumnConfiguration;
+
+    protected string $componentView;
+    protected $attributesCallback;
+    protected $slotCallback;
+
+    public function __construct(string $title, string $from = null)
+    {
+        parent::__construct($title, $from);
+    }
+
+    public function getContents(Model $row)
+    {
+        if ($this->isLabel()) {
+            throw new DataTableConfigurationException('You can not use a label column with a component column');
+        }
+
+        if (false === $this->hasComponentView()) {
+            throw new DataTableConfigurationException('You must specify a component view for a component column');
+        }
+
+        $attributes  = [];
+        $value       = $this->getValue($row);
+        $slotContent = $value;
+
+        if ($this->hasAttributesCallback()) {
+            $attributes = call_user_func($this->getAttributesCallback(), $value, $row, $this);
+
+            if (!is_array($attributes)) {
+                throw new DataTableConfigurationException('The return type of callback must be an array');
+            }
+        }
+        if ($this->hasSlotCallback()) {
+            $slotContent = call_user_func($this->getSlotCallback(), $value, $row, $this);
+            if (is_string($slotContent)) {
+                $slotContent = new HtmlString($slotContent);
+            }
+        }
+
+        return view($this->getComponentView(), [
+            'attributes' =>  new ComponentAttributeBag($attributes),
+            'slot' => $slotContent,
+        ]);
+    }
+}

--- a/src/Views/Traits/Configuration/ComponentColumnConfiguration.php
+++ b/src/Views/Traits/Configuration/ComponentColumnConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Views\Traits\Configuration;
+
+trait ComponentColumnConfiguration
+{
+    public function component(string $component): self
+    {
+        $this->componentView = 'components.' . $component;
+        return $this;
+    }
+
+    public function attributes(callable $callback): self
+    {
+        $this->attributesCallback = $callback;
+        return $this;
+    }
+
+    public function slot(callable $callback): self
+    {
+        $this->slotCallback = $callback;
+        return $this;
+    }
+}

--- a/src/Views/Traits/Helpers/ComponentColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ComponentColumnHelpers.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Views\Traits\Helpers;
+
+trait ComponentColumnHelpers
+{
+    public function getAttributesCallback()
+    {
+        return $this->attributesCallback;
+    }
+
+    public function hasAttributesCallback(): bool
+    {
+        return $this->attributesCallback !== null;
+    }
+
+    public function getSlotCallback()
+    {
+        return $this->slotCallback;
+    }
+
+    public function hasSlotCallback(): bool
+    {
+        return $this->slotCallback !== null;
+    }
+
+    /**
+     * Get the value of componentView
+     */
+    public function getComponentView()
+    {
+        return $this->componentView;
+    }
+
+    public function hasComponentView(): bool
+    {
+        return isset($this->componentView);
+    }
+}

--- a/tests/Views/ComponentColumnTest.php
+++ b/tests/Views/ComponentColumnTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Views;
+
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+use Rappasoft\LaravelLivewireTables\Views\Columns\ComponentColumn;
+
+class ComponentColumnTest extends TestCase
+{
+    /** @test */
+    public function component_column_attributes_callback_return_can_not_be_an_string()
+    {
+        $this->expectException(DataTableConfigurationException::class);
+        ComponentColumn::make('Name')
+            ->component('alert')
+            ->attributes(fn () => 'string')->getContents(Pet::find(1));
+    }
+
+    /** @test */
+    public function component_column_component_has_to_be_an_string()
+    {
+        $column = ComponentColumn::make('Name')
+            ->component('alert');
+        $this->assertEquals('components.alert', $column->getComponentView());
+    }
+
+    /** @test */
+    public function component_column_component_view_has_to_be_set()
+    {
+        $this->expectException(DataTableConfigurationException::class);
+        ComponentColumn::make('Name')
+            ->getContents(Pet::find(1));
+    }
+}

--- a/tests/Views/Traits/Configuration/ComponentColumnConfigurationTest.php
+++ b/tests/Views/Traits/Configuration/ComponentColumnConfigurationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Views\Traits\Configuration;
+
+use Closure;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+use Rappasoft\LaravelLivewireTables\Views\Columns\ComponentColumn;
+
+class ComponentColumnConfigurationTest extends TestCase
+{
+    /** @test */
+    public function component_column_can_set_slot_callback(): void
+    {
+        $column = ComponentColumn::make('Name');
+
+        $this->assertFalse($column->hasSlotCallback());
+
+        $column->slot(fn ($value) => $value);
+
+        $this->assertTrue($column->hasSlotCallback());
+
+        $this->assertTrue($column->getSlotCallback() instanceof Closure);
+    }
+
+    /** @test */
+    public function component_column_can_set_attributes_callback(): void
+    {
+        $column = ComponentColumn::make('Name');
+
+        $this->assertFalse($column->hasAttributesCallback());
+
+        $column->attributes(fn ($value) => $value);
+
+        $this->assertTrue($column->hasAttributesCallback());
+
+        $this->assertTrue($column->getAttributesCallback() instanceof Closure);
+    }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

## Explain
Added a new Column type for projec blade component (anonimous).
This is better than create a cell for that component or return a view with an instance of ComponentAttributeBag.
Until now if you want to render a blade component, you had to create a new cell and place the component there or 'hack' it like this.

```php
Column::make("Email", "email")
->format(function ($value) {
    return view('components.alert')
        ->with('attributes', new ComponentAttributeBag([
            'type' => Str::endsWith($value, 'example.org') ? 'success' : 'danger',
            'dismissible' => true,
        ]))
        ->with('slot', $value);
}),
```

After this PR it will be like that:
```php
ComponentColumn::make("Email", "email")
->component('alert')
->attributes(fn ($value, $row, Column $column) => [
    'type' => Str::endsWith($value, 'example.org') ? 'success' : 'danger',
    'dismissible' => true,
]),
```