### PR TITLE
Column select hidden on tablet or mobile

### DIFF
--- a/docs/columns/column-selection.md
+++ b/docs/columns/column-selection.md
@@ -63,12 +63,11 @@ public function configure(): void
 
 ### setColumnSelectHiddenOnTablet
 
-Hide column select menu when on tablet or mobile.
+Hide column select menu when on tablet
 
 ```php
 public function configure(): void
 {
-    // Shorthand for $this->setColumnSelectStatus(false)
     $this->setColumnSelectHiddenOnTablet();
 }
 ```
@@ -80,7 +79,6 @@ Hide column select menu when on mobile.
 ```php
 public function configure(): void
 {
-    // Shorthand for $this->setColumnSelectStatus(false)
     $this->setColumnSelectHiddenOnMobile();
 }
 ```

--- a/docs/columns/column-selection.md
+++ b/docs/columns/column-selection.md
@@ -61,6 +61,31 @@ public function configure(): void
 }
 ```
 
+### setColumnSelectHiddenOnTablet
+
+Hide column select menu when on tablet or mobile.
+
+```php
+public function configure(): void
+{
+    // Shorthand for $this->setColumnSelectStatus(false)
+    $this->setColumnSelectHiddenOnTablet();
+}
+```
+
+### setColumnSelectHiddenOnMobile
+
+Hide column select menu when on mobile.
+
+```php
+public function configure(): void
+{
+    // Shorthand for $this->setColumnSelectStatus(false)
+    $this->setColumnSelectHiddenOnMobile();
+}
+```
+
+
 ### setRememberColumnSelectionStatus
 
 **Enabled by default**, whether or not to remember the users column select choices.

--- a/docs/columns/column-selection.md
+++ b/docs/columns/column-selection.md
@@ -63,7 +63,7 @@ public function configure(): void
 
 ### setColumnSelectHiddenOnTablet
 
-Hide column select menu when on tablet
+Hide column select menu when on tablet or mobile
 
 ```php
 public function configure(): void

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -206,7 +206,7 @@
             @endif
 
             @if ($component->columnSelectIsEnabled())
-                <div class="mb-4 w-full md:w-auto md:mb-0 md:ml-2">
+                <div class="@if ($component->getColumnSelectIsHiddenOnMobile()) hidden md:block @elseif ($component->getColumnSelectIsHiddenOnTablet()) hidden lg:block @endif mb-4 w-full md:w-auto md:mb-0 md:ml-2">
                     <div
                         x-data="{ open: false }"
                         @keydown.window.escape="open = false"

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -494,7 +494,7 @@
             @endif
 
             @if ($component->columnSelectIsEnabled())
-                <div class="mb-3 mb-md-0 pl-0 pl-md-2">
+                <div class="@if ($component->getColumnSelectIsHiddenOnMobile()) hidden sm:block @elseif ($component->getColumnSelectIsHiddenOnTablet()) hidden md:block @endif mb-3 mb-md-0 pl-0 pl-md-2">
                     <div
                         x-data="{ open: false }"
                         x-on:keydown.escape.stop="open = false"

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -206,7 +206,7 @@
             @endif
 
             @if ($component->columnSelectIsEnabled())
-                <div class="@if ($component->getColumnSelectIsHiddenOnMobile()) hidden md:block @elseif ($component->getColumnSelectIsHiddenOnTablet()) hidden lg:block @endif mb-4 w-full md:w-auto md:mb-0 md:ml-2">
+                <div class="@if ($component->getColumnSelectIsHiddenOnMobile()) hidden sm:block @elseif ($component->getColumnSelectIsHiddenOnTablet()) hidden md:block @endif mb-4 w-full md:w-auto md:mb-0 md:ml-2">
                     <div
                         x-data="{ open: false }"
                         @keydown.window.escape="open = false"

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -85,6 +85,7 @@ trait ColumnSelectHelpers
         return $this->getDataTableFingerprint().'-columnSelectEnabled';
     }
 
+
     /**
      * @return $this
      */
@@ -95,9 +96,9 @@ trait ColumnSelectHelpers
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    protected function getColumnSelectIsHiddenOnTablet()
+    protected function getColumnSelectIsHiddenOnTablet(): bool
     {
         return $this->columnSelectHiddenOnTablet;
     }
@@ -113,9 +114,9 @@ trait ColumnSelectHelpers
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    protected function getColumnSelectIsHiddenOnMobile()
+    protected function getColumnSelectIsHiddenOnMobile(): bool
     {
         return $this->columnSelectHiddenOnMobile;
     }

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -85,7 +85,6 @@ trait ColumnSelectHelpers
         return $this->getDataTableFingerprint().'-columnSelectEnabled';
     }
 
-
     /**
      * @return $this
      */
@@ -110,8 +109,8 @@ trait ColumnSelectHelpers
     public function setColumnSelectHiddenOnTablet(): self
     {
         $this->columnSelectHiddenOnTablet = true;
-        return $this;
 
+        return $this;
     }
 
     /**

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -84,4 +84,39 @@ trait ColumnSelectHelpers
     {
         return $this->getDataTableFingerprint().'-columnSelectEnabled';
     }
+
+    /**
+     * @return $this
+     */
+    public function setColumnSelectHiddenOnMobile(): self
+    {
+        $this->columnSelectHiddenOnMobile = true;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getColumnSelectIsHiddenOnTablet()
+    {
+        return $this->columnSelectHiddenOnTablet;
+    }
+
+     /**
+     * @return $this
+     */
+    public function setColumnSelectHiddenOnTablet(): self
+    {
+        $this->columnSelectHiddenOnTablet = true;
+        return $this;
+
+    }
+
+    /**
+     * @return string
+     */
+    protected function getColumnSelectIsHiddenOnMobile()
+    {
+        return $this->columnSelectHiddenOnMobile;
+    }
 }

