### PR TITLE
Filter fix repeated calling

### DIFF
--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -69,8 +69,6 @@ abstract class DataTableComponent extends Component
             'columns' => $this->{$this->tableName}['columns'] ?? [],
         ];
         
-        // Set the filter defaults based on the filter type
-        $this->setFilterDefaults();
     }
 
     /**
@@ -78,9 +76,19 @@ abstract class DataTableComponent extends Component
      */
     public function booted(): void
     {
+        // Call the configure() method
         $this->configure();
+
+        // Set the filter defaults based on the filter type
+        $this->setFilterDefaults();
+
+        // Sets the Theme - tailwind/bootstrap
         $this->setTheme();
+
+        //Sets up the Builder Instance
         $this->setBuilder($this->builder());
+
+        // Sets Columns
         $this->setColumns();
 
         // Make sure a primary key is set

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -111,7 +111,7 @@ trait FilterHelpers
      */
     public function hasFilters(): bool
     {
-        return ($this->getFilters()->count() > 0);
+        return ($this->getFiltersCount() > 0);
     }
 
     /**
@@ -129,7 +129,12 @@ trait FilterHelpers
      */
     public function getFilters(): Collection
     {
-        return collect($this->filters());
+        if(! isset($this->filterCollection)) {
+            $this->filterCollection = collect($this->filters());
+        }
+
+        return $this->filterCollection;
+
     }
 
     /**
@@ -137,7 +142,12 @@ trait FilterHelpers
      */
     public function getFiltersCount(): int
     {
-        return $this->getFilters()->count();
+        if (! isset($this->filterCount)) {
+            $this->filterCount = $this->getFilters()->count();
+        }
+
+        return $this->filterCount;
+
     }
 
     /**

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -16,6 +16,8 @@ trait WithFilters
     public bool $filterPillsStatus = true;
     public bool $filterSlideDownDefaultVisible = false;
     public string $filterLayout = 'popover';
+    public int $filterCount;
+    protected $filterCollection;
 
     public function filters(): array
     {

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -59,8 +59,8 @@ class FilterVisualsTest extends TestCase
     public function filter_pills_show_when_visible(): void
     {
         Livewire::test(PetsTable::class)
-            ->set('table.filters.breed', [1])
             ->call('setFiltersVisibilityEnabled')
+            ->set('table.filters.breed', [1])
             ->assertSee('Applied Filters');
     }
 

--- a/tests/Traits/Visuals/ReorderingVisualsTest.php
+++ b/tests/Traits/Visuals/ReorderingVisualsTest.php
@@ -172,7 +172,7 @@ class ReorderingVisualsTest extends TestCase
     /** @test
     * @depends testFilterArraySetup
     */
-    public function search_hides_on_reorder(): void
+    public function search_hides_on_reorder(array $filterDefaultArray): void
     {
         Livewire::test(PetsTable::class)
             ->call('setReorderEnabled')

--- a/tests/Traits/Visuals/ReorderingVisualsTest.php
+++ b/tests/Traits/Visuals/ReorderingVisualsTest.php
@@ -169,7 +169,9 @@ class ReorderingVisualsTest extends TestCase
             ->assertSet('perPage', 10);
     }
 
-    /** @test */
+    /** @test
+    * @depends testFilterArraySetup
+    */
     public function search_hides_on_reorder(): void
     {
         Livewire::test(PetsTable::class)
@@ -183,7 +185,7 @@ class ReorderingVisualsTest extends TestCase
             ->assertDontSee('Search')
             ->call('disableReordering')
             ->assertSet('searchStatus', true)
-            ->assertSet('table', ['search' => 'abc123'])
+            ->assertSet('table', ['search' => 'abc123', 'filters' => $filterDefaultArray])
             ->assertSee('Search');
     }
 
@@ -275,13 +277,14 @@ class ReorderingVisualsTest extends TestCase
     */
     public function filters_are_disabled_on_reorder(array $filterDefaultArray): void
     {
-        $filterDefaultArray['breed'] = [1];
+        $customisedFilterArray = $filterDefaultArray;
+        $customisedFilterArray['breed'] = [1];
 
         Livewire::test(PetsTable::class)
             ->call('setReorderEnabled')
             ->assertSet('filtersStatus', true)
             ->set('table.filters.breed', [1])
-            ->assertSet('table', ['filters' => $filterDefaultArray, 'sorts' => [], 'columns' => []])
+            ->assertSet('table', ['filters' => $customisedFilterArray, 'sorts' => [], 'columns' => []])
             ->assertSee('Filters')
             ->call('enableReordering')
             ->assertSet('filtersStatus', false)


### PR DESCRIPTION
This fix addresses an issue where filters() is called numerous times during the render process.  To fix, the following changes are made:

1. Only calls setFilterDefaults after the component is booted, but before the Builder is set.
2. Sets a protected variable for Filters, so that it is refreshed after each render, but persists during a single lifecycle
3. Sets a public count for the filters, which persists for duration (will be reviewed when a "showIf" method is added to the Filters)

This is a performance enhancement only.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
5. [ ] Did you update all templates (if applicable)?
6. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
7. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
