### PR TITLE
Set Filter - Custom Pill Blade

### DIFF
--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -276,3 +276,12 @@ If the filter takes any config options, you can set them with the `config` metho
         'max' => '2021-12-31',
     ])
 ```
+
+### setFilterPillBlade
+
+Set a blade file for use in displaying the filter values in the pills area.
+
+```php
+SelectFilter::make('Active')
+    ->setFilterPillBlade('path.to.blade')
+```

--- a/resources/views/components/tools/filter-pills.blade.php
+++ b/resources/views/components/tools/filter-pills.blade.php
@@ -17,24 +17,27 @@
 
                     @continue(is_null($filter))
                     @continue($filter->isHiddenFromPills())
-
-                    <span
-                        wire:key="{{ $component->getTableName() }}-filter-pill-{{ $filter->getKey() }}"
-                        class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900"
-                    >
-                        {{ $filter->getFilterPillTitle() }}: {{ $filter->getFilterPillValue($value) }}
-
-                        <button
-                            wire:click="resetFilter('{{ $filter->getKey() }}')"
-                            type="button"
-                            class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:outline-none focus:bg-indigo-500 focus:text-white"
+                    @if ($filter->hasCustomPillBlade())
+                        @include($filter->getCustomPillBlade(), ['filter' => $filter])
+                    @else
+                        <span
+                            wire:key="{{ $component->getTableName() }}-filter-pill-{{ $filter->getKey() }}"
+                            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900"
                         >
-                            <span class="sr-only">@lang('Remove filter option')</span>
-                            <svg class="h-2 w-2" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
-                            </svg>
-                        </button>
-                    </span>
+                            {{ $filter->getFilterPillTitle() }}: {{ $filter->getFilterPillValue($value) }}
+
+                            <button
+                                wire:click="resetFilter('{{ $filter->getKey() }}')"
+                                type="button"
+                                class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:outline-none focus:bg-indigo-500 focus:text-white"
+                            >
+                                <span class="sr-only">@lang('Remove filter option')</span>
+                                <svg class="h-2 w-2" stroke="currentColor" fill="none" viewBox="0 0 8 8">
+                                    <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                </svg>
+                            </button>
+                        </span>
+                    @endif
                 @endforeach
 
                 <button
@@ -61,7 +64,9 @@
 
                     @continue(is_null($filter))
                     @continue($filter->isHiddenFromPills())
-
+                    @if ($filter->hasCustomPillBlade())
+                        @include($filter->getCustomPillBlade(), ['filter' => $filter])
+                    @else
                     <span
                         wire:key="{{ $component->getTableName() }}-filter-pill-{{ $filter->getKey() }}"
                         class="badge badge-pill badge-info d-inline-flex align-items-center"
@@ -79,6 +84,7 @@
                             </svg>
                         </a>
                     </span>
+                    @endif
                 @endforeach
 
                 <a
@@ -105,6 +111,9 @@
                     @continue(is_null($filter))
                     @continue($filter->isHiddenFromPills())
 
+                    @if ($filter->hasCustomPillBlade())
+                        @include($filter->getCustomPillBlade(), ['filter' => $filter])
+                    @else
                     <span
                         wire:key="{{ $component->getTableName() }}-filter-pill-{{ $filter->getKey() }}"
                         class="badge rounded-pill bg-info d-inline-flex align-items-center"
@@ -122,6 +131,7 @@
                             </svg>
                         </a>
                     </span>
+                    @endif
                 @endforeach
 
                 <a

--- a/src/Views/Filter.php
+++ b/src/Views/Filter.php
@@ -22,7 +22,8 @@ abstract class Filter
     protected array $config = [];
     protected ?string $filterPillTitle = null;
     protected array $filterPillValues = [];
-
+    protected ?string $filterCustomPillBlade = null;
+    
     public function __construct(string $name, string $key = null)
     {
         $this->name = $name;

--- a/src/Views/Traits/Configuration/FilterConfiguration.php
+++ b/src/Views/Traits/Configuration/FilterConfiguration.php
@@ -94,4 +94,16 @@ trait FilterConfiguration
 
         return $this;
     }
+
+    /**
+     * @param string $blade
+     *
+     * @return $this
+     */
+    public function setFilterPillBlade(string $blade): self
+    {
+        $this->filterCustomPillBlade = $blade;
+
+        return $this;
+    }
 }

--- a/src/Views/Traits/Helpers/FilterHelpers.php
+++ b/src/Views/Traits/Helpers/FilterHelpers.php
@@ -225,4 +225,24 @@ trait FilterHelpers
     {
         return $this->resetByClearButton === true;
     }
+
+    /**
+     * Determine if filter has a Custom Pill Blade
+     *
+     * @return bool
+     */
+    public function hasCustomPillBlade(): bool
+    {
+        return $this->filterCustomPillBlade != null;
+    }
+
+    /**
+     * Get the path to the Custom Pill Blade
+     *
+     * @return string|null
+     */
+    public function getCustomPillBlade(): ?string
+    {
+        return $this->filterCustomPillBlade ?? null;
+    }
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

This is an initial PR just to test appetite from @rappasoft and others (before I start writing tests/docs)

The intention is to provide the ability for Custom Pills Blades for Filters, for a couple of reasons:

1. To enhance the capability (particularly with Multi-Select or future Filters) to interact with the data more cleanly (removing individual items for example), rather than having to clear a filter completely.

2. To allow for customisation of look/feel of Pills on a per-filter basis, without the need to publish the main views, removing some of the issues that crop up due to older published views.

This adds the following new methods:

#Added to Views\Traits\FilterHelpers
##hasCustomPillBlade
Determines whether the filter has a custom blade for the pills
```php
  /**
   * Determine if filter has a Custom Pill Blade
   *
   * @return bool
   */
  public function hasCustomPillBlade(): bool
  {
      return $this->filterCustomPillBlade != null;
  }
```

##getCustomPillBlade
Retrieves the path for any custom pill blade
```php
/**
 * Get the path to the Custom Pill Blade
 *
 * @return string|null
 */
public function getCustomPillBlade(): ?string
{
    return $this->filterCustomPillBlade ?? null;
}
```

#Added To Views\Traits\FilterConfiguration
```php
/**
 * @param string $blade
 *
 * @return $this
 */
public function setFilterPillBlade(string $blade): self
{
    $this->filterCustomPillBlade = $blade;

    return $this;
}
```

#Added parameter to Views\Filter
```php
    protected ?string $filterCustomPillBlade = null;
```

#filter-pills.blade updated to check (after the checks for applied/null/hidden pills)
```php
@foreach ($component->getAppliedFiltersWithValues() as $filterSelectName => $value)
    @php
        $filter = $component->getFilterByKey($filterSelectName);
    @endphp

    @continue(is_null($filter))
    @continue($filter->isHiddenFromPills())

    @if ($filter->hasCustomPillBlade())
        @include($filter->getCustomPillBlade(), ['filter' => $filter])
    @else
        // Standard Code Here
    @endif
@endforeach
```

Initial tests are showing that this works quite smoothly, and doesn't appear to impact performance, although I've not yet scaled it up properly.