### PR TITLE
fix responsive on bootstrap 4 - 5

### DIFF
--- a/resources/views/components/table/td/plain.blade.php
+++ b/resources/views/components/table/td/plain.blade.php
@@ -17,8 +17,8 @@
     <td {{ $attributes
         ->merge($customAttributes)
         ->class(['' => $customAttributes['default'] ?? true])
-        ->class(['none d-sm-table-cell' => $column && $column->shouldCollapseOnMobile()])
-        ->class(['none d-md-table-cell' => $column && $column->shouldCollapseOnTablet()])
+        ->class(['d-none d-sm-table-cell' => $column && $column->shouldCollapseOnMobile()])
+        ->class(['d-none d-md-table-cell' => $column && $column->shouldCollapseOnTablet()])
         ->except('default')
     }}>{{ $slot }}</td>
 @endif


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


Hi. The Header row doesnt look good on mobile when bootstrap is used. 
![image](https://user-images.githubusercontent.com/12190841/188907666-49ba2dd3-f30f-46f7-818f-13673d01260d.png)

This is because the class is 'd-none' for toggle hide on elements.
https://getbootstrap.com/docs/4.6/utilities/display/#hiding-elements
https://getbootstrap.com/docs/4.6/utilities/display/#hiding-elements

![image](https://user-images.githubusercontent.com/12190841/188908753-33f0e874-74b5-4ad1-bcca-347f6e217f4d.png)


