### PR TITLE
Adding the capability  to add a "first option" (all) to a SelectFilter when generating options from a query/builder

### DIFF
--- a/docs/filters/creating-filters.md
+++ b/docs/filters/creating-filters.md
@@ -38,6 +38,28 @@ public function filters(): array
 
 You should supply the first option as the default value. I.e. nothing selected, so the filter is not applied. This value should be an empty string. When this value is selected, the filter will be removed from the query and the query string.
 
+When creating options from a Query or Builder function, you can use the setFirstOption() to set this.
+
+```php
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
+
+public function filters(): array
+{
+    return [
+        SelectFilter::make('Tags')
+            ->options(
+                Tag::query()
+                    ->orderBy('name')
+                    ->get()
+                    ->keyBy('id')
+                    ->map(fn($tag) => $tag->name)
+                    ->toArray()
+            )
+            ->setFirstOption('All Tags'),
+    ];
+}
+```
+
 ### Option Groups
 
 To use `<optgroup>` elements, pass a nested array of options to the select filter.
@@ -77,6 +99,29 @@ public function filters(): array
 {
     return [
         MultiSelectFilter::make('Tags')
+            ->options(
+                Tag::query()
+                    ->orderBy('name')
+                    ->get()
+                    ->keyBy('id')
+                    ->map(fn($tag) => $tag->name)
+                    ->toArray()
+            ),
+    ];
+}
+```
+
+## Multi-select dropdown Filters
+
+Multi-select dropdown filters are a simple dropdown list. The user can select multiple options from the list. There is also an 'All' option that will select all values.
+
+```php
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter;
+
+public function filters(): array
+{
+    return [
+        MultiSelectDropdownFilter::make('Tags')
             ->options(
                 Tag::query()
                     ->orderBy('name')

--- a/docs/filters/creating-filters.md
+++ b/docs/filters/creating-filters.md
@@ -111,29 +111,6 @@ public function filters(): array
 }
 ```
 
-## Multi-select dropdown Filters
-
-Multi-select dropdown filters are a simple dropdown list. The user can select multiple options from the list. There is also an 'All' option that will select all values.
-
-```php
-use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter;
-
-public function filters(): array
-{
-    return [
-        MultiSelectDropdownFilter::make('Tags')
-            ->options(
-                Tag::query()
-                    ->orderBy('name')
-                    ->get()
-                    ->keyBy('id')
-                    ->map(fn($tag) => $tag->name)
-                    ->toArray()
-            ),
-    ];
-}
-```
-
 ## Date Filters
 
 Date filters are HTML date elements.

--- a/resources/views/components/tools/filters/multi-select-dropdown.blade.php
+++ b/resources/views/components/tools/filters/multi-select-dropdown.blade.php
@@ -4,11 +4,11 @@
 
 @if ($theme === 'tailwind')
     <div class="rounded-md shadow-sm">
-        <select
+        <select multiple
             wire:model.stop="{{ $component->getTableName() }}.filters.{{ $filter->getKey() }}"
             wire:key="{{ $component->getTableName() }}-filter-{{ $filter->getKey() }}"
             id="{{ $component->getTableName() }}-filter-{{ $filter->getKey() }}"
-            class="block w-full border-gray-300 rounded-md shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-800 dark:text-white dark:border-gray-600"
+            class="block w-full transition duration-150 ease-in-out border-gray-300 rounded-md shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-800 dark:text-white dark:border-gray-600"
         >
             @if ($filter->getFirstOption() != "")
             <option value="">{{ $filter->getFirstOption()}}</option>
@@ -27,15 +27,16 @@
         </select>
     </div>
 @elseif ($theme === 'bootstrap-4' || $theme === 'bootstrap-5')
-    <select
+    <select multiple
         wire:model.stop="{{ $component->getTableName() }}.filters.{{ $filter->getKey() }}"
         wire:key="{{ $component->getTableName() }}-filter-{{ $filter->getKey() }}"
         id="{{ $component->getTableName() }}-filter-{{ $filter->getKey() }}"
         class="{{ $theme === 'bootstrap-4' ? 'form-control' : 'form-select' }}"
     >
-    @if ($filter->getFirstOption() != "")
-    <option value="">{{ $filter->getFirstOption()}}</option>
-    @endif
+        @if ($filter->getFirstOption() != "")
+        <option value="">{{ $filter->getFirstOption()}}</option>
+        @endif
+
         @foreach($filter->getOptions() as $key => $value)
             @if (is_iterable($value))
                 <optgroup label="{{ $key }}">

--- a/src/Views/Filters/MultiSelectDropdownFilter.php
+++ b/src/Views/Filters/MultiSelectDropdownFilter.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Views\Filters;
+
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Views\Filter;
+
+class MultiSelectDropdownFilter extends Filter
+{
+    protected array $options = [];
+    protected string $firstOption = "";
+
+    public function options(array $options = []): MultiSelectDropdownFilter
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+
+    public function setFirstOption(string $firstOption): SelectFilter
+    {
+        $this->firstOption = $firstOption;
+
+        return $this;
+    }
+
+    public function getFirstOption(): string
+    {
+        return $this->firstOption;
+    }
+
+    public function getKeys(): array
+    {
+        return collect($this->getOptions())
+            ->keys()
+            ->map(fn ($value) => (string)$value)
+            ->filter(fn ($value) => strlen($value))
+            ->values()
+            ->toArray();
+    }
+
+    public function validate($value)
+    {
+        if (is_array($value)) {
+            foreach ($value as $index => $val) {
+                // Remove the bad value
+                if (! in_array($val, $this->getKeys())) {
+                    unset($value[$index]);
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    public function getDefaultValue()
+    {
+        return [];
+    }
+
+    public function getFilterPillValue($value): ?string
+    {
+        $values = [];
+
+        foreach ($value as $item) {
+            $found = $this->getCustomFilterPillValue($item) ?? $this->getOptions()[$item] ?? null;
+
+            if ($found) {
+                $values[] = $found;
+            }
+        }
+
+        return implode(', ', $values);
+    }
+
+    public function isEmpty($value): bool
+    {
+        return ! is_array($value);
+    }
+
+    public function render(DataTableComponent $component)
+    {
+        return view('livewire-tables::components.tools.filters.multi-select-dropdown', [
+            'component' => $component,
+            'filter' => $this,
+        ]);
+    }
+}

--- a/src/Views/Filters/MultiSelectDropdownFilter.php
+++ b/src/Views/Filters/MultiSelectDropdownFilter.php
@@ -22,7 +22,6 @@ class MultiSelectDropdownFilter extends Filter
         return $this->options;
     }
 
-
     public function setFirstOption(string $firstOption): SelectFilter
     {
         $this->firstOption = $firstOption;

--- a/src/Views/Filters/SelectFilter.php
+++ b/src/Views/Filters/SelectFilter.php
@@ -9,11 +9,25 @@ class SelectFilter extends Filter
 {
     protected array $options = [];
 
+    protected string $firstOption = "";
+
     public function options(array $options = []): SelectFilter
     {
         $this->options = $options;
 
         return $this;
+    }
+
+    public function setFirstOption(string $firstOption): SelectFilter
+    {
+        $this->firstOption = $firstOption;
+
+        return $this;
+    }
+
+    public function getFirstOption(): string
+    {
+        return $this->firstOption;
     }
 
     public function getOptions(): array


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

Adding the capability for a SelectFilter to add a "first option" (all) when generating from a query/builder, for example:

```
public function filters(): array
{
    return [
        SelectFilter::make('Tags')
            ->options(
                Tag::query()
                    ->orderBy('name')
                    ->get()
                    ->keyBy('id')
                    ->map(fn($tag) => $tag->name)
                    ->toArray()
            )
            ->setFirstOption('All Tags'),
    ];
}
```