### PR TITLE
v3 - Adding CollapseAlways Option for Columns

### DIFF
--- a/docs/columns/available-methods.md
+++ b/docs/columns/available-methods.md
@@ -153,7 +153,15 @@ The component has the ability to collapse certain columns at different screen si
 
 ![Collapsing](https://imgur.com/z1rWHzP.png)
 
-You have 2 options when it comes to collapsing.
+You have 3 options when it comes to collapsing.
+
+Collapse Always:
+
+```php
+Column::make('Name')
+    ->collapseAlways(),
+```
+The columns will always be collapsed
 
 Collapse on tablet:
 

--- a/resources/views/components/table/row-contents.blade.php
+++ b/resources/views/components/table/row-contents.blade.php
@@ -6,6 +6,10 @@
         $colspan = $component->getColspanCount();
         $columns = collect();
 
+        if($component->shouldCollapseAlways())
+        {
+            $columns->push($component->getCollapsedAlwaysColumns());
+        }
         if ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) {
             $columns->push($component->getCollapsedMobileColumns());
             $columns->push($component->getCollapsedTabletColumns());
@@ -44,8 +48,10 @@
 
                     <p wire:key="{{ $tableName }}-row-{{ $row->{$this->getPrimaryKey()} }}-collapsed-contents-{{ $colIndex }}"
                         @class([
+                            'block mb-2' => $component->isTailwind() && $column->shouldCollapseAlways(),
                             'block mb-2 sm:hidden' => $component->isTailwind() && $column->shouldCollapseOnMobile(),
                             'block mb-2 md:hidden' => $component->isTailwind() && $column->shouldCollapseOnTablet(),
+                            'd-block mb-2' => $component->isBootstrap() && $column->shouldCollapseAlways(),
                             'd-block mb-2 d-sm-none' => $component->isBootstrap() && $column->shouldCollapseOnMobile(),
                             'd-block mb-2 d-md-none' => $component->isBootstrap() && $column->shouldCollapseOnTablet(),
                         ])

--- a/resources/views/components/table/row-contents.blade.php
+++ b/resources/views/components/table/row-contents.blade.php
@@ -53,10 +53,12 @@
                             'block mb-2 sm:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && !$column->shouldCollapseOnMobile(),
                             'block mb-2 md:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && $column->shouldCollapseOnMobile(),
                             'block mb-2 lg:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && ($column->shouldCollapseOnTablet() || $column->shouldCollapseOnMobile()),
+                            
+                            'd-block mb-2' => $component->isTailwind() && $column->shouldCollapseAlways(),
+                            'd-block mb-2 d-sm-none' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && !$column->shouldCollapseOnMobile(),
+                            'd-block mb-2 d-md-none' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && $column->shouldCollapseOnMobile(),
+                            'd-block mb-2 d-lg-none' => $component->isTailwind() && !$column->shouldCollapseAlways() && ($column->shouldCollapseOnTablet() || $column->shouldCollapseOnMobile()),
 
-                            'd-block mb-2' => $component->isBootstrap() && $column->shouldCollapseAlways(),
-                            'd-block mb-2 d-sm-none' => $component->isBootstrap() && $column->shouldCollapseOnMobile(),
-                            'd-block mb-2 d-md-none' => $component->isBootstrap() && $column->shouldCollapseOnTablet(),
                         ])
                     >
                         <strong>{{ $column->getTitle() }}</strong>: {{ $column->renderContents($row) }}

--- a/resources/views/components/table/row-contents.blade.php
+++ b/resources/views/components/table/row-contents.blade.php
@@ -54,10 +54,10 @@
                             'block mb-2 md:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && $column->shouldCollapseOnMobile(),
                             'block mb-2 lg:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && ($column->shouldCollapseOnTablet() || $column->shouldCollapseOnMobile()),
                             
-                            'd-block mb-2' => $component->isTailwind() && $column->shouldCollapseAlways(),
-                            'd-block mb-2 d-sm-none' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && !$column->shouldCollapseOnMobile(),
-                            'd-block mb-2 d-md-none' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && $column->shouldCollapseOnMobile(),
-                            'd-block mb-2 d-lg-none' => $component->isTailwind() && !$column->shouldCollapseAlways() && ($column->shouldCollapseOnTablet() || $column->shouldCollapseOnMobile()),
+                            'd-block mb-2' => $component->isBootstrap() && $column->shouldCollapseAlways(),
+                            'd-block mb-2 d-sm-none' => $component->isBootstrap() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && !$column->shouldCollapseOnMobile(),
+                            'd-block mb-2 d-md-none' => $component->isBootstrap() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && $column->shouldCollapseOnMobile(),
+                            'd-block mb-2 d-lg-none' => $component->isBootstrap() && !$column->shouldCollapseAlways() && ($column->shouldCollapseOnTablet() || $column->shouldCollapseOnMobile()),
 
                         ])
                     >

