### PR TITLE
New configurable area 'before-tools', to be able to place above also the pills

### DIFF
--- a/docs/datatable/configurable-areas.md
+++ b/docs/datatable/configurable-areas.md
@@ -15,6 +15,7 @@ You can use the `setConfigurableAreas` method to set the areas that you want to 
 public function configure(): void
 {
   $this->setConfigurableAreas([
+    'before-tools' => 'path.to.my.view',
     'toolbar-left-start' => 'path.to.my.view',
     'toolbar-left-end' => 'path.to.my.view',
     'toolbar-right-start' => 'path.to.my.view',

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -5,10 +5,6 @@
     $theme = $component->getTheme();
 @endphp
 
-@if ($component->hasConfigurableAreaFor('before-tools'))
-    @include($component->getConfigurableAreaFor('before-tools'), $component->getParametersForConfigurableArea('before-tools'))
-@endif
-
  <div
     {{ $attributes->merge($this->getComponentWrapperAttributes()) }}
 

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -5,6 +5,10 @@
     $theme = $component->getTheme();
 @endphp
 
+@if ($component->hasConfigurableAreaFor('before-tools'))
+    @include($component->getConfigurableAreaFor('before-tools'), $component->getParametersForConfigurableArea('before-tools'))
+@endif
+
  <div
     {{ $attributes->merge($this->getComponentWrapperAttributes()) }}
 

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -1,4 +1,9 @@
 <x-livewire-tables::wrapper :component="$this">
+
+    @if ($component->hasConfigurableAreaFor('before-tools'))
+        @include($component->getConfigurableAreaFor('before-tools'), $component->getParametersForConfigurableArea('before-tools'))
+    @endif
+
     <x-livewire-tables::tools>
         <x-livewire-tables::tools.sorting-pills />
         <x-livewire-tables::tools.filter-pills />

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -1,7 +1,7 @@
 <x-livewire-tables::wrapper :component="$this">
 
-    @if ($component->hasConfigurableAreaFor('before-tools'))
-        @include($component->getConfigurableAreaFor('before-tools'), $component->getParametersForConfigurableArea('before-tools'))
+    @if ($this->hasConfigurableAreaFor('before-tools'))
+        @include($this->getConfigurableAreaFor('before-tools'), $this->getParametersForConfigurableArea('before-tools'))
     @endif
 
     <x-livewire-tables::tools>

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -37,6 +37,7 @@ trait ComponentUtilities
     protected array $additionalSelects = [];
     protected bool $hideConfigurableAreasWhenReorderingStatus = true;
     protected array $configurableAreas = [
+        'before-tools' => null,
         'toolbar-left-start' => null,
         'toolbar-left-end' => null,
         'toolbar-right-start' => null,

--- a/tests/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Traits/Helpers/ComponentHelpersTest.php
@@ -167,6 +167,7 @@ class ComponentHelpersTest extends TestCase
     public function can_get_configurable_areas(): void
     {
         $this->assertEquals([
+            'before-tools' => null,
             'toolbar-left-start' => null,
             'toolbar-left-end' => null,
             'toolbar-right-start' => null,


### PR DESCRIPTION
Adds a configurable `before-tools` section, to be able to be at the very tip-top even above filter/sort pills. 

Example video attached. 

https://user-images.githubusercontent.com/1260938/216110230-7dc01648-95a3-4c75-a35c-6b82a3618331.mov


Related to a previous PR attempting the same thing in a different way: https://github.com/rappasoft/laravel-livewire-tables/pull/1036


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
