### PR TITLE
Filter excluded columns from select

### DIFF
--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -93,6 +93,7 @@ trait ColumnHelpers
     public function getSelectableColumns(): Collection
     {
         return $this->getColumns()
+            ->reject(fn (Column $column) => $column->isLabel())
             ->filter(fn (Column $column) => $column->isSelectable())
             ->values();
     }

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -93,7 +93,7 @@ trait ColumnHelpers
     public function getSelectableColumns(): Collection
     {
         return $this->getColumns()
-            ->reject(fn (Column $column) => $column->isLabel())
+            ->filter(fn (Column $column) => $column->isSelectable())
             ->values();
     }
 


### PR DESCRIPTION
I found that `excludeFromColumnSelect` wasn't working corectly. 

E.g 
```php
Column::make('Actions', 'actions')
                ->excludeFromColumnSelect()
                ->view('tables.columns.actions')
```