### PR TITLE
Restore hideBulkActionsWhenEmptyIsDisabled Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 - Fixes
-    - Re-enable capability for hideBulkActionsWhenEmptyIsDisabled
+    - Re-enable capability for configuring whether to Hide/Show Bulk Actions when 
 
 ## [2.14.0] - 2023-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
+- Fixes
+    - Re-enable capability for hideBulkActionsWhenEmptyIsDisabled
 
 ## [2.14.0] - 2023-05-18
 

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -128,7 +128,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-cloak x-show="selectedItems.length > 0" class="w-full md:w-auto mb-4 md:mb-0">
+                <div x-cloak x-show="selectedItems.length > 0 || alwaysShowBulkActions" class="w-full md:w-auto mb-4 md:mb-0">
                     <div x-data="{ open: false, childElementOpen: false }" @keydown.window.escape="if (!childElementOpen) { open = false }"
                         x-on:click.away="if (!childElementOpen) { open = false }"
                         class="relative inline-block text-left z-10 w-full md:w-auto">
@@ -409,7 +409,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-cloak x-show="selectedItems.length > 0" class="mb-3 mb-md-0">
+                <div x-cloak x-show="selectedItems.length > 0 || alwaysShowBulkActions" class="mb-3 mb-md-0">
                     <div class="dropdown d-block d-md-inline">
                         <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button"
                             id="{{ $component->getTableName() }}-bulkActionsDropdown" data-toggle="dropdown"
@@ -634,7 +634,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-cloak x-show="selectedItems.length > 0" class="mb-3 mb-md-0">
+                <div x-cloak x-show="selectedItems.length > 0 || alwaysShowBulkActions" class="mb-3 mb-md-0">
                     <div class="dropdown d-block d-md-inline">
                         <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button"
                             id="{{ $component->getTableName() }}-bulkActionsDropdown" data-bs-toggle="dropdown"

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -128,7 +128,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-cloak x-show="selectedItems.length > 0 || alwaysShowBulkActions" class="w-full md:w-auto mb-4 md:mb-0">
+                <div x-cloak x-show="(selectedItems.length > 0 || alwaysShowBulkActions)" class="w-full md:w-auto mb-4 md:mb-0">
                     <div x-data="{ open: false, childElementOpen: false }" @keydown.window.escape="if (!childElementOpen) { open = false }"
                         x-on:click.away="if (!childElementOpen) { open = false }"
                         class="relative inline-block text-left z-10 w-full md:w-auto">
@@ -409,7 +409,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-cloak x-show="selectedItems.length > 0 || alwaysShowBulkActions" class="mb-3 mb-md-0">
+                <div x-cloak x-show="(selectedItems.length > 0 || alwaysShowBulkActions)" class="mb-3 mb-md-0">
                     <div class="dropdown d-block d-md-inline">
                         <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button"
                             id="{{ $component->getTableName() }}-bulkActionsDropdown" data-toggle="dropdown"
@@ -634,7 +634,7 @@
             @endif
 
             @if ($component->showBulkActionsDropdownAlpine())
-                <div x-cloak x-show="selectedItems.length > 0 || alwaysShowBulkActions" class="mb-3 mb-md-0">
+                <div x-cloak x-show="(selectedItems.length > 0 || alwaysShowBulkActions)" class="mb-3 mb-md-0">
                     <div class="dropdown d-block d-md-inline">
                         <button class="btn dropdown-toggle d-block w-100 d-md-inline" type="button"
                             id="{{ $component->getTableName() }}-bulkActionsDropdown" data-bs-toggle="dropdown"

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -10,6 +10,7 @@
     paginationCurrentCount: $wire.entangle('paginationCurrentCount'),
     paginationTotalItemCount: $wire.entangle('paginationTotalItemCount'),
     paginationCurrentItems: $wire.entangle('paginationCurrentItems'),
