### PR TITLE
improve active page visibility

### DIFF
--- a/resources/views/specific/tailwind/pagination.blade.php
+++ b/resources/views/specific/tailwind/pagination.blade.php
@@ -67,7 +67,7 @@
                                         <span wire:key="paginator-{{ $paginator->getPageName() }}-{{ $this->numberOfPaginatorsRendered[$paginator->getPageName()] }}-page{{ $page }}">
                                             @if ($page == $paginator->currentPage())
                                                 <span aria-current="page">
-                                                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-white border border-gray-300 cursor-default leading-5 dark:bg-gray-500 dark:text-white dark:border-gray-500">{{ $page }}</span>
+                                                    <span class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-500 bg-gray-100 border border-gray-300 cursor-default leading-5 dark:bg-gray-500 dark:text-white dark:border-gray-500">{{ $page }}</span>
                                                 </span>
                                             @else
                                                 <button wire:click="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')" class="relative inline-flex items-center px-4 py-2 -ml-px text-sm font-medium text-gray-700 bg-white border border-gray-300 leading-5 hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150 dark:bg-gray-700 dark:text-white dark:ring-gray-600 dark:border-gray-600 dark:hover:bg-gray-600" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This improves the visibility of the active page for light mode themes (it’s already very clear which page is active in dark mode):

# Before

![Screenshot 2023-03-10 at 16 41 40](https://user-images.githubusercontent.com/784333/224441976-c3bfcf09-149f-4972-8ea5-3160b6a3d49a.png)

# After

![Screenshot 2023-03-10 at 16 41 48](https://user-images.githubusercontent.com/784333/224441965-779731bd-e824-4f88-8fd0-5414ed46cc9b.png)
