### PR TITLE
Allow multiple relationships on same table

### DIFF
--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -100,7 +100,7 @@ trait WithData
                     $foreign = "$tableAlias.{$model->getForeignKeyName()}";
                     $other = $i === 0
                         ? $model->getQualifiedParentKeyName()
-                        : $lastAlias . '.' . $model->getLocalKeyName();
+                        : $lastAlias.'.'.$model->getLocalKeyName();
 
                     break;
 
@@ -108,7 +108,7 @@ trait WithData
                     $table = "{$model->getRelated()->getTable()} AS $tableAlias";
                     $foreign = $i === 0
                         ? $model->getQualifiedForeignKeyName()
-                        : $lastAlias . '.' . $model->getForeignKeyName();
+                        : $lastAlias.'.'.$model->getForeignKeyName();
 
                     $other = "$tableAlias.{$model->getOwnerKeyName()}";
 
@@ -175,10 +175,6 @@ trait WithData
 
     /**
      * Generate a unique alias used for joins and column selection.
-     *
-     * @param string|null $currentTableAlias
-     * @param string $relationPart
-     * @return string
      */
     protected function getTableAlias(?string $currentTableAlias, string $relationPart): string
     {
@@ -186,7 +182,7 @@ trait WithData
             return $relationPart;
         }
 
-        return $currentTableAlias . '_' . $relationPart;
+        return $currentTableAlias.'_'.$relationPart;
     }
 
     protected function getQuerySql(): string

--- a/tests/Http/Livewire/PetsTable.php
+++ b/tests/Http/Livewire/PetsTable.php
@@ -52,7 +52,7 @@ class PetsTable extends DataTableComponent
                     fn (Builder $query, string $direction) => $query->orderBy('pets.id', $direction)
                 )
                 ->searchable(
-                    fn (Builder $query, $searchTerm) => $query->orWhere('breeds.name', $searchTerm)
+                    fn (Builder $query, $searchTerm) => $query->orWhere('breed.name', $searchTerm)
                 ),
 
             Column::make('Other')

--- a/tests/Views/ColumnTest.php
+++ b/tests/Views/ColumnTest.php
@@ -66,6 +66,6 @@ class ColumnTest extends TestCase
 
         $column = $this->basicTable->getColumnBySelectName('breed.name');
 
-        $this->assertSame('breeds', $column->getTable());
+        $this->assertSame('breed', $column->getTable());
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

### Introduction
This pull request is an attempt to introduce the possibility to embed two relationships linked to the same table. 

The problem is described in the issue #688. When we try to display two relationships linked to the same table, the first relation will be shown as the second relation too. As there is no alias, the second join is not applied because a join already exists on the target table.

As far as I know, the current workaround consists in configuring the column with the foreign key, and then formatting the column with the `label` or `format` column helper. For me, this has two problems:
- it is not possible to search in the column
- for the second relation, the workaround has to be used, so we have to use two differents methods to display the same thing

### Proposed solution
This PR fix the problem by generating and adding an alias to the tables that are joined. The alias for the relations joins are generated by imploding the relation parts together and glueing them with an underscore. 

Some examples:
I have a document class, with a sender and a producer, where both are a Sender

```php
class Document {
    public function sender(): BelongsTo
    {
        return $this->belongsTo(Sender::class, 'sender_id');
    }

    public function producer(): BelongsTo
    {
        return $this->belongsTo(Sender::class, 'producer_id');
    }
}
```

Table columns configuration:
```php
    public function columns(): array
    {
        return [
            Column::make('sender_id', "sender_id"),
            Column::make('sender.id', "sender.id"),
            Column::make('producer_id', "producer_id"),
            Column::make('producer.id', "producer.id"),
        ];
    }
```

Before the fix:
![image](https://github.com/rappasoft/laravel-livewire-tables/assets/7632591/4d5ac81d-4777-4299-b59b-fb7ad0320784)

- first line: producer_id is empty, because the document has no producer. But the table incorrectly link the sender 1 as a producer
- second line: producer_id is 2, but the table shows 1, because it is based on the first and unique join

Generated query:
```sql
select 
    `documents`.`sender_id` as `sender_id`,
    `senders`.`id` as `sender.id`,
    `documents`.`producer_id` as `producer_id`,
    `senders`.`id` as `producer.id` 
from 
    `documents` 
left join 
    `senders` on `documents`.`sender_id` = `senders`.`id` -- only 1 join, should have 2 (producer_id is missing)

limit 10 offset 0
```

After the fix
![image](https://github.com/rappasoft/laravel-livewire-tables/assets/7632591/980762ed-4794-482f-a260-4e8338eb998b)

Generated query:
```sql
select
    `documents`.`sender_id` as `sender_id`,
    `sender`.`id` as `sender.id`,
    `documents`.`producer_id` as `producer_id`,
    `producer`.`id` as `producer.id` 
from
    `documents` 
left join
    `senders` as `sender` on `documents`.`sender_id` = `sender`.`id` -- alias based on the relationship name
left join
    `senders` as `producer` on `documents`.`producer_id` = `producer`.`id` -- missing join is now present

limit 10 offset 0
```

Because the tables are now aliased, the joins are correctly handled by the `performJoin` method (at line 112).

### Breaking changes
If you provide a custom callback to `Column` `searchable` function and you are specifying a table, you have to replace it by the alias. 

Example: 
In the `tests/Http/Livewire/PetsTable.php` file at line `55`, before the PR is merged:
```php
    ->searchable(
        fn (Builder $query, $searchTerm) => $query->orWhere('breeds.name', $searchTerm)
    ),
```
After the merge:
```php
    ->searchable(
        fn (Builder $query, $searchTerm) => $query->orWhere('breed.name', $searchTerm)
    ),
```
 `breeds.name` was replaced by `breed.name` 

### TODO
- document somewhere the breaking change ?
- add some tests ? Currently there is none for the WithDataTrait

### Discussion
This is my first PR proposal, please let me know if I should change or improve something.

I'd appreciate some feedback about this feature, thank you.
