### PR TITLE
Interim Fix for Bulk Actions

### DIFF
--- a/resources/views/components/table/th/bulk-actions.blade.php
+++ b/resources/views/components/table/th/bulk-actions.blade.php
@@ -9,7 +9,8 @@
         <x-livewire-tables::table.th.plain>
             <div class="inline-flex rounded-md shadow-sm">
                 <input
-                    wire:model="selectAll"
+                    x-model="allItemsSelected"
+                    x-on:click="toggleSelectAll"
                     type="checkbox"
                     class="rounded border-gray-300 text-indigo-600 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600"
                 />

--- a/resources/views/components/table/tr/bulk-actions.blade.php
+++ b/resources/views/components/table/tr/bulk-actions.blade.php
@@ -15,7 +15,9 @@
         <x-livewire-tables::table.tr.plain 
             wire:key="bulk-select-message-{{ $table }}"
             class="bg-indigo-50 dark:bg-gray-900 dark:text-white" 
+            x-cloak
             x-show="shouldShowBulkActionSelect"
+            x-effect="updateTotalItemCount({{ $rows->total() ?? 'unknown' }})"
         >
             <x-livewire-tables::table.td.plain :colspan="$colspan">
                 <template x-if="allItemsSelected">
@@ -78,7 +80,9 @@
     @elseif ($theme === 'bootstrap-4' || $theme === 'bootstrap-5')
         <x-livewire-tables::table.tr.plain 
             wire:key="bulk-select-message-{{ $table }}"
+            x-cloak
             x-show="shouldShowBulkActionSelect"
+            x-effect="updateTotalItemCount({{ $rows->total() ?? 'unknown' }})"
         >
             <x-livewire-tables::table.td.plain :colspan="$colspan">
                 <template x-if="allItemsSelected">

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -128,7 +128,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-show="shouldShowBulkActionSelect" class="w-full md:w-auto mb-4 md:mb-0">
+                <div x-cloak x-show="shouldShowBulkActionSelect" class="w-full md:w-auto mb-4 md:mb-0">
                     <div x-data="{ open: false, childElementOpen: false }" @keydown.window.escape="if (!childElementOpen) { open = false }"
                         x-on:click.away="if (!childElementOpen) { open = false }"
                         class="relative inline-block text-left z-10 w-full md:w-auto">
@@ -409,7 +409,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-show="shouldShowBulkActionSelect" class="mb-3 mb-md-0">
+                <div x-cloak x-show="shouldShowBulkActionSelect" class="mb-3 mb-md-0">
                     <div class="dropdown d-block d-md-inline">
                         <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button"
                             id="{{ $component->getTableName() }}-bulkActionsDropdown" data-toggle="dropdown"
@@ -634,7 +634,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-show="shouldShowBulkActionSelect" class="mb-3 mb-md-0">
+                <div x-cloak x-show="shouldShowBulkActionSelect" class="mb-3 mb-md-0">
                     <div class="dropdown d-block d-md-inline">
                         <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button"
                             id="{{ $component->getTableName() }}-bulkActionsDropdown" data-bs-toggle="dropdown"

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -13,6 +13,13 @@
         totalItems: 0,
         visibleItems: {},
         allItemsSelected: false,
+        toggleSelectAll() {
+            if (this.totalItems == this.selectedCount) {
+                this.clearSelected()
+            } else {
+                this.setAllSelected()
+            }
+        },
         setAllSelected() {
             allItemsSelected = true;
             $wire.setAllSelected();

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -8,11 +8,13 @@
 <div x-data="{
     shouldShowBulkActionSelect: false,
     @if ($component->isFilterLayoutSlideDown()) filtersOpen: $wire.filterSlideDownDefaultVisible, @endif
-    @if ($component->bulkActionsAreEnabled()) selectedItems: $wire.entangle('selected').defer,
+        selectedItems: $wire.entangle('selected').defer,
         selectedCount: 0,
+        totalItems: 0,
         visibleItems: {},
         allItemsSelected: false,
         setAllSelected() {
+            allItemsSelected = true;
             $wire.setAllSelected();
         },
         clearSelected() {
@@ -25,9 +27,14 @@
                 tempSelectedItems.push(value.toString());
             }
             this.selectedItems = [...new Set(tempSelectedItems)];
-        }, @endif
+        },
+        updateTotalItemCount(itemCount) {
+            this.totalItems = itemCount;
+            this.allItemsSelected = (itemCount == this.selectedCount);
+        },
 }"
-    x-effect="shouldShowBulkActionSelect = (selectedItems.length > 0); selectedCount = selectedItems.length;">
+    x-init="selectedCount = selectedItems.length; shouldShowBulkActionSelect = (selectedCount > 0);"
+    x-effect="selectedCount = selectedItems.length; shouldShowBulkActionSelect = (selectedItems.length > 0);">
     <div {{ $attributes->merge($this->getComponentWrapperAttributes()) }}
         @if ($component->hasRefresh()) wire:poll{{ $component->getRefreshOptions() }} @endif
         @if ($component->isFilterLayoutSlideDown()) wire:ignore.self @endif>

--- a/tests/Traits/Visuals/ReorderingVisualsTest.php
+++ b/tests/Traits/Visuals/ReorderingVisualsTest.php
@@ -224,7 +224,7 @@ class ReorderingVisualsTest extends TestCase
             ->call('setReorderEnabled')
             ->assertSet('bulkActionsStatus', true)
             ->call('setBulkActions', ['activate' => 'Activate'])
-            ->assertSeeHtml('wire:model="selectAll"')
+            ->assertSeeHtml('x-model="allItemsSelected"')
             ->call('enableReordering')
             ->assertSet('bulkActionsStatus', false)
             ->assertDontSee('Select All');


### PR DESCRIPTION
Correcting lack of x-cloak, which caused the Bulk Actions dropdown to flicker on load.
Adding variable for $rows->total() to toggle display of "you have selected all" when selecting rows manually

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
