### PR TITLE
Update WithSearch.php

### DIFF
--- a/src/Traits/WithSearch.php
+++ b/src/Traits/WithSearch.php
@@ -26,12 +26,18 @@ trait WithSearch
 
             if ($searchableColumns->count()) {
                 $this->setBuilder($this->getBuilder()->where(function ($query) use ($searchableColumns) {
-                    foreach ($searchableColumns as $index => $column) {
-                        if ($column->hasSearchCallback()) {
-                            ($column->getSearchCallback())($query, $this->getSearch());
-                        } else {
-                            $query->{$index === 0 ? 'where' : 'orWhere'}($column->getColumn(), 'like', '%'.$this->getSearch().'%');
-                        }
+                    $searchTerms = preg_split("/[\s]+/", $this->getSearch(), -1, PREG_SPLIT_NO_EMPTY);
+
+                    foreach ($searchTerms as $value) {
+                        $query->where(function ($query) use ($searchableColumns, $value) {
+                            foreach ($searchableColumns as $index => $column) {
+                                if ($column->hasSearchCallback()) {
+                                    ($column->getSearchCallback())($query, $this->getSearch());
+                                } else {
+                                    $query->{$index === 0 ? 'where' : 'orWhere'}($column->getColumn(), 'like', '%' . $value . '%');
+                                }
+                            }
+                        });
                     }
                 }));
             }
@@ -39,4 +45,4 @@ trait WithSearch
 
         return $this->getBuilder();
     }
-}
+    }


### PR DESCRIPTION
For the global searcher to work, words must be in the correct order and multiple words must be in the same field. With this change, you should be able to use various terms to search in numerous fields as long as they are in the same record, regardless of the order of the words. I tested it myself, but I suggest internal testing before applying. Thoughts?

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
