### PR TITLE
The query-select for the column can be modified or omitted.

### DIFF
--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -117,8 +117,11 @@ trait WithData
         }
 
         foreach ($this->getSelectableColumns() as $column) {
-            $tablePrefix = ($column->getApplyTableNamePrefix() ? $column->getColumn() . ' as ' : '');
-            $this->setBuilder($this->getBuilder()->addSelect($tablePrefix . $column->getColumnSelectName()));
+            if ($column->getModifiedQuerySelect() === "") continue;
+
+            $selectQuery = ($column->getModifiedQuerySelect() === null ?
+                $column->getColumn() . ' as ' . $column->getColumnSelectName() : $column->getModifiedQuerySelect());
+            $this->setBuilder($this->getBuilder()->addSelect($selectQuery));
         }
 
         return $this->getBuilder();

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -13,7 +13,7 @@ trait WithData
     public function getRows()
     {
         $this->baseQuery();
-        
+
         return $this->executeQuery();
     }
 
@@ -117,7 +117,8 @@ trait WithData
         }
 
         foreach ($this->getSelectableColumns() as $column) {
-            $this->setBuilder($this->getBuilder()->addSelect($column->getColumn() . ' as ' .$column->getColumnSelectName()));
+            $tablePrefix = ($column->getApplyTableNamePrefix() ? $column->getColumn() . ' as ' : '');
+            $this->setBuilder($this->getBuilder()->addSelect($tablePrefix . $column->getColumnSelectName()));
         }
 
         return $this->getBuilder();

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -55,7 +55,7 @@ class Column
     protected bool $footer = false;
     protected $footerCallback;
     protected bool $clickable = true;
-    protected bool $applyTableNamePrefix = true;
+    protected ?string $modifiedQuerySelect = null;
 
     /**
      * @param  string  $title

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -55,6 +55,7 @@ class Column
     protected bool $footer = false;
     protected $footerCallback;
     protected bool $clickable = true;
+    protected bool $applyTableNamePrefix = true;
 
     /**
      * @param  string  $title

--- a/src/Views/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Views/Traits/Configuration/ColumnConfiguration.php
@@ -216,4 +216,14 @@ trait ColumnConfiguration
 
         return $this;
     }
+
+    /**
+     * @return $this
+     */
+    public function applyTableNamePrefix(bool $applyTableNamePrefix): self
+    {
+        $this->applyTableNamePrefix = $applyTableNamePrefix;
+
+        return $this;
+    }
 }

--- a/src/Views/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Views/Traits/Configuration/ColumnConfiguration.php
@@ -220,9 +220,9 @@ trait ColumnConfiguration
     /**
      * @return $this
      */
-    public function applyTableNamePrefix(bool $applyTableNamePrefix): self
+    public function modifyQuerySelect(?string $querySelect = null): self
     {
-        $this->applyTableNamePrefix = $applyTableNamePrefix;
+        $this->modifiedQuerySelect = empty($querySelect) ? "" : $querySelect;
 
         return $this;
     }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -540,7 +540,7 @@ trait ColumnHelpers
             if (is_bool($attributes[$key])) {
                 return $attributes[$key] ? $key : '';
             }
-            
+
             return $key . '="' . $attributes[$key] . '"';
         }, array_keys($attributes)));
     }
@@ -553,5 +553,13 @@ trait ColumnHelpers
         return $this->clickable &&
             $this->component->hasTableRowUrl() &&
             ! $this instanceof LinkColumn;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getApplyTableNamePrefix(): bool
+    {
+        return $this->applyTableNamePrefix === true;
     }
 }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -556,10 +556,10 @@ trait ColumnHelpers
     }
 
     /**
-     * @return bool
+     * @return ?string
      */
-    public function getApplyTableNamePrefix(): bool
+    public function getModifiedQuerySelect(): ?string
     {
-        return $this->applyTableNamePrefix === true;
+        return $this->modifiedQuerySelect;
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

This pull requests let you hide the table-name prefix in front of some selects in the query. This is helpful to enable sorting and filtering for additional added columns (like with a join). With this pull it is also possible to mitigate some problems related to relationships. (Requested in Issue #874 )

If this pull request would be merged, than I can add the documentation too.