### PR TITLE
Change return type of Filter::make() to static

### DIFF
--- a/src/Views/Filter.php
+++ b/src/Views/Filter.php
@@ -34,6 +34,9 @@ abstract class Filter
         }
     }
 
+    /**
+     * @return static
+     */
     public static function make(string $name, string $key = null): Filter
     {
         return new static($name, $key);


### PR DESCRIPTION
Currently `SelectFilter::make('Foo')->options()` gives an error in PHPStan because it expects it to return a Filter, but it returns a  SelectFilter.

Added the static return type to the method's DocBlock since PHP 7.4 needs to be supported.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
