### PR TITLE
Custom view prepend

### DIFF
--- a/docs/misc/custom-markup.md
+++ b/docs/misc/custom-markup.md
@@ -13,3 +13,14 @@ public function customView(): string
     return 'includes.custom';
 }
 ```
+
+If you would like to append any custom markup right before the start of the component, you may use the `customViewPrepend` method and return a view.
+
+This is good for loading extra content such as dismissible alerts or flash notifications.
+
+```php
+public function customViewPrepend(): string
+{
+    return 'includes.custom';
+}
+```

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -1,4 +1,7 @@
 <x-livewire-tables::wrapper :component="$this">
+    @isset($customViewPrepend)
+        @include($customViewPrepend)
+    @endisset
     <x-livewire-tables::tools>
         <x-livewire-tables::tools.sorting-pills />
         <x-livewire-tables::tools.filter-pills />

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -68,7 +68,7 @@ abstract class DataTableComponent extends Component
             'filters' => $this->{$this->tableName}['filters'] ?? [],
             'columns' => $this->{$this->tableName}['columns'] ?? [],
         ];
-        
+
         // Set the filter defaults based on the filter type
         $this->setFilterDefaults();
     }
@@ -122,7 +122,18 @@ abstract class DataTableComponent extends Component
     {
         return 'livewire-tables::stubs.custom';
     }
-    
+
+
+    /**
+     * The view to add any html before the table
+     *
+     * @return string
+     */
+    public function customViewPrepend(): string
+    {
+        return 'livewire-tables::stubs.custom-prepend';
+    }
+
     /**
      * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
      */
@@ -139,6 +150,7 @@ abstract class DataTableComponent extends Component
                 'columns' => $this->getColumns(),
                 'rows' => $this->getRows(),
                 'customView' => $this->customView(),
+                'customViewPrepend' => $this->customViewPrepend(),
             ]);
     }
 }


### PR DESCRIPTION
The currently existing `customView` is only suitable for modals and things at the bottom of the page. I really needed something like this as well so that I can do what I have shown in the video comment I added below. 

I would propose renaming `customView` to `customViewAppend` but not worth breaking changes obviously. 

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