+    alwaysShowBulkActions: {{ $component->hideBulkActionsWhenEmptyIsDisabled() }},
     @if ($component->bulkActionsAreEnabled() && $component->hasBulkActions())
     selectedItems: $wire.entangle('selected').defer,
     @else

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -10,7 +10,7 @@
     paginationCurrentCount: $wire.entangle('paginationCurrentCount'),
     paginationTotalItemCount: $wire.entangle('paginationTotalItemCount'),
     paginationCurrentItems: $wire.entangle('paginationCurrentItems'),
-    alwaysShowBulkActions: {{ $component->hideBulkActionsWhenEmptyIsDisabled() ? 'true' : 'false' }},
+    alwaysShowBulkActions: {{ $component->getHideBulkActionsWhenEmptyStatus() ? 'false' : 'true' }},
     selectedItems: $wire.entangle('selected').defer,
     @if ($component->showBulkActionsDropdownAlpine())
     toggleSelectAll() {

--- a/resources/views/components/wrapper.blade.php
+++ b/resources/views/components/wrapper.blade.php
@@ -10,12 +10,9 @@
     paginationCurrentCount: $wire.entangle('paginationCurrentCount'),
     paginationTotalItemCount: $wire.entangle('paginationTotalItemCount'),
     paginationCurrentItems: $wire.entangle('paginationCurrentItems'),
-    alwaysShowBulkActions: {{ $component->hideBulkActionsWhenEmptyIsDisabled() }},
-    @if ($component->bulkActionsAreEnabled() && $component->hasBulkActions())
+    alwaysShowBulkActions: {{ $component->hideBulkActionsWhenEmptyIsDisabled() ? 'true' : 'false' }},
     selectedItems: $wire.entangle('selected').defer,
-    @else
-    selectedItems: {},
-    @endif
+    @if ($component->showBulkActionsDropdownAlpine())
     toggleSelectAll() {
         if (this.paginationTotalItemCount == this.selectedItems.length) {
             this.clearSelected();
@@ -37,6 +34,21 @@
         }
         this.selectedItems = [...new Set(tempSelectedItems)];
     },
+    @else
+    toggleSelectAll() {
+        return;
+    },
+    setAllSelected() {
+        return;
+    },
+    clearSelected() {
+        return;
+    },
+    selectAllOnPage() {
+        return;
+    },
+
+    @endif
 }">
     <div {{ $attributes->merge($this->getComponentWrapperAttributes()) }}
         @if ($component->hasRefresh()) wire:poll{{ $component->getRefreshOptions() }} @endif

--- a/src/Views/Traits/Helpers/FilterHelpers.php
+++ b/src/Views/Traits/Helpers/FilterHelpers.php
@@ -169,13 +169,13 @@ trait FilterHelpers
         return $this->filterPosition;
     }
 
-     /**
-      * Returns whether the filter has a custom label blade
-      */
-     public function hasCustomFilterLabel(): bool
-     {
-         return ! is_null($this->filterCustomLabel);
-     }
+    /**
+     * Returns whether the filter has a custom label blade
+     */
+    public function hasCustomFilterLabel(): bool
+    {
+        return ! is_null($this->filterCustomLabel);
+    }
 
     /**
      * Returns the path to the custom filter label blade

--- a/tests/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Traits/Helpers/ComponentHelpersTest.php
@@ -228,10 +228,10 @@ class ComponentHelpersTest extends TestCase
     }
 
     // Exists in DataTableComponentTest
-   // public function can_get_dataTable_fingerprint(): void
+    // public function can_get_dataTable_fingerprint(): void
     //{
-   //     $this->assertSame($this->defaultFingerPrintingAlgo($this->basicTable::class), $this->basicTable->getDataTableFingerprint());
-   // }
+    //     $this->assertSame($this->defaultFingerPrintingAlgo($this->basicTable::class), $this->basicTable->getDataTableFingerprint());
+    // }
 
     /** @test */
     public function can_get_query_string_alias_and_it_will_be_the_same_as_table_name_by_default(): void


### PR DESCRIPTION
Enables hideBulkActionsWhenEmptyIsDisabled for the AlpineJS Approach

NOTE: This is still in testing!

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
