### PR TITLE
Fix assertViewIs is not working

### DIFF
--- a/src/Features/AutoInjectRappasoftAssets.php
+++ b/src/Features/AutoInjectRappasoftAssets.php
@@ -57,7 +57,9 @@ class AutoInjectRappasoftAssets extends ComponentHook
             $html = $handled->response->getContent();
 
             if (str($html)->contains('</html>')) {
+                $original = $handled->response->original;
                 $handled->response->setContent(static::injectAssets($html));
+                $handled->response->original = $original;
             }
         });
     }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

This is a fix for #1367 

https://github.com/rappasoft/laravel-livewire-tables/blob/v3-develop/src/Features/AutoInjectRappasoftAssets.php#L60
`$handled->response->setContent(static::injectAssets($html));` overrides `$original` property of response which `assertViewIs` uses to assert the response.

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Testing/TestResponse.php#L1131C30-L1131C30
```php
protected function responseHasView()
{
    return isset($this->original) && $this->original instanceof View;
}