### PR TITLE
Make PHP7.4 Compatible filterSlidedownRow/filterSlidedownColspan

### DIFF
--- a/src/Views/Traits/Configuration/FilterConfiguration.php
+++ b/src/Views/Traits/Configuration/FilterConfiguration.php
@@ -119,26 +119,27 @@ trait FilterConfiguration
     }
     
     /**
-     * @param string|int $filterSlidedownRow
+     * @param string $filterSlidedownRow
      *
      * @return self
      */
-    public function setFilterSlidedownRow(string|int $filterSlidedownRow): self
+    public function setFilterSlidedownRow(string $filterSlidedownRow): self
     {
-        $this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
-
+        //$this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
+        $this->filterSlidedownRow = intval($filterSlidedownRow);
         return $this;
     }
 
     /**
-     * @param string|int $filterSlidedownColspan
+     * @param string $filterSlidedownColspan
      *
      * @return self
      */
-    public function setFilterSlidedownColspan(string|int $filterSlidedownColspan): self
+    public function setFilterSlidedownColspan(string $filterSlidedownColspan): self
     {
-        $this->filterSlidedownColspan = (is_int($filterSlidedownColspan) ? $filterSlidedownColspan : intval($filterSlidedownColspan));
-        
+        //$this->filterSlidedownColspan = (is_int($filterSlidedownColspan) ? $filterSlidedownColspan : intval($filterSlidedownColspan));
+        $this->filterSlidedownColspan = intval($filterSlidedownColspan);
+
         return $this;
     }
     

--- a/src/Views/Traits/Configuration/FilterConfiguration.php
+++ b/src/Views/Traits/Configuration/FilterConfiguration.php
@@ -127,6 +127,7 @@ trait FilterConfiguration
     {
         //$this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
         $this->filterSlidedownRow = intval($filterSlidedownRow);
+
         return $this;
     }
 


### PR DESCRIPTION
Removes references to int|string to make this PHP7.4 compatible.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
