### PR TITLE
Fix - Allows Label Columns to be Sortable

### DIFF
--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -6,7 +6,7 @@
     $theme = $component->getTheme();
     $customAttributes = $component->getThAttributes($column);
     $customSortButtonAttributes = $component->getThSortButtonAttributes($column);
-    $direction = $column->hasField() ? $component->getSort($column->getColumnSelectName()) : null;
+    $direction = $column->hasField() ? $component->getSort($column->getColumnSelectName()) : $component->getSort($column->getSlug()) ?? null ;
 @endphp
 
 @if ($theme === 'tailwind')
@@ -17,11 +17,11 @@
             ->class(['hidden md:table-cell' => $column->shouldCollapseOnTablet()])
             ->except('default')
     }}>
-        @unless ($component->sortingIsEnabled() && $column->isSortable())
+        @unless ($component->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
             {{ $column->getTitle() }}
         @else
             <button
-                wire:click="sortBy('{{ $column->getColumnSelectName() }}')"
+                wire:click="sortBy('{{ ($column->isSortable() ? $column->getColumnSelectName() : $column->getSlug()) }}')"
                 {{ 
                     $attributes->merge($customSortButtonAttributes)
                         ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider group focus:outline-none dark:text-gray-400' => $customSortButtonAttributes['default'] ?? true])
@@ -64,12 +64,12 @@
             ->class(['d-none d-md-table-cell' => $column->shouldCollapseOnTablet()])
             ->except('default')
     }}>
-        @unless ($component->sortingIsEnabled() && $column->isSortable())
+        @unless ($component->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
             {{ $column->getTitle() }}
         @else
             <div 
                 class="d-flex align-items-center"
-                wire:click="sortBy('{{ $column->getColumnSelectName() }}')"
+                wire:click="sortBy('{{ ($column->isSortable() ? $column->getColumnSelectName() : $column->getSlug()) }}')"
                 style="cursor:pointer;"
             >
                 <span>{{ $column->getTitle() }}</span>

--- a/resources/views/components/tools/sorting-pills.blade.php
+++ b/resources/views/components/tools/sorting-pills.blade.php
@@ -12,7 +12,7 @@
 
                 @foreach($component->getSorts() as $columnSelectName => $direction)
                     @php
-                        $column = $component->getColumnBySelectName($columnSelectName);
+                        $column = $component->getColumnBySelectName($columnSelectName) ?? $component->getColumnBySlug($columnSelectName);
                     @endphp
 
                     @continue(is_null($column))

--- a/resources/views/components/tools/sorting-pills.blade.php
+++ b/resources/views/components/tools/sorting-pills.blade.php
@@ -57,7 +57,7 @@
 
                 @foreach($component->getSorts() as $columnSelectName => $direction)
                     @php
-                        $column = $component->getColumnBySelectName($columnSelectName);
+                        $column = $component->getColumnBySelectName($columnSelectName) ?? $component->getColumnBySlug($columnSelectName);
                     @endphp
 
                     @continue(is_null($column))
@@ -101,7 +101,7 @@
 
                 @foreach($component->getSorts() as $columnSelectName => $direction)
                     @php
-                        $column = $component->getColumnBySelectName($columnSelectName);
+                        $column = $component->getColumnBySelectName($columnSelectName) ?? $component->getColumnBySlug($columnSelectName);
                     @endphp
 
                     @continue(is_null($column))

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -49,6 +49,13 @@ trait ColumnHelpers
             ->filter(fn (Column $column) => $column->isColumnBySelectName($qualifiedColumn))
             ->first();
     }
+    
+    public function getColumnBySlug(string $columnSlug): ?Column
+    {
+        return $this->getColumns()
+            ->filter(fn (Column $column) => $column->isColumnBySlug($columnSlug))
+            ->first();
+    }
 
     /**
      * @return array<mixed>

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -49,7 +49,7 @@ trait ColumnHelpers
             ->filter(fn (Column $column) => $column->isColumnBySelectName($qualifiedColumn))
             ->first();
     }
-    
+
     public function getColumnBySlug(string $columnSlug): ?Column
     {
         return $this->getColumns()

--- a/src/Traits/WithSorting.php
+++ b/src/Traits/WithSorting.php
@@ -12,19 +12,21 @@ trait WithSorting
         SortingHelpers;
 
     public array $sorts = [];
+
     public bool $sortingStatus = true;
+
     public bool $singleColumnSortingStatus = true;
+
     public bool $sortingPillsStatus = true;
+
     public ?string $defaultSortColumn = null;
+
     public string $defaultSortDirection = 'asc';
+
     public string $defaultSortingLabelAsc = 'A-Z';
+
     public string $defaultSortingLabelDesc = 'Z-A';
 
-    /**
-     * @param  string  $columnSelectName
-     *
-     * @return string|null
-     */
     public function sortBy(string $columnSelectName): ?string
     {
         if ($this->sortingIsDisabled()) {
@@ -50,9 +52,6 @@ trait WithSorting
         return null;
     }
 
-    /**
-     * @return Builder
-     */
     public function applySorting(): Builder
     {
         if ($this->hasDefaultSort() && ! $this->hasSorts()) {
@@ -91,9 +90,9 @@ trait WithSorting
             } elseif ($column->isBaseColumn()) {
                 $this->setBuilder($this->getBuilder()->orderBy($column->getColumnSelectName(), $direction));
             } else {
-                $value = $this->getBuilder()->getGrammar()->wrap($column->getColumn() . ' as ' . $column->getColumnSelectName());
+                $value = $this->getBuilder()->getGrammar()->wrap($column->getColumn().' as '.$column->getColumnSelectName());
                 $segments = preg_split('/\s+as\s+/i', $value);
-                $this->setBuilder($this->getBuilder()->orderByRaw($segments[1] . ' ' . $direction));
+                $this->setBuilder($this->getBuilder()->orderByRaw($segments[1].' '.$direction));
             }
         }
 

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -61,6 +61,11 @@ trait ColumnHelpers
     {
         return $this->getColumnSelectName() === $name;
     }
+    
+    public function isColumnBySlug(string $slug): bool
+    {
+        return $this->getSlug() === $slug;
+    }
 
     public function hasField(): bool
     {

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -61,7 +61,7 @@ trait ColumnHelpers
     {
         return $this->getColumnSelectName() === $name;
     }
-    
+
     public function isColumnBySlug(string $slug): bool
     {
         return $this->getSlug() === $slug;

--- a/src/Views/Traits/Helpers/FilterHelpers.php
+++ b/src/Views/Traits/Helpers/FilterHelpers.php
@@ -169,13 +169,13 @@ trait FilterHelpers
         return $this->filterPosition;
     }
 
-     /**
-      * Returns whether the filter has a custom label blade
-      */
-     public function hasCustomFilterLabel(): bool
-     {
-         return ! is_null($this->filterCustomLabel);
-     }
+    /**
+     * Returns whether the filter has a custom label blade
+     */
+    public function hasCustomFilterLabel(): bool
+    {
+        return ! is_null($this->filterCustomLabel);
+    }
 
     /**
      * Returns the path to the custom filter label blade

--- a/tests/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Traits/Helpers/ComponentHelpersTest.php
@@ -228,10 +228,10 @@ class ComponentHelpersTest extends TestCase
     }
 
     // Exists in DataTableComponentTest
-   // public function can_get_dataTable_fingerprint(): void
+    // public function can_get_dataTable_fingerprint(): void
     //{
-   //     $this->assertSame($this->defaultFingerPrintingAlgo($this->basicTable::class), $this->basicTable->getDataTableFingerprint());
-   // }
+    //     $this->assertSame($this->defaultFingerPrintingAlgo($this->basicTable::class), $this->basicTable->getDataTableFingerprint());
+    // }
 
     /** @test */
     public function can_get_query_string_alias_and_it_will_be_the_same_as_table_name_by_default(): void


### PR DESCRIPTION
Presently in testing

This adds the capability for label-only columns to be sortable, by checking first for the Column by Select Name, but if that is null, checks for the column's existence by Slug Name.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
