### PR TITLE
Implemented ability to hide toolbar and entire data table when empty

### DIFF
--- a/resources/views/components/tools.blade.php
+++ b/resources/views/components/tools.blade.php
@@ -5,11 +5,11 @@
 @endphp
 
 @if ($theme === 'tailwind')
-    <div class="flex-col">
+    <div class="flex-col tools">
         {{ $slot }}
     </div>
 @elseif ($theme === 'bootstrap-4' || $theme === 'bootstrap-5')
-    <div class="d-flex flex-column">
+    <div class="d-flex flex-column tools">
         {{ $slot }}
     </div>
 @endif

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -1,13 +1,19 @@
+@if (!$this->getHideOnEmptyStatus() || ($this->getHideOnEmptyStatus() && !empty($rows)))
+@isset($beforeComponentView)
+    @include($beforeComponentView)
+@endisset
 <x-livewire-tables::wrapper :component="$this">
     @if ($this->hasConfigurableAreaFor('before-tools'))
         @include($this->getConfigurableAreaFor('before-tools'), $this->getParametersForConfigurableArea('before-tools'))
     @endif
 
+    @if ($this->getToolbarStatusIsEnabled())
     <x-livewire-tables::tools>
         <x-livewire-tables::tools.sorting-pills />
         <x-livewire-tables::tools.filter-pills />
         <x-livewire-tables::tools.toolbar />
     </x-livewire-tables::tools>
+    @endif
 
     <x-livewire-tables::table>
         <x-slot name="thead">
@@ -69,3 +75,4 @@
         @include($customView)
     @endisset
 </x-livewire-tables::wrapper>
+@endif

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -122,6 +122,16 @@ abstract class DataTableComponent extends Component
     {
         return 'livewire-tables::stubs.custom';
     }
