### PR TITLE
Fix 'clear filters' by using getFilterDefaultValue instead of getDefaultValue

### DIFF
--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -222,7 +222,7 @@ trait FilterHelpers
             $filter = $this->getFilterByKey($filter);
         }
 
-        $this->setFilter($filter->getKey(), $filter->getDefaultValue());
+        $this->setFilter($filter->getKey(), $filter->getFilterDefaultValue());
     }
 
     public function getFilterLayout(): string


### PR DESCRIPTION
Fix 'Clear filters' to reset the filters to their default values instead.

Please be aware this breaks expected functionality for other users, as filters are reset to their default values instead of cleared all together. In past versions the filters were also reset to their default values.

Fixes #1364

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