--- a/resources/views/components/table/row-contents.blade.php
+++ b/resources/views/components/table/row-contents.blade.php
@@ -30,8 +30,8 @@
         wire:loading.class.delay="opacity-50 dark:bg-gray-900 dark:opacity-60"
 
         @class([
-            'hidden md:hidden bg-white dark:bg-gray-700 dark:text-white' => $component->isTailwind(),
-            'd-none d-md-none' => $component->isBootstrap()
+            'hidden bg-white dark:bg-gray-700 dark:text-white' => $component->isTailwind(),
+            'd-none' => $component->isBootstrap()
         ])
     >
         <td
@@ -47,10 +47,13 @@
                     @continue($this->columnSelectIsEnabled() && ! $this->columnSelectIsEnabledForColumn($column))
 
                     <p wire:key="{{ $tableName }}-row-{{ $row->{$this->getPrimaryKey()} }}-collapsed-contents-{{ $colIndex }}"
+                    
                         @class([
                             'block mb-2' => $component->isTailwind() && $column->shouldCollapseAlways(),
-                            'block mb-2 sm:hidden' => $component->isTailwind() && $column->shouldCollapseOnMobile(),
-                            'block mb-2 md:hidden' => $component->isTailwind() && $column->shouldCollapseOnTablet(),
+                            'block mb-2 sm:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && !$column->shouldCollapseOnMobile(),
+                            'block mb-2 md:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && $column->shouldCollapseOnMobile(),
+                            'block mb-2 lg:hidden' => $component->isTailwind() && !$column->shouldCollapseAlways() && ($column->shouldCollapseOnTablet() || $column->shouldCollapseOnMobile()),
+
                             'd-block mb-2' => $component->isBootstrap() && $column->shouldCollapseAlways(),
                             'd-block mb-2 d-sm-none' => $component->isBootstrap() && $column->shouldCollapseOnMobile(),
                             'd-block mb-2 d-md-none' => $component->isBootstrap() && $column->shouldCollapseOnTablet(),

--- a/resources/views/components/table/td.blade.php
+++ b/resources/views/components/table/td.blade.php
@@ -14,6 +14,7 @@
         {{
             $attributes->merge($customAttributes)
                 ->class(['px-6 py-4 whitespace-nowrap text-sm font-medium dark:text-white' => $customAttributes['default'] ?? true])
+                ->class(['hidden' => $column && $column->shouldCollapseAlways()])
                 ->class(['hidden sm:table-cell' => $column && $column->shouldCollapseOnMobile()])
                 ->class(['hidden md:table-cell' => $column && $column->shouldCollapseOnTablet()])
                 ->except('default')
@@ -31,6 +32,7 @@
         {{
             $attributes->merge($customAttributes)
                 ->class(['' => $customAttributes['default'] ?? true])
+                ->class(['d-none' => $column && $column->shouldCollapseAlways()])
                 ->class(['d-none d-sm-table-cell' => $column && $column->shouldCollapseOnMobile()])
                 ->class(['d-none d-md-table-cell' => $column && $column->shouldCollapseOnTablet()])
                 ->except('default')

--- a/resources/views/components/table/td/plain.blade.php
+++ b/resources/views/components/table/td/plain.blade.php
@@ -5,6 +5,7 @@
     <td x-cloak {{ $attributes
         ->merge($customAttributes)
         ->class(['px-6 py-4 whitespace-nowrap text-sm font-medium dark:text-white' => $customAttributes['default'] ?? true])
+        ->class(['hidden' => $column && $column->shouldCollapseAlways()])
         ->class(['hidden sm:table-cell' => $column && $column->shouldCollapseOnMobile()])
         ->class(['hidden md:table-cell' => $column && $column->shouldCollapseOnTablet()])
         ->except('default')
@@ -15,6 +16,7 @@
     <td {{ $attributes
         ->merge($customAttributes)
         ->class(['' => $customAttributes['default'] ?? true])
+        ->class(['d-none' => $column && $column->shouldCollapseAlways()])
         ->class(['d-none d-sm-table-cell' => $column && $column->shouldCollapseOnMobile()])
         ->class(['d-none d-md-table-cell' => $column && $column->shouldCollapseOnTablet()])
         ->except('default')

--- a/resources/views/components/table/td/row-contents.blade.php
+++ b/resources/views/components/table/td/row-contents.blade.php
@@ -3,8 +3,7 @@
 
 @if ($component->collapsingColumnsAreEnabled() && $component->hasCollapsedColumns())
     @if ($component->isTailwind())
-        <td
-            @if (! $hidden) x-data="{open:false}" @endif
+        <td x-data="{open:false}" wire:key="{{ $tableName }}-collapsingIcon-{{ $rowIndex }}-{{ md5(now()) }}"
             {{
                 $attributes
                     ->merge(['class' => 'p-3 table-cell text-center '])
@@ -17,7 +16,7 @@
             @if (! $hidden)
                 <button
                     x-show="!currentlyReorderingStatus"
-                    x-on:click.prevent="$dispatch('toggle-row-content', {'row': {{ $rowIndex }}});open = !open"
+                    x-on:click.prevent="$dispatch('toggle-row-content', {'row': {{ $rowIndex }}}); open = !open"
                 >
                     <x-heroicon-o-plus-circle x-show="!open" class="text-green-600 h-6 w-6" />
                     <x-heroicon-o-minus-circle x-cloak x-show="open" class="text-yellow-600 h-6 w-6" />
@@ -25,14 +24,14 @@
             @endif
         </td>
     @elseif ($component->isBootstrap())
-        <td :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
-            @if (! $hidden) x-data="{open:false}" @endif
+        <td x-data="{open:false}" wire:key="{{ $tableName }}-collapsingIcon-{{ $rowIndex }}-{{ md5(now()) }}" 
             {{
                 $attributes
                     ->class(['d-sm-none' => !$component->shouldCollapseAlways() && !$component->shouldCollapseOnTablet()])
                     ->class(['d-md-none' => !$component->shouldCollapseAlways() && !$component->shouldCollapseOnTablet() && $component->shouldCollapseOnMobile()])
                     ->class(['d-lg-none' => !$component->shouldCollapseAlways() && ($component->shouldCollapseOnTablet() || $component->shouldCollapseOnMobile())])
             }}
+            :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
         >
             @if (! $hidden)
                 <button

--- a/resources/views/components/table/td/row-contents.blade.php
+++ b/resources/views/components/table/td/row-contents.blade.php
@@ -29,14 +29,9 @@
             @if (! $hidden) x-data="{open:false}" @endif
             {{
                 $attributes
-                    ->class(['d-none' => !$component->shouldCollapseAlways()])
-                    ->class([
-                        'd-md-none' => !$component->shouldCollapseAlways() && (
-                            ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
-                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile())
-                        )
-                    ])
-                    ->class(['d-sm-none' => !$component->shouldCollapseAlways() && $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
+                    ->class(['d-sm-none' => !$component->shouldCollapseAlways() && !$component->shouldCollapseOnTablet()])
+                    ->class(['d-md-none' => !$component->shouldCollapseAlways() && !$component->shouldCollapseOnTablet() && $component->shouldCollapseOnMobile()])
+                    ->class(['d-lg-none' => !$component->shouldCollapseAlways() && ($component->shouldCollapseOnTablet() || $component->shouldCollapseOnMobile())])
             }}
         >
             @if (! $hidden)

--- a/resources/views/components/table/td/row-contents.blade.php
+++ b/resources/views/components/table/td/row-contents.blade.php
@@ -7,15 +7,10 @@
             @if (! $hidden) x-data="{open:false}" @endif
             {{
                 $attributes
-                    ->merge(['class' => 'p-3 table-cell text-center'])
-                    ->class([
-                        'md:hidden' =>
-                            !$component->shouldCollapseAlways() && (
-                            ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
-                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile())
-                            )
-                    ])
-                    ->class(['sm:hidden' => !$component->shouldCollapseAlways() &&  $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
+                    ->merge(['class' => 'p-3 table-cell text-center '])
+                    ->class(['sm:hidden' => !$component->shouldCollapseAlways() && !$component->shouldCollapseOnTablet()])
+                    ->class(['md:hidden' => !$component->shouldCollapseAlways() && !$component->shouldCollapseOnTablet() && $component->shouldCollapseOnMobile()])
+                    ->class(['lg:hidden' => !$component->shouldCollapseAlways() && ($component->shouldCollapseOnTablet() || $component->shouldCollapseOnMobile())])
             }}
             :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
         >
@@ -34,6 +29,7 @@
             @if (! $hidden) x-data="{open:false}" @endif
             {{
                 $attributes
+                    ->class(['d-none' => !$component->shouldCollapseAlways()])
                     ->class([
                         'd-md-none' => !$component->shouldCollapseAlways() && (
                             ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||

--- a/resources/views/components/table/td/row-contents.blade.php
+++ b/resources/views/components/table/td/row-contents.blade.php
@@ -10,10 +10,12 @@
                     ->merge(['class' => 'p-3 table-cell text-center'])
                     ->class([
                         'md:hidden' =>
-                            (($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
-                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile()))
+                            !$component->shouldCollapseAlways() && (
+                            ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
+                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile())
+                            )
                     ])
-                    ->class(['sm:hidden' => $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
+                    ->class(['sm:hidden' => !$component->shouldCollapseAlways() &&  $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
             }}
             :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
         >
@@ -33,11 +35,12 @@
             {{
                 $attributes
                     ->class([
-                        'd-md-none' =>
-                            (($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
-                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile()))
+                        'd-md-none' => !$component->shouldCollapseAlways() && (
+                            ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
+                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile())
+                        )
                     ])
-                    ->class(['d-sm-none' => $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
+                    ->class(['d-sm-none' => !$component->shouldCollapseAlways() && $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
             }}
         >
             @if (! $hidden)

--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -12,6 +12,7 @@
     <th scope="col" {{
         $attributes->merge($customAttributes)
             ->class(['px-6 py-3 text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase tracking-wider dark:bg-gray-800 dark:text-gray-400' => $customAttributes['default'] ?? true])
+            ->class(['hidden' => $column->shouldCollapseAlways()])
             ->class(['hidden sm:table-cell' => $column->shouldCollapseOnMobile()])
             ->class(['hidden md:table-cell' => $column->shouldCollapseOnTablet()])
             ->except('default')
@@ -48,6 +49,7 @@
     <th scope="col" {{
         $attributes->merge($customAttributes)
             ->class(['' => $customAttributes['default'] ?? true])
+            ->class(['d-none' => $column->shouldCollapseAlways()])
             ->class(['d-none d-sm-table-cell' => $column->shouldCollapseOnMobile()])
             ->class(['d-none d-md-table-cell' => $column->shouldCollapseOnTablet()])
             ->except('default')

--- a/resources/views/components/table/th/row-contents.blade.php
+++ b/resources/views/components/table/th/row-contents.blade.php
@@ -8,11 +8,12 @@
                 $attributes
                     ->merge(['class' => 'table-cell dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised'])
                     ->class([
-                        'md:hidden' =>
-                            (($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
-                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile()))
+                        'md:hidden' => !$component->shouldCollapseAlways() && (
+                            ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
+                            ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile())
+                        )
                     ])
-                    ->class(['sm:hidden' => $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
+                    ->class(['sm:hidden' => !$component->shouldCollapseAlways() && $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
             }}
             :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }"
         ></th>
@@ -23,11 +24,11 @@
                 $attributes
                     ->merge(['class' => 'd-table-cell laravel-livewire-tables-reorderingMinimised'])
                     ->class([
-                        'd-md-none' =>
-                            (($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
+                        'd-md-none' => !$component->shouldCollapseAlways() && 
+                            ( ($component->shouldCollapseOnMobile() && $component->shouldCollapseOnTablet()) ||
                             ($component->shouldCollapseOnTablet() && ! $component->shouldCollapseOnMobile()))
                     ])
-                    ->class(['d-sm-none' => $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
+                    ->class(['d-sm-none' => !$component->shouldCollapseAlways() && $component->shouldCollapseOnMobile() && ! $component->shouldCollapseOnTablet()])
             }}
             :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }"
         ></th>

--- a/resources/views/components/table/tr/footer.blade.php
+++ b/resources/views/components/table/tr/footer.blade.php
@@ -18,6 +18,7 @@
     @foreach($this->getColumns() as $colIndex => $column)
         @continue($column->isHidden())
         @continue($this->columnSelectIsEnabled() && ! $this->columnSelectIsEnabledForColumn($column))
+        @continue($column->isReorderColumn() && !$this->getCurrentlyReorderingStatus())
 
         @if($column->isReorderColumn())
             <x-livewire-tables::table.td.plain :column="$column" :displayMinimisedOnReorder="false"  wire:key="{{ $tableName .'-footer-'.$colIndex.'-show' }}"   :customAttributes="$this->getFooterTdAttributes($column, $rows, $colIndex)" />

--- a/resources/views/components/table/tr/secondary-header.blade.php
+++ b/resources/views/components/table/tr/secondary-header.blade.php
@@ -19,13 +19,10 @@
     @foreach($this->getColumns() as $colIndex => $column)
         @continue($column->isHidden())
         @continue($this->columnSelectIsEnabled() && ! $this->columnSelectIsEnabledForColumn($column))
+        @continue($column->isReorderColumn() && !$this->getCurrentlyReorderingStatus())
 
-        @if($column->isReorderColumn())
-            <x-livewire-tables::table.td.plain :column="$column" :displayMinimisedOnReorder="false"  :customAttributes="$this->getSecondaryHeaderTdAttributes($column, $rows, $colIndex)" />
-        @else
-            <x-livewire-tables::table.td.plain :column="$column" :displayMinimisedOnReorder="true" wire:key="{{ $tableName .'-secondary-header-show-'.$column->getSlug() }}"  :customAttributes="$this->getSecondaryHeaderTdAttributes($column, $rows, $colIndex)">
-                {{ $column->getSecondaryHeaderContents($rows) }}
-            </x-livewire-tables::table.td.plain>
-        @endif
+        <x-livewire-tables::table.td.plain :column="$column" :displayMinimisedOnReorder="true" wire:key="{{ $tableName .'-secondary-header-show-'.$column->getSlug() }}"  :customAttributes="$this->getSecondaryHeaderTdAttributes($column, $rows, $colIndex)">
+            {{ $column->getSecondaryHeaderContents($rows) }}
+        </x-livewire-tables::table.td.plain>
     @endforeach
 </x-livewire-tables::table.tr.plain>

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -21,12 +21,9 @@
                 @foreach($columns as $index => $column)
                     @continue($column->isHidden())
                     @continue($this->columnSelectIsEnabled() && ! $this->columnSelectIsEnabledForColumn($column))
+                    @continue($column->isReorderColumn() && !$this->getCurrentlyReorderingStatus())
 
-                    @if($column->isReorderColumn())
-                        <x-livewire-tables::table.th wire:key="{{ $tableName.'-table-head-'.$index }}" :displayMinimisedOnReorder="true" :column="$column" :index="$index" />
-                    @else
-                        <x-livewire-tables::table.th wire:key="{{ $tableName.'-table-head-'.$index }}" :column="$column" :index="$index" />
-                    @endif
+                    <x-livewire-tables::table.th wire:key="{{ $tableName.'-table-head-'.$index }}" :column="$column" :index="$index" />
                 @endforeach
             </x-slot>
 
@@ -45,16 +42,11 @@
                     @foreach($columns as $colIndex => $column)
                         @continue($column->isHidden())
                         @continue($this->columnSelectIsEnabled() && ! $this->columnSelectIsEnabledForColumn($column))
+                        @continue($column->isReorderColumn() && !$this->getCurrentlyReorderingStatus())
 
-                        @if($column->isReorderColumn())
-                            <x-livewire-tables::table.td :displayMinimisedOnReorder="true"  wire:key="{{ $tableName . '-' . $row->{$this->getPrimaryKey()} . '-datatable-reorder-' . $column->getSlug() }}"  :column="$column" :colIndex="$colIndex">
-                                {{ $column->renderContents($row) }}
-                            </x-livewire-tables::table.td>
-                        @else
-                            <x-livewire-tables::table.td wire:key="{{ $tableName . '-' . $row->{$this->getPrimaryKey()} . '-datatable-td-' . $column->getSlug() }}"  :column="$column" :colIndex="$colIndex">
-                                {{ $column->renderContents($row) }}
-                            </x-livewire-tables::table.td>
-                        @endif
+                        <x-livewire-tables::table.td wire:key="{{ $tableName . '-' . $row->{$this->getPrimaryKey()} . '-datatable-td-' . $column->getSlug() }}"  :column="$column" :colIndex="$colIndex">
+                            {{ $column->renderContents($row) }}
+                        </x-livewire-tables::table.td>
                     @endforeach
                 </x-livewire-tables::table.tr>
 

--- a/src/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Traits/Configuration/ColumnConfiguration.php
@@ -43,4 +43,12 @@ trait ColumnConfiguration
                 return $column;
             });
     }
+
+    public function unsetCollapsedStatuses(): void
+    {
+        unset($this->shouldAlwaysCollapse);
+        unset($this->shouldMobileCollapse);
+        unset($this->shouldTabletCollapse);
+    }
+
 }

--- a/src/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Traits/Configuration/ColumnConfiguration.php
@@ -50,5 +50,4 @@ trait ColumnConfiguration
         unset($this->shouldMobileCollapse);
         unset($this->shouldTabletCollapse);
     }
-
 }

--- a/src/Traits/WithColumns.php
+++ b/src/Traits/WithColumns.php
@@ -17,6 +17,18 @@ trait WithColumns
 
     protected Collection $appendedColumns;
 
+    protected ?bool $shouldAlwaysCollapse;
+
+    protected ?bool $shouldMobileCollapse;
+
+    protected ?bool $shouldTabletCollapse;
+
+    public array $columnSelectStats2;
+
+    public int $defaultVisibleColumnCount;
+
+    public int $visibleColumnCount;
+
     public function bootWithColumns(): void
     {
         $this->columns = collect();

--- a/src/Views/Column.php
+++ b/src/Views/Column.php
@@ -46,6 +46,8 @@ class Column
 
     protected bool $collapseOnTablet = false;
 
+    protected bool $collapseAlways = false;
+
     protected ?string $sortingPillTitle = null;
 
     protected ?string $sortingPillDirectionAsc = null;

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -197,6 +197,18 @@ trait ColumnHelpers
         return $this->collapseOnTablet;
     }
 
+    public function collapseAlways(): self
+    {
+        $this->collapseAlways = true;
+
+        return $this;
+    }
+
+    public function shouldCollapseAlways(): bool
+    {
+        return $this->collapseAlways;
+    }
+
     public function getSortingPillTitle(): string
     {
         if ($this->hasCustomSortingPillTitle()) {

--- a/tests/Traits/Helpers/ColumnHelpersTest.php
+++ b/tests/Traits/Helpers/ColumnHelpersTest.php
@@ -75,6 +75,8 @@ class ColumnHelpersTest extends TestCase
 
         $this->basicTable->getColumnBySelectName('id')->collapseOnMobile();
 
+        $this->basicTable->unsetCollapsedStatuses();
+
         $this->assertTrue($this->basicTable->getColumnBySelectName('id')->shouldCollapseOnMobile());
 
         $this->assertTrue($this->basicTable->hasCollapsedColumns());
@@ -87,6 +89,8 @@ class ColumnHelpersTest extends TestCase
 
         $this->basicTable->getColumnBySelectName('id')->collapseOnMobile();
 
+        $this->basicTable->unsetCollapsedStatuses();
+
         $this->assertTrue($this->basicTable->shouldCollapseOnMobile());
     }
 
@@ -98,8 +102,9 @@ class ColumnHelpersTest extends TestCase
         $this->basicTable->getColumnBySelectName('id')->collapseOnMobile();
         $this->basicTable->getColumnBySelectName('name')->collapseOnMobile();
 
-        $this->assertCount(2, $this->basicTable->getCollapsedMobileColumns());
+        $this->basicTable->unsetCollapsedStatuses();
 
+        $this->assertCount(2, $this->basicTable->getCollapsedMobileColumns());
         $this->assertSame('ID', $this->basicTable->getCollapsedMobileColumns()[0]->getTitle());
         $this->assertSame('Name', $this->basicTable->getCollapsedMobileColumns()[1]->getTitle());
     }
@@ -112,6 +117,8 @@ class ColumnHelpersTest extends TestCase
         $this->basicTable->getColumnBySelectName('id')->collapseOnMobile();
         $this->basicTable->getColumnBySelectName('name')->collapseOnMobile();
 
+        $this->basicTable->unsetCollapsedStatuses();
+
         $this->assertSame(2, $this->basicTable->getCollapsedMobileColumnsCount());
     }
 
@@ -122,6 +129,8 @@ class ColumnHelpersTest extends TestCase
 
         $this->basicTable->getColumnBySelectName('id')->collapseOnMobile();
         $this->basicTable->getColumnBySelectName('name')->collapseOnMobile();
+
+        $this->basicTable->unsetCollapsedStatuses();
 
         $this->assertCount(7, $this->basicTable->getVisibleMobileColumns());
         $this->assertSame('Sort', $this->basicTable->getVisibleMobileColumns()->values()[0]->getTitle());
@@ -148,6 +157,8 @@ class ColumnHelpersTest extends TestCase
 
         $this->basicTable->getColumnBySelectName('id')->collapseOnTablet();
 
+        $this->basicTable->unsetCollapsedStatuses();
+
         $this->assertTrue($this->basicTable->shouldCollapseOnTablet());
     }
 
@@ -158,6 +169,8 @@ class ColumnHelpersTest extends TestCase
 
         $this->basicTable->getColumnBySelectName('id')->collapseOnTablet();
         $this->basicTable->getColumnBySelectName('name')->collapseOnTablet();
+
+        $this->basicTable->unsetCollapsedStatuses();
 
         $this->assertCount(2, $this->basicTable->getCollapsedTabletColumns());
         $this->assertSame('ID', $this->basicTable->getCollapsedTabletColumns()[0]->getTitle());
@@ -172,6 +185,8 @@ class ColumnHelpersTest extends TestCase
         $this->basicTable->getColumnBySelectName('id')->collapseOnTablet();
         $this->basicTable->getColumnBySelectName('name')->collapseOnTablet();
 
+        $this->basicTable->unsetCollapsedStatuses();
+
         $this->assertSame(2, $this->basicTable->getCollapsedTabletColumnsCount());
     }
 
@@ -182,6 +197,8 @@ class ColumnHelpersTest extends TestCase
 
         $this->basicTable->getColumnBySelectName('id')->collapseOnTablet();
         $this->basicTable->getColumnBySelectName('name')->collapseOnTablet();
+
+        $this->basicTable->unsetCollapsedStatuses();
 
         $this->assertCount(7, $this->basicTable->getVisibleTabletColumns());
         $this->assertSame('Sort', $this->basicTable->getVisibleTabletColumns()->values()[0]->getTitle());
@@ -198,7 +215,50 @@ class ColumnHelpersTest extends TestCase
         $this->basicTable->getColumnBySelectName('id')->collapseOnTablet();
         $this->basicTable->getColumnBySelectName('name')->collapseOnTablet();
 
+        $this->basicTable->unsetCollapsedStatuses();
+
         $this->assertSame(7, $this->basicTable->getVisibleTabletColumnsCount());
+    }
+
+    /// *** ** //
+
+    public function can_tell_if_columns_should_collapse_always(): void
+    {
+        $this->assertFalse($this->basicTable->shouldCollapseAlways());
+
+        $this->basicTable->getColumnBySelectName('id')->collapseAlways();
+
+        $this->basicTable->unsetCollapsedStatuses();
+
+        $this->assertTrue($this->basicTable->shouldCollapseAlways());
+    }
+
+    /** @test */
+    public function can_get_always_collapsed_columns(): void
+    {
+        $this->assertCount(0, $this->basicTable->getCollapsedAlwaysColumns());
+
+        $this->basicTable->getColumnBySelectName('id')->collapseAlways();
+        $this->basicTable->getColumnBySelectName('name')->collapseAlways();
+
+        $this->basicTable->unsetCollapsedStatuses();
+
+        $this->assertCount(2, $this->basicTable->getCollapsedAlwaysColumns());
+        $this->assertSame('ID', $this->basicTable->getCollapsedAlwaysColumns()[0]->getTitle());
+        $this->assertSame('Name', $this->basicTable->getCollapsedAlwaysColumns()[1]->getTitle());
+    }
+
+    /** @test */
+    public function can_get_always_collapsed_columns_count(): void
+    {
+        $this->assertSame(0, $this->basicTable->getCollapsedAlwaysColumnsCount());
+
+        $this->basicTable->getColumnBySelectName('id')->collapseAlways();
+        $this->basicTable->getColumnBySelectName('name')->collapseAlways();
+
+        $this->basicTable->unsetCollapsedStatuses();
+
+        $this->assertSame(2, $this->basicTable->getCollapsedAlwaysColumnsCount());
     }
 
     /** @test */


### PR DESCRIPTION
This PR changes the blade approach for collapsing columns, and adds a "collapseAlways()" option for Columns.

In addition, this PR restores the behaviour of the Reorder Column, allowing it to be hidden when reordering is not active (as previously configurable in v2)

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
