### PR TITLE
Default value for select when options() are driven from an query/collection.

### DIFF
--- a/docs/filters/creating-filters.md
+++ b/docs/filters/creating-filters.md
@@ -38,6 +38,27 @@ public function filters(): array
 
 You should supply the first option as the default value. I.e. nothing selected, so the filter is not applied. This value should be an empty string. When this value is selected, the filter will be removed from the query and the query string.
 
+When creating options from a Query or Builder function, you can alternatively use the setFirstOption() below to set this first value instead of having to merge arrays.
+
+```php
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
+
+public function filters(): array
+{
+    return [
+        SelectFilter::make('Tags')
+            ->options(
+                Tag::query()
+                    ->orderBy('name')
+                    ->get()
+                    ->keyBy('id')
+                    ->map(fn($tag) => $tag->name)
+                    ->toArray()
+            )
+            ->setFirstOption('All Tags'),
+    ];
+}
+```
 ### Option Groups
 
 To use `<optgroup>` elements, pass a nested array of options to the select filter.

--- a/src/Views/Filters/MultiSelectFilter.php
+++ b/src/Views/Filters/MultiSelectFilter.php
@@ -34,7 +34,6 @@ class MultiSelectFilter extends Filter
         return $this->firstOption;
     }
 
-
     public function getKeys(): array
     {
         return collect($this->getOptions())

--- a/src/Views/Filters/MultiSelectFilter.php
+++ b/src/Views/Filters/MultiSelectFilter.php
@@ -8,6 +8,7 @@ use Rappasoft\LaravelLivewireTables\Views\Filter;
 class MultiSelectFilter extends Filter
 {
     protected array $options = [];
+    protected string $firstOption = "";
 
     public function options(array $options = []): MultiSelectFilter
     {
@@ -20,6 +21,19 @@ class MultiSelectFilter extends Filter
     {
         return $this->options;
     }
+
+    public function setFirstOption(string $firstOption)
+    {
+        $this->firstOption = $firstOption;
+
+        return $this;
+    }
+
+    public function getFirstOption(): string
+    {
+        return $this->firstOption;
+    }
+
 
     public function getKeys(): array
     {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

The basic premise of this is for when users are generating the content of filters using builder/query.  The limitation of this is that there is no "all" function.  This feature allows them to set a "top-of-list" item (i.e. SELECT ALL), which will set to "all" and remove the filter from being applied.