### PR TITLE
ON HOLD - Core - New Functionality - Add setAdditionalSelectRaws

### DIFF
--- a/docs/datatable/available-methods.md
+++ b/docs/datatable/available-methods.md
@@ -408,6 +408,37 @@ public function configure(): void
 
 Since you probably won't have an `ID` column defined, the ID will not be available on the model to use. In the case of an actions column where you have buttons specific to the row, you probably need that, so you can add the select statement to make it available on the model.
 
+
+### setAdditionalSelectRaws
+
+By default the only columns defined in the select statement are the ones defined via columns. If you need to add DB::raw selects so that they are available in the model, you can do so here.  All statements will be added individually, you should add an "as" to each to ensure that it will be available for use.
+
+Raw statements will be injected into the query as strings, so you should be extremely careful to avoid creating SQL injection vulnerabilities.
+
+
+```php
+public function configure(): void
+{
+  $this->setAdditionalSelectRaws(["CONCAT(users.id,users.name) as idName", "CONCAT(users.firstname,' ',users.parent_id)"])     
+}
+```
+
+You may optionally pass one or more variables to the raw query either as a string or an array.
+```php
+public function configure(): void
+{
+  $this->setAdditionalSelectRaws(["CONCAT(users.id,users.name) as idName", ['CONCAT(users.id,?,users.parent_id) as userParentLink', ' has parent of ']])   
+}
+```
+
+
+This can be used in the table as follows:
+```php
+Column::make('Full Name')
+    ->label(fn ($row) => $row->fullname),
+```
+
+
 ## Misc.
 
 ### setEmptyMessage

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -35,6 +35,7 @@ trait ComponentUtilities
     protected $collapsingColumnsStatus = true;
     protected string $emptyMessage = 'No items found. Try to broaden your search.';
     protected array $additionalSelects = [];
+    protected array $additionalSelectRaws = [];
     protected bool $hideConfigurableAreasWhenReorderingStatus = true;
     protected array $configurableAreas = [
         'before-tools' => null,

--- a/src/Traits/Configuration/ComponentConfiguration.php
+++ b/src/Traits/Configuration/ComponentConfiguration.php
@@ -313,6 +313,20 @@ trait ComponentConfiguration
     }
 
     /**
+     * @return $this
+     */
+    public function setAdditionalSelectRaws($selects): self
+    {
+        if (! is_array($selects)) {
+            $selects = [$selects];
+        }
+
+        $this->additionalSelectRaws = $selects;
+
+        return $this;
+    }
+
+    /**
      * @param  $areas
      *
      * @return $this

--- a/src/Traits/Helpers/ComponentHelpers.php
+++ b/src/Traits/Helpers/ComponentHelpers.php
@@ -288,7 +288,7 @@ trait ComponentHelpers
     {
         return $this->collapsingColumnsStatus;
     }
-    
+
     /**
      * @return bool
      */
@@ -347,6 +347,14 @@ trait ComponentHelpers
     public function getAdditionalSelects(): array
     {
         return $this->additionalSelects;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalSelectRaws(): array
+    {
+        return $this->additionalSelectRaws;
     }
 
     /**

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -126,6 +126,20 @@ trait WithData
             $this->setBuilder($this->getBuilder()->addSelect($select));
         }
 
+        // Load any additional selects that were not already columns
+        $rawCount = 1;
+        foreach ($this->getAdditionalSelectRaws() as $selectRaw) {
+            if (is_array($selectRaw)) {
+                if (strpos($selectRaw[0], 'as') === false) {
+                    $selectRaw[0] .= ' as rawSelect'.$rawCount;
+                }
+                $this->setBuilder($this->getBuilder()->selectRaw($selectRaw[0], (is_array($selectRaw[1]) ? $selectRaw[1] : [$selectRaw[1]])));
+            } else {
+                $this->setBuilder($this->getBuilder()->selectRaw($selectRaw));
+            }
+            $rawCount++;
+        }
+
         foreach ($this->getSelectableColumns() as $column) {
             $this->setBuilder($this->getBuilder()->addSelect($column->getColumn() . ' as ' .$column->getColumnSelectName()));
         }

--- a/tests/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Traits/Helpers/ComponentHelpersTest.php
@@ -164,6 +164,16 @@ class ComponentHelpersTest extends TestCase
     }
 
     /** @test */
+    public function can_get_additional_select_raws(): void
+    {
+        $this->assertEquals([], $this->basicTable->getAdditionalSelectRaws());
+
+        $this->basicTable->setAdditionalSelectRaws(['CONCAT(users.id,users.name) as concatName']);
+
+        $this->assertEquals(['CONCAT(users.id,users.name) as concatName'], $this->basicTable->getAdditionalSelectRaws());
+    }
+
+    /** @test */
     public function can_get_configurable_areas(): void
     {
         $this->assertEquals([


### PR DESCRIPTION
Allows for adding selectRaw to the query, for use cases such as concatenating columns from the database directly.  I've caveated the docs that this isn't a great idea, as it does carry risks, but may be useful for some.  Not sure what appetite there is for this.

e.g.
```php
$this->setAdditionalSelectRaws(['CONCAT(users.id,users.name) as userIDNameCombined'])
```

Or with parameters:
```php
public function configure(): void
{
  $this->setAdditionalSelectRaws(["CONCAT(users.id,users.name) as idName", ['CONCAT(users.id,?,users.parent_id) as userParentLink', ' has parent of ']])   
}
```


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
