### PR TITLE
Filters - FIX - Restrict AppliedFilters to only return non-empty

### DIFF
--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -136,7 +136,7 @@ trait FilterHelpers
             ->toArray();
 
         return collect($this->{$this->getTableName()}['filters'] ?? [])
-            ->filter(fn ($value, $key) => (in_array($key, $validFilterKeys, true) && ! $this->getFilterByKey($key)->isEmpty($value)))
+            ->filter(fn ($value, $key) => in_array($key, $validFilterKeys, true))
             ->toArray();
     }
 
@@ -171,9 +171,9 @@ trait FilterHelpers
 
     public function getAppliedFiltersWithValues(): array
     {
-        return array_filter($this->getAppliedFilters(), function ($item) {
-            return is_array($item) ? count($item) : $item !== null;
-        });
+        return array_filter($this->getAppliedFilters(), function ($item, $key) {
+            return ! $this->getFilterByKey($key)->isEmpty($item) && (is_array($item) ? count($item) : $item !== null);
+        }, ARRAY_FILTER_USE_BOTH);
     }
 
     public function getAppliedFilterWithValue(string $filterKey)

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -136,7 +136,7 @@ trait FilterHelpers
             ->toArray();
 
         return collect($this->{$this->getTableName()}['filters'] ?? [])
-            ->filter(fn ($value, $key) => in_array($key, $validFilterKeys, true))
+            ->filter(fn ($value, $key) => (in_array($key, $validFilterKeys, true) && ! $this->getFilterByKey($key)->isEmpty($value)))
             ->toArray();
     }
 


### PR DESCRIPTION
At the moment, a filter will be considered "applied" if it has any value, including the default value.  This causes the Pills to appear with a blank value.  To avoid this, I've added an additional check for "isEmpty" in the getAppliedFiltersWithValues.

I am somewhat in two minds on this, but figured that using the filter Defaults for anything other than setting up the array keys (i.e. array with keys, but no values) shouldn't really be done, especially as you can apply filter values at component boot with:
```php
    $this->setFilter('created_after', date('Y-m-d', strtotime('now -1 month')));
```
Tested against the Demo instance.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
