### PR TITLE
Fix errors when filter does not exist

### DIFF
--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -94,7 +94,7 @@ trait ComponentUtilities
             $filterName = Str::after($name, $this->getTableName().'.filters.');
             $filter = $this->getFilterByKey($filterName);
 
-            if ($filter->isEmpty($value)) {
+            if ($filter && $filter->isEmpty($value)) {
                 $this->resetFilter($filterName);
             }
         }

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -115,7 +115,9 @@ trait FilterHelpers
 
     public function getAppliedFilters(): array
     {
-        $validFilterKeys = $this->getFilters()->map(fn($filter) => $filter->getKey())->toArray();
+        $validFilterKeys = $this->getFilters()
+            ->map(fn(Filter $filter) => $filter->getKey())
+            ->toArray();
 
         return collect($this->{$this->getTableName()}['filters'] ?? [])
             ->filter(fn ($value, $key) => in_array($key, $validFilterKeys, true))

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -116,7 +116,7 @@ trait FilterHelpers
     public function getAppliedFilters(): array
     {
         $validFilterKeys = $this->getFilters()
-            ->map(fn(Filter $filter) => $filter->getKey())
+            ->map(fn (Filter $filter) => $filter->getKey())
             ->toArray();
 
         return collect($this->{$this->getTableName()}['filters'] ?? [])

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -115,7 +115,11 @@ trait FilterHelpers
 
     public function getAppliedFilters(): array
     {
-        return $this->{$this->getTableName()}['filters'] ?? [];
+        $validFilterKeys = collect($this->getFilters())->map(fn($filter) => $filter->getKey())->toArray();
+
+        return collect($this->{$this->getTableName()}['filters'] ?? [])
+            ->filter(fn ($value, $key) => in_array($key, $validFilterKeys, true))
+            ->toArray();
     }
 
     public function hasAppliedFiltersWithValues(): bool

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -115,7 +115,7 @@ trait FilterHelpers
 
     public function getAppliedFilters(): array
     {
-        $validFilterKeys = collect($this->getFilters())->map(fn($filter) => $filter->getKey())->toArray();
+        $validFilterKeys = $this->getFilters()->map(fn($filter) => $filter->getKey())->toArray();
 
         return collect($this->{$this->getTableName()}['filters'] ?? [])
             ->filter(fn ($value, $key) => in_array($key, $validFilterKeys, true))

--- a/tests/Traits/Helpers/FilterHelpersTest.php
+++ b/tests/Traits/Helpers/FilterHelpersTest.php
@@ -115,6 +115,17 @@ class FilterHelpersTest extends TestCase
     }
 
     /** @test */
+    public function can_not_set_invalid_filter(): void
+    {
+        $this->basicTable->setFilter('invalid-filter', ['1']);
+
+        $this->assertNull($this->basicTable->getAppliedFilterWithValue('invalid-filter'));
+
+        $this->assertArrayNotHasKey('invalid-filter', $this->basicTable->getAppliedFilters());
+    }
+
+
+    /** @test */
     public function can_see_if_filters_set_with_values(): void
     {
         $this->assertFalse($this->basicTable->hasAppliedFiltersWithValues());

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -88,4 +88,13 @@ class FilterVisualsTest extends TestCase
         Livewire::test(PetsTable::class)
             ->assertDontSee('Applied Filters');
     }
+
+    /** @test */
+    public function filters_with_invalid_key_dont_error(): void
+    {
+        Livewire::test(PetsTable::class)
+            ->set('table.filters.invalid-filter', [1])
+            ->assertHasNoErrors()
+            ->assertDontSee('Applied Filters');
+    }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<hr>

The application throws an error when supplying an invalid filter key in the URL. The appropriate action would be to ignore the invalid filter key.

**Steps to reproduce**
1. You have a table
2. You supply an invalid filter. For example, it is possible to accomplish that by changing the filter key in the URL. An example: `http://localhost:8000/dashboard?table[filters][invalid-filter]=test`.
3. You now see an error.

**Errors it fixes**

1. `Rappasoft\LaravelLivewireTables\DataTableComponent::Rappasoft\LaravelLivewireTables\Traits\Helpers\{closure}():
Argument #1 ($filter) must be of type Rappasoft\LaravelLivewireTables\Views\Filter, null given, called in /..../src/Illuminate/Collections/Traits/EnumeratesValues.php on line 780`
2. `Error: Call to a member function isEmpty() on null: /..../src/Traits/ComponentUtilities.php:97`


I expect that the application does not accept invalid filters (filters not defined in filters()) and doesn't error on such input.

This PR fixes this behavior.