### PR TITLE
Hide Filter Labels in Header/Footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
   - Moved Setting of Theme to Traits/ComponentUtilities - mountComponentUtilities for efficiency  - https://github.com/rappasoft/laravel-livewire-tables/pull/1191
   
 - Filters
+  - *Fix* - Hide the filter label in the header/footer when using as a secondary header/footer
   - *Fix* - Changed the booting order to prevent repeated calling of filters() - https://github.com/rappasoft/laravel-livewire-tables/pull/1166 
   - *Fix* - fixed multiSelectDropdownFilter in menus - https://github.com/rappasoft/laravel-livewire-tables/pull/1160 
   - *Fix* - TypeHint to allow continued support of PHP 7.4 - https://github.com/rappasoft/laravel-livewire-tables/pull/1185

--- a/resources/views/components/tools/filters/date.blade.php
+++ b/resources/views/components/tools/filters/date.blade.php
@@ -4,11 +4,12 @@
     $tableName = $component->getTableName();
 @endphp
 <div>
-    @if($filter->hasCustomFilterLabel())
-        @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName])
-    @else
+    @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
+        @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName  ])
+    @elseif(!$filter->hasCustomPosition())
         <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
     @endif
+
     @if ($theme === 'tailwind')
         <div class="rounded-md shadow-sm">
             <input

--- a/resources/views/components/tools/filters/datetime.blade.php
+++ b/resources/views/components/tools/filters/datetime.blade.php
@@ -4,9 +4,9 @@
     $tableName = $component->getTableName();
 @endphp
 <div>
-    @if($filter->hasCustomFilterLabel())
+    @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
         @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName  ])
-    @else
+    @elseif(!$filter->hasCustomPosition())
         <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
     @endif
         @if ($theme === 'tailwind')

--- a/resources/views/components/tools/filters/multi-select-dropdown.blade.php
+++ b/resources/views/components/tools/filters/multi-select-dropdown.blade.php
@@ -4,9 +4,9 @@
     $tableName = $component->getTableName();
 @endphp
 <div>
-    @if($filter->hasCustomFilterLabel())
+    @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
         @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName  ])
-    @else
+    @elseif(!$filter->hasCustomPosition())
         <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
     @endif
         @if ($theme === 'tailwind')

--- a/resources/views/components/tools/filters/multi-select.blade.php
+++ b/resources/views/components/tools/filters/multi-select.blade.php
@@ -4,10 +4,10 @@
     $tableName = $component->getTableName();
 @endphp
 <div>
-    @if($filter->hasCustomFilterLabel())
-        @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName])
-    @else
-    <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
+    @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
+        @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName  ])
+    @elseif(!$filter->hasCustomPosition())
+        <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
     @endif
     @if ($theme === 'tailwind')
         <div class="rounded-md">

--- a/resources/views/components/tools/filters/number.blade.php
+++ b/resources/views/components/tools/filters/number.blade.php
@@ -4,9 +4,9 @@
     $tableName = $component->getTableName();
 @endphp
 <div>
-    @if($filter->hasCustomFilterLabel())
-        @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName])
-    @else
+    @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
+        @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName  ])
+    @elseif(!$filter->hasCustomPosition())
         <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
     @endif
         @if ($theme === 'tailwind')

--- a/resources/views/components/tools/filters/select.blade.php
+++ b/resources/views/components/tools/filters/select.blade.php
@@ -4,9 +4,9 @@
     $tableName = $component->getTableName();
 @endphp
 <div>
-    @if($filter->hasCustomFilterLabel())
+    @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
         @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName  ])
-    @else
+    @elseif(!$filter->hasCustomPosition())
         <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
     @endif
         @if ($theme === 'tailwind')

--- a/resources/views/components/tools/filters/text-field.blade.php
+++ b/resources/views/components/tools/filters/text-field.blade.php
@@ -4,9 +4,9 @@
     $tableName = $component->getTableName();
 @endphp
 <div>
-    @if($filter->hasCustomFilterLabel())
+    @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
         @include($filter->getCustomFilterLabel(),['filter' => $filter, 'theme' => $theme, 'filterLayout' => $filterLayout, 'tableName' => $tableName  ])
-    @else
+    @elseif(!$filter->hasCustomPosition())
         <x-livewire-tables::tools.filter-label :filter="$filter" :theme="$theme" :filterLayout="$filterLayout" :tableName="$tableName" />
     @endif
         @if ($theme === 'tailwind')


### PR DESCRIPTION
This is a minor fix to hide the Filter Labels when using the Filter as a Secondary Header/Footer.
See issue #1200  and discussion #1198 

It does this by modifying the filter blades and checks for $filter->hasCustomPosition (true if filter is in the secondary header/footer - otherwise false).
This does not affect the display of the label in the menu/pills.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
