### PR TITLE
Add check for table 'from' field inside ImageColumn

### DIFF
--- a/src/Views/Columns/ImageColumn.php
+++ b/src/Views/Columns/ImageColumn.php
@@ -21,7 +21,9 @@ class ImageColumn extends Column
     {
         parent::__construct($title, $from);
 
-        $this->label(fn () => null);
+        if (is_null($from)) {
+            $this->label(fn () => null);
+        }
     }
 
     public function getContents(Model $row)


### PR DESCRIPTION
Let's say you have an **image** field on your table. The current solution for **ImageColumn** will not query the **image** column from the database because somehow the existing label callback returns null which in turn results in *$this->field* being null.