### PR TITLE
FilterSlideDown - Ability to set Default to Open or Closed

### DIFF
--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -172,7 +172,7 @@ public function configure(): void
 
 ### setFilterSlideDownDefaultStatusDisabled
 
-Set the filter slide down to invisible by default
+Set the filter slide down to collapsed by default
 
 ```php
 public function configure(): void

--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -158,6 +158,31 @@ public function configure(): void
 }
 ```
 
+### setFilterSlideDownDefaultStatusEnabled
+
+Set the filter slide down to visible by default
+
+```php
+public function configure(): void
+{
+    // Shorthand for $this->setFilterSlideDownDefaultStatus(true)
+    $this->setFilterSlideDownDefaultStatusEnabled();
+}
+```
+
+### setFilterSlideDownDefaultStatusDisabled
+
+Set the filter slide down to invisible by default
+
+```php
+public function configure(): void
+{
+    // Shorthand for $this->setFilterSlideDownDefaultStatus(false)
+    $this->setFilterSlideDownDefaultStatusDisabled();
+}
+```
+
+
 ----
 
 ## Filter Methods

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -13,7 +13,7 @@
     @endif
 
     @if ($component->isFilterLayoutSlideDown())
-        x-data="{ filtersOpen: false }"
+        wire:ignore.self x-data="{ filtersOpen: $wire.filterSlideDownDefaultVisible }"
     @endif
 >
      @include('livewire-tables::includes.debug')

--- a/src/Traits/Configuration/FilterConfiguration.php
+++ b/src/Traits/Configuration/FilterConfiguration.php
@@ -137,4 +137,36 @@ trait FilterConfiguration
 
         return $this;
     }
+
+    /**
+     * @param  bool $status
+     *
+     * @return $this
+     */
+    public function setFilterSlideDownDefaultStatus(bool $status): self
+    {
+        $this->filterSlideDownDefaultVisible = $status;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setFilterSlideDownDefaultStatusDisabled(): self
+    {
+        $this->setFilterSlideDownDefaultStatus(false);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setFilterSlideDownDefaultStatusEnabled(): self
+    {
+        $this->setFilterSlideDownDefaultStatus(true);
+
+        return $this;
+    }
 }

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -38,6 +38,21 @@ trait FilterHelpers
         return $this->getFiltersVisibilityStatus() === false;
     }
 
+    public function getFilterSlideDownDefaultStatus(): bool
+    {
+        return $this->filterSlideDownDefaultVisible;
+    }
+
+    public function filtersSlideDownIsDefaultVisible(): bool
+    {
+        return $this->getFilterSlideDownDefaultStatus() === true;
+    }
+
+    public function filtersSlideDownIsDefaultHidden(): bool
+    {
+        return $this->getFilterSlideDownDefaultStatus() === false;
+    }
+
     public function getFilterPillsStatus(): bool
     {
         return $this->filterPillsStatus;
@@ -175,7 +190,7 @@ trait FilterHelpers
         if (! $filter instanceof Filter) {
             $filter = $this->getFilterByKey($filter);
         }
-        
+
         $this->setFilter($filter->getKey(), $filter->getDefaultValue());
     }
 

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -14,6 +14,7 @@ trait WithFilters
     public bool $filtersStatus = true;
     public bool $filtersVisibilityStatus = true;
     public bool $filterPillsStatus = true;
+    public bool $filterSlideDownDefaultVisible = false;
     public string $filterLayout = 'popover';
 
     public function filters(): array

--- a/tests/Traits/Configuration/FilterConfigurationTest.php
+++ b/tests/Traits/Configuration/FilterConfigurationTest.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Configuration;
 
-use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 
 class FilterConfigurationTest extends TestCase
 {
@@ -99,5 +99,27 @@ class FilterConfigurationTest extends TestCase
         $this->basicTable->setFilterLayoutPopover();
 
         $this->basicTable->setFilterLayout('popover');
+    }
+
+    /** @test */
+    public function filters_layout_popover_default_can_be_set(): void
+    {
+        $this->assertFalse($this->basicTable->filterSlideDownDefaultVisible);
+
+        $this->basicTable->setFilterSlideDownDefaultStatusEnabled();
+
+        $this->assertTrue($this->basicTable->filterSlideDownDefaultVisible);
+
+        $this->basicTable->setFilterSlideDownDefaultStatusDisabled();
+
+        $this->assertFalse($this->basicTable->filterSlideDownDefaultVisible);
+
+        $this->basicTable->setFilterSlideDownDefaultStatus(true);
+
+        $this->assertTrue($this->basicTable->filterSlideDownDefaultVisible);
+
+        $this->basicTable->setFilterSlideDownDefaultStatus(false);
+
+        $this->assertFalse($this->basicTable->filterSlideDownDefaultVisible);
     }
 }

--- a/tests/Traits/Configuration/FilterConfigurationTest.php
+++ b/tests/Traits/Configuration/FilterConfigurationTest.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Configuration;
 
-use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 class FilterConfigurationTest extends TestCase
 {

--- a/tests/Traits/Helpers/FilterHelpersTest.php
+++ b/tests/Traits/Helpers/FilterHelpersTest.php
@@ -167,4 +167,24 @@ class FilterHelpersTest extends TestCase
 
         $this->assertTrue($this->basicTable->isFilterLayoutSlideDown());
     }
+
+    /** @test */
+    public function can_check_if_filter_layout_slidedown_is_visible(): void
+    {
+        $this->assertFalse($this->basicTable->getFilterSlideDownDefaultStatus());
+
+        $this->basicTable->setFilterSlideDownDefaultStatusEnabled();
+
+        $this->assertTrue($this->basicTable->getFilterSlideDownDefaultStatus());
+    }
+
+    /** @test */
+    public function can_check_if_filter_layout_slidedown_is_hidden(): void
+    {
+        $this->assertFalse($this->basicTable->getFilterSlideDownDefaultStatus());
+
+        $this->basicTable->setFilterSlideDownDefaultStatusDisabled();
+
+        $this->assertFalse($this->basicTable->getFilterSlideDownDefaultStatus());
+    }
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?


Changes relate to the SlideDown filter layout

Default value is set to false in WIthFilters, and will show it as closed
```
public bool $filterSlideDownDefaultVisible = false
```

Two configuration options added for the configure() function

```
    // Shorthand for $this->setFilterSlideDownDefaultStatus(true)
    $this->setFilterSlideDownDefaultStatusEnabled();
```    

```
// Shorthand for $this->setFilterSlideDownDefaultStatus(false)
    $this->setFilterSlideDownDefaultStatusDisabled();
```
```
  public function setFilterSlideDownDefaultStatus(bool $status): self
  {
      $this->filterSlideDownDefaultVisible = $status;

      return $this;
  }
```

### WithFilters
```
// Adding filter for use in wireable
public bool $filterSlideDownDefaultVisible = false;
```

##  views/components)/wrapper.blade.php

Adjusted for filterOpen reflecting wire value
```
    @if ($component->isFilterLayoutSlideDown())
        wire:ignore.self x-data="{ filtersOpen: $wire.filterSlideDownDefaultVisible }"
    @endif
```

Relevant tests & Helper Functions created within FilterConfigurationTest and FilterHelpersTest

These set the initial value of the "filtersOpen" using ALpine:
```
wire:ignore.self x-data="{ filtersOpen: $wire.filterSlideDownDefaultVisible }"
```

As the initial value is set only, it will not reset to default upon refresh.