### PR TITLE
Lazy Loading Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 - Add documentation for setSearchPlaceholder()
 - Fix for Bulk Actions dropdown not working in Bootstrap
 - Fix for Column Select "Select All" not consistently updating
+- Add fix for lazy loading of table
 
 ## [Unreleased] - 3.x (beta-0)
 - Requirements Change

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -1,5 +1,5 @@
 @php($tableName = $this->getTableName())
-
+<div>
 <x-livewire-tables::wrapper :component="$this" :tableName="$tableName">
     @if ($this->hasConfigurableAreaFor('before-tools'))
         @include($this->getConfigurableAreaFor('before-tools'), $this->getParametersForConfigurableArea('before-tools'))
@@ -77,3 +77,4 @@
 
     @includeIf($customView)
 </x-livewire-tables::wrapper>
+</div>

--- a/src/Views/Columns/ComponentColumn.php
+++ b/src/Views/Columns/ComponentColumn.php
@@ -32,7 +32,7 @@ class ComponentColumn extends Column
             throw new DataTableConfigurationException('You can not use a label column with a component column');
         }
 
-        if (false === $this->hasComponentView()) {
+        if ($this->hasComponentView() === false) {
             throw new DataTableConfigurationException('You must specify a component view for a component column');
         }
 


### PR DESCRIPTION
This fix addresses a LW3 bug where the snapshot cannot apply to top-level component elements if they are used in a wire/alpine.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