+
+    /**
+     * The view to add any modals for the table, could also be used for any non-visible html
+     *
+     * @return string
+     */
+    public function beforeComponentView(): string
+    {
+        return 'livewire-tables::stubs.before';
+    }
     
     /**
      * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
@@ -139,6 +149,7 @@ abstract class DataTableComponent extends Component
                 'columns' => $this->getColumns(),
                 'rows' => $this->getRows(),
                 'customView' => $this->customView(),
+                'before' => $this->beforeComponentView(),
             ]);
     }
 }

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -36,6 +36,8 @@ trait ComponentUtilities
     protected string $emptyMessage = 'No items found. Try to broaden your search.';
     protected array $additionalSelects = [];
     protected bool $hideConfigurableAreasWhenReorderingStatus = true;
+    protected bool $toolbarStatus = true;
+    protected bool $hideOnEmptyStatus = false;
     protected array $configurableAreas = [
         'before-tools' => null,
         'toolbar-left-start' => null,

--- a/src/Traits/Configuration/ComponentConfiguration.php
+++ b/src/Traits/Configuration/ComponentConfiguration.php
@@ -369,4 +369,60 @@ trait ComponentConfiguration
 
         return $this;
     }
+
+    /**
+     * @param $status
+     * 
+     * @return $this
+     */
+    public function setToolbarStatus(bool $status): self
+    {
+        $this->toolbarStatus = $status;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setToolbarDisabled(): self
+    {
+        return $this->setToolbarStatus(false);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setToolbarEnabled(): self
+    {
+        return $this->setToolbarStatus(true);
+    }
+
+    /**
+     * @param $status
+     * 
+     * @return $this
+     */
+    public function setHideOnEmptyStatus(bool $status): self
+    {
+        $this->hideOnEmptyStatus = $status;
+        
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHideOnEmptyDisabled(): self
+    {
+        return $this->setHideOnEmptyStatus(false);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHideOnEmptyEnabled(): self
+    {
+        return $this->setHideOnEmptyStatus(true);
+    }
 }

--- a/src/Traits/Helpers/ComponentHelpers.php
+++ b/src/Traits/Helpers/ComponentHelpers.php
@@ -426,4 +426,52 @@ trait ComponentHelpers
     {
         return $this->getHideConfigurableAreasWhenReorderingStatus() === false;
     }
+
+    /**
+     * @return bool
+     */
+    public function getToolbarStatus(): bool
+    {
+        return $this->toolbarStatus;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getToolbarStatusIsEnabled(): bool
+    {
+        return $this->getToolbarStatus() === true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getToolbarStatusIsDisabled(): bool
+    {
+        return $this->getToolbarStatus() === false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHideOnEmptyStatus(): bool
+    {
+        return $this->hideOnEmptyStatus;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHideOnEmptyStatusIsEnabled(): bool
+    {
+        return $this->getHideOnEmptyStatus() === true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHideOnEmptyStatusIsDisabled(): bool
+    {
+        return $this->getHideOnEmptyStatus() === false;
+    }
 }

--- a/tests/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Traits/Helpers/ComponentHelpersTest.php
@@ -238,4 +238,40 @@ class ComponentHelpersTest extends TestCase
     {
         $this->assertSame($this->basicTable->getTableName(), $this->basicTable->getQueryStringAlias());
     }
+
+    /** @test */
+    public function can_get_toolbar_status(): void
+    {
+        $this->assertTrue($this->basicTable->getToolbarStatus());
+        
+        $this->basicTable->setToolbarDisabled();
+        
+        $this->assertSame(false, $this->basicTable->getToolbarStatus());
+        
+        $this->basicTable->setToolbarEnabled();
+
+        $this->assertTrue($this->basicTable->getToolbarStatus());
+
+        $bool = boolval(mt_rand(0,1));
+
+        $this->basicTable->setToolbarStatus($bool);
+
+        $this->assertSame($bool, $this->basicTable->getToolbarStatus());
+    }
+
+    /** @test */
+    public function can_get_hide_on_empty_status(): void
+    {
+        $this->assertFalse($this->basicTable->getHideOnEmptyStatus());
+        
+        $this->basicTable->setHideOnEmptyEnabled();
+        
+        $this->assertSame(true, $this->basicTable->getHideOnEmptyStatus());
+
+        $bool = boolval(mt_rand(0,1));
+
+        $this->basicTable->setHideOnEmptyStatus($bool);
+
+        $this->assertSame($bool, $this->basicTable->getHideOnEmptyStatus());
+    }
 }

--- a/tests/Traits/Visuals/ComponentVisualsTest.php
+++ b/tests/Traits/Visuals/ComponentVisualsTest.php
@@ -24,6 +24,23 @@ class ComponentVisualsTest extends TestCase
     }
 
     /** @test */
+    public function disable_when_hide_on_empty_enabled_with_no_results(): void
+    {
+        Livewire::test(PetsTable::class)
+            ->call('setHideOnEmptyEnabled')
+            ->set('table.search', 'sdfsdfsdf')
+            ->assertDontSeeText('datatable');
+    }
+
+    /** @test */
+    public function visible_when_hide_on_empty_enabled_with_results(): void
+    {
+        Livewire::test(PetsTable::class)
+            ->call('setHideOnEmptyEnabled')
+            ->assertSee('Cartman');
+    }
+
+    /** @test */
     public function debugging_shows_when_enabled(): void
     {
         Livewire::test(PetsTable::class)

--- a/tests/Traits/Visuals/ToolbarVisualsTest.php
+++ b/tests/Traits/Visuals/ToolbarVisualsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Visuals;
+
+use Livewire\Livewire;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableNoFilters;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+class ToolbarVisualsTest extends TestCase
+{
+    /** @test */
+    public function toolbar_shows_when_enabled(): void
+    {
+        Livewire::test(PetsTable::class)
+            ->assertSee('flex-col tools');
+    }
+
+    /** @test */
+    public function toolbar_doesnt_show_when_disabled(): void
+    {
+        Livewire::test(PetsTable::class)
+            ->call('setToolbarDisabled')
+            ->assertDontSee('flex-col tools');
+    }
+}


### PR DESCRIPTION
For purposes of DRY, I am using the same data table component in multiple areas of the site, some of which don't need the toolbar etc (disabling individual components hides them but still keeps the wrappers) and some don't need to appear at all if there are no results to show. 

In addition to this, I also added the ability to include a custom view before the data table, so you can add things like titles, that if combined with hiding when empty, shouldn't show either.

Happy to make as many changes as needed to make it acceptable.

---

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
