### PR TITLE
Fix DateRangeFilter Blade - Superfluous @endphp and remove published/cdn third party options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
-## [Unreleased] - 3.x Amends
+## [3.0.0-beta.2] - Removing superfluous item from blade
+- Removes superfluous @endphp from the DateRangeFilter blade
+- Removes reference to remote/published 3rd party assets
+
+## [3.0.0-beta.1] - 3.x Amends
 - Amending Documentation for Reordering
 - Adding capabilities & tests for setTrAttributes
 - Force calculation of even/odd only once in reorder mode
@@ -27,7 +31,6 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 - Add setExcludeDeselectedColumnsFromQueryEnabled and setExcludeDeselectedColumnsFromQueryDisabled methods to configure()
 
-## [Unreleased] - 3.x (beta-0)
 - Requirements Change
     - Requires LiveWire 3.x
     - Requires PHP 8.1+

--- a/resources/views/components/tools/filters/date-range.blade.php
+++ b/resources/views/components/tools/filters/date-range.blade.php
@@ -22,20 +22,8 @@
 @endphp
 
 <div x-cloak id="{{ $tableName }}-dateRangeFilter-{{ $filterKey }}" x-data="flatpickrFilter($wire, '{{ $filterKey }}', @js($filter->getConfigs()), $refs.dateRangeInput, '{{ App::currentLocale() }}')" >
-@if(config('livewire-tables.remote_third_party_assets'))
-    @once
-    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-    @endonce
-@elseif(config('livewire-tables.published_third_party_assets'))
-    @once
-    <script src="/vendor/rappasoft/livewire-tables/js/flatpickr.min.js"></script>
-    <link rel="stylesheet" href="/vendor/rappasoft/livewire-tables/css/flatpickr.css">
-    @endonce
-@endif
 
 
-@endphp
     <div>
         @if($filter->hasCustomFilterLabel() && !$filter->hasCustomPosition())
             @include($filter->getCustomFilterLabel(), ['filter' => $filter, 'filterLayout' => $filterLayout, 'tableName' => $tableName])


### PR DESCRIPTION
This:
1) Removes the code for using the "Published" third party items
2) Removes the superfluous ``` @endphp ``` from the DateRangeFilter blade 

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
