### PR TITLE
Workflow (run-tests) - Use of ParaTest, Composer Caching, Fix Stability Matrix Clash

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,39 +5,58 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '[ci]')"
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1, 8.2]
-        laravel: [9.*, 10.*]
+        php: [8.1, 8.2]
+        laravel: [8.*, 9.*, 10.*]
         stability: [prefer-stable]
         exclude:
           - laravel: 10.*
-            php: 8.0
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, pcov, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: pcov
+          tools: phpstan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-composer--${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.laravel }}-composer-
+
+      - name: Add token
+        run: |
+          composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+
+      - name: Update dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer update --${{ matrix.stability }} --no-interaction
 
       - name: Setup problem matchers
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
-
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: Execute tests
-        run: vendor/bin/phpunit
+      - name: Run Unit Tests
+        run: php -d pcov.enabled=1 ./vendor/bin/paratest --passthru-php="'-d pcov.enabled=1'"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,16 +10,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2]
         laravel: [8.*, 9.*, 10.*]
         stability: [prefer-stable]
         exclude:
           - laravel: 10.*
             php: 8.0
-          - laravel: 10.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,12 +10,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2]
+        php: [7.4, 8.0, 8.1, 8.2]
         laravel: [8.*, 9.*, 10.*]
         stability: [prefer-stable]
         exclude:
           - laravel: 10.*
-            php: 8.1
+            php: 8.0
+          - laravel: 10.*
+            php: 7.4
+          - laravel: 9.*
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Tests](https://github.com/rappasoft/laravel-livewire-tables/actions/workflows/run-tests.yml/badge.svg)](https://github.com/rappasoft/laravel-livewire-tables/actions/workflows/run-tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/rappasoft/laravel-livewire-tables.svg?style=flat-square)](https://packagist.org/packages/rappasoft/laravel-livewire-tables)
 
+### Enjoying this package? [Buy me a beer 🍺](https://www.buymeacoffee.com/rappasoft)
+
 A dynamic Laravel Livewire component for data tables.
 
 ![Dark Mode](https://imgur.com/QoEdC7n.png)

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "illuminate/contracts": "^8.0|^9.0|^10.0"
     },
     "require-dev": {
+        "brianium/paratest": "^4.0|^5.0|^6.1|^7.0",
         "ext-sqlite3": "*",
         "orchestra/testbench": "^6.13|^7.0|^8.0",
         "phpunit/phpunit": "^9.3",

--- a/tests/Events/ColumnsSelectedTest.php
+++ b/tests/Events/ColumnsSelectedTest.php
@@ -5,7 +5,7 @@ namespace Rappasoft\LaravelLivewireTables\Events;
 use Illuminate\Support\Facades\Event;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
-class ColumnSelectedTest extends TestCase
+class ColumnsSelectedTest extends TestCase
 {
     /** @test */
     public function an_event_is_emitted_when_a_column_selection_are_updated()


### PR DESCRIPTION
Three files modified:
1. Fix for ColumnsSelectedTest.php class being named ColumnSelectedTest instead of ColumnsSelectedTest

2. New Composer require-dev for ParaTest rather than straight PHPUnit, which allows for parallel running of PHPUnit tests up to the maximum threads that the CPU is capable of.

4. Workflow actions major changes:
a) Introduces use of ParaTest rather than PHPUnit to allow for parallel processing of tests
b) Re-introduces Laravel 8 to the matrix
c) Introduces use of Composer Caching to avoid repeated downloads of requirements when running actions.  This is a cache per-matrix instance, which expires when the hash of the composer.lock changes.
d) Removes the clash between the matrix line for stability, and what was enforced prefer-dist.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
5. [x] Did you update all templates (if applicable)?
6. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
7. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
