### PR TITLE
Bulk Actions Simple Pagination fix & typo in toolbar.blade.php

### DIFF
--- a/resources/views/components/table/tr/bulk-actions.blade.php
+++ b/resources/views/components/table/tr/bulk-actions.blade.php
@@ -8,6 +8,7 @@
         $colspan = $component->getColspanCount();
         $selected = $component->getSelectedCount();
         $selectAll = $component->selectAllIsEnabled();
+        $simplePagination = ($component->paginationMethod == "simple") ? true : false;
     @endphp
 
     @if ($theme === 'tailwind')
@@ -20,7 +21,7 @@
                     <div wire:key="all-selected-{{ $table }}">
                         <span>
                             @lang('You are currently selecting all')
-                            <strong>{{ number_format($rows->total()) }}</strong>
+                            @if(!$simplePagination) <strong>{{ number_format($rows->total()) }}</strong> @endif
                             @lang('rows').
                         </span>
 
@@ -39,7 +40,7 @@
                             @lang('You have selected')
                             <strong>{{ $selected }}</strong>
                             @lang('rows, do you want to select all')
-                            <strong>{{ number_format($rows->total()) }}</strong>?
+                            @if(!$simplePagination) <strong>{{ number_format($rows->total()) }}</strong> @endif
                         </span>
 
                         <button
@@ -72,7 +73,7 @@
                     <div wire:key="all-selected-{{ $table }}">
                         <span>
                             @lang('You are currently selecting all')
-                            <strong>{{ number_format($rows->total()) }}</strong>
+                            @if(!$simplePagination) <strong>{{ number_format($rows->total()) }}</strong> @endif
                             @lang('rows').
                         </span>
 
@@ -91,7 +92,7 @@
                             @lang('You have selected')
                             <strong>{{ $selected }}</strong>
                             @lang('rows, do you want to select all')
-                            <strong>{{ number_format($rows->total()) }}</strong>?
+                            @if(!$simplePagination) <strong>{{ number_format($rows->total()) }}</strong> @endif
                         </span>
 
                         <button

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -843,7 +843,7 @@
             @endif
 
             @if ($component->hasConfigurableAreaFor('toolbar-right-end'))
-                @include($component->getConfigurableAreaFor('toolbar-right-end'), $component->getParametersForConfigurableArea('toolbar-righ-end'))
+                @include($component->getConfigurableAreaFor('toolbar-right-end'), $component->getParametersForConfigurableArea('toolbar-right-end'))
             @endif
         </div>
     </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

Two blade fixes in this pull request:
1)  Presently, the Total Count will always try to render.  This fix prevents it from doing so when in SimplePagination made.  When in SimplePagination, the TotalCount is not avaialble, resulting in an exception being thrown.
The code changes simply exclude the display of the "total" to ensure that the exception isn't thrown.

2) There was a typo reported within toolbar.blade.php whereby toolbar-right-end is referenced as toolbar-righ-end for parameters, causing users to be unable to set thsese correctly.  Typo fixed.