--- a/src/Traits/Helpers/ColumnSelectHelpers.php
+++ b/src/Traits/Helpers/ColumnSelectHelpers.php
@@ -92,13 +92,14 @@ trait ColumnSelectHelpers
     public function setColumnSelectHiddenOnMobile(): self
     {
         $this->columnSelectHiddenOnMobile = true;
+
         return $this;
     }
 
     /**
      * @return bool
      */
-    protected function getColumnSelectIsHiddenOnTablet(): bool
+    public function getColumnSelectIsHiddenOnTablet(): bool
     {
         return $this->columnSelectHiddenOnTablet;
     }
@@ -116,7 +117,7 @@ trait ColumnSelectHelpers
     /**
      * @return bool
      */
-    protected function getColumnSelectIsHiddenOnMobile(): bool
+    public function getColumnSelectIsHiddenOnMobile(): bool
     {
         return $this->columnSelectHiddenOnMobile;
     }

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -13,6 +13,8 @@ trait WithColumnSelect
     public array $selectedColumns = [];
     protected bool $columnSelectStatus = true;
     protected bool $rememberColumnSelectionStatus = true;
+    protected bool $columnSelectHiddenOnMobile = false;
+    protected bool $columnSelectHiddenOnTablet = false;
 
     public function setupColumnSelect(): void
     {

--- a/tests/Traits/Configuration/ColumnSelectConfigurationTest.php
+++ b/tests/Traits/Configuration/ColumnSelectConfigurationTest.php
@@ -49,4 +49,25 @@ class ColumnSelectConfigurationTest extends TestCase
 
         $this->assertTrue($this->basicTable->getRememberColumnSelectionStatus());
     }
+
+
+    /** @test */
+    public function can_set_column_select_hidden_on_mobile_status(): void
+    {
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnMobile());
+
+        $this->basicTable->setColumnSelectHiddenOnMobile();
+
+        $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnMobile());
+    }
+
+    /** @test */
+    public function can_set_column_select_hidden_on_tablet_status(): void
+    {
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnTablet());
+
+        $this->basicTable->setColumnSelectHiddenOnTablet();
+
+        $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnTablet());
+    }
 }

--- a/tests/Traits/Configuration/ColumnSelectConfigurationTest.php
+++ b/tests/Traits/Configuration/ColumnSelectConfigurationTest.php
@@ -49,6 +49,4 @@ class ColumnSelectConfigurationTest extends TestCase
 
         $this->assertTrue($this->basicTable->getRememberColumnSelectionStatus());
     }
-
-
 }

--- a/tests/Traits/Configuration/ColumnSelectConfigurationTest.php
+++ b/tests/Traits/Configuration/ColumnSelectConfigurationTest.php
@@ -51,23 +51,4 @@ class ColumnSelectConfigurationTest extends TestCase
     }
 
 
-    /** @test */
-    public function can_set_column_select_hidden_on_mobile_status(): void
-    {
-        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnMobile());
-
-        $this->basicTable->setColumnSelectHiddenOnMobile();
-
-        $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnMobile());
-    }
-
-    /** @test */
-    public function can_set_column_select_hidden_on_tablet_status(): void
-    {
-        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnTablet());
-
-        $this->basicTable->setColumnSelectHiddenOnTablet();
-
-        $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnTablet());
-    }
 }

--- a/tests/Traits/Helpers/ColumnSelectHelpersTest.php
+++ b/tests/Traits/Helpers/ColumnSelectHelpersTest.php
@@ -34,7 +34,6 @@ class ColumnSelectHelpersTest extends TestCase
         $this->assertTrue($this->basicTable->rememberColumnSelectionIsEnabled());
     }
 
-
     /** @test */
     public function can_set_column_select_hidden_on_mobile_status(): void
     {
@@ -47,7 +46,6 @@ class ColumnSelectHelpersTest extends TestCase
         $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnMobile());
 
         $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnTablet());
-
     }
 
     /** @test */
@@ -62,7 +60,5 @@ class ColumnSelectHelpersTest extends TestCase
         $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnMobile());
 
         $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnTablet());
-
-
     }
 }

--- a/tests/Traits/Helpers/ColumnSelectHelpersTest.php
+++ b/tests/Traits/Helpers/ColumnSelectHelpersTest.php
@@ -33,4 +33,36 @@ class ColumnSelectHelpersTest extends TestCase
 
         $this->assertTrue($this->basicTable->rememberColumnSelectionIsEnabled());
     }
+
+
+    /** @test */
+    public function can_set_column_select_hidden_on_mobile_status(): void
+    {
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnMobile());
+
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnTablet());
+
+        $this->basicTable->setColumnSelectHiddenOnMobile();
+
+        $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnMobile());
+
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnTablet());
+
+    }
+
+    /** @test */
+    public function can_set_column_select_hidden_on_tablet_status(): void
+    {
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnMobile());
+
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnTablet());
+
+        $this->basicTable->setColumnSelectHiddenOnTablet();
+
+        $this->assertFalse($this->basicTable->getColumnSelectIsHiddenOnMobile());
+
+        $this->assertTrue($this->basicTable->getColumnSelectIsHiddenOnTablet());
+
+
+    }
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

Per updated documentation, adds two new functions to set when the Column Select Dropdown is hidden (Tablet or Mobile), defaults to always visible.

### setColumnSelectHiddenOnTablet

Hide column select menu when on tablet or mobile

```php
public function configure(): void
{
    $this->setColumnSelectHiddenOnTablet();
}
```

### setColumnSelectHiddenOnMobile

Hide column select menu when on mobile.

```php
public function configure(): void
{
    $this->setColumnSelectHiddenOnMobile();
}
```