### PR TITLE
v3 - Full Page Table Component Options

### DIFF
--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -129,11 +129,30 @@ abstract class DataTableComponent extends Component
         $this->setupFooter();
         $this->setupReordering();
 
-        return view('livewire-tables::datatable')
-            ->with([
-                'columns' => $this->getColumns(),
-                'rows' => $this->getRows(),
-                'customView' => $this->customView(),
-            ]);
+        $view = view('livewire-tables::datatable');
+
+        if (isset($this->layout)){
+            $view->layout($this->layout);
+        }
+
+        if (isset($this->extends)){
+            $view->extends($this->extends);
+        }
+
+        if (isset($this->section)){
+            $view->section($this->section);
+        }
+
+        if (isset($this->slot)){
+            $view->section($this->slot);
+        }
+
+        $view->with([
+            'columns' => $this->getColumns(),
+            'rows' => $this->getRows(),
+            'customView' => $this->customView(),
+        ]);
+
+        return $view;
     }
 }

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -131,20 +131,20 @@ abstract class DataTableComponent extends Component
 
         $view = view('livewire-tables::datatable');
 
-        if (isset($this->layout)){
+        if ($this->hasLayout()){
             $view->layout($this->layout);
         }
 
-        if (isset($this->extends)){
+        if ($this->hasExtends()){
             $view->extends($this->extends);
         }
 
-        if (isset($this->section)){
+        if ($this->hasSection()){
             $view->section($this->section);
         }
 
-        if (isset($this->slot)){
-            $view->section($this->slot);
+        if ($this->hasSlot()){
+            $view->slot($this->slot);
         }
 
         $view->with([

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -54,6 +54,14 @@ trait ComponentUtilities
 
     protected $tdAttributesCallback;
 
+    protected string $layout;
+
+    protected string $slot;
+
+    protected string $extends;
+
+    protected string $section;
+
     protected bool $collapsingColumnsStatus = true;
 
     protected string $emptyMessage = 'No items found. Try to broaden your search.';

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -54,13 +54,13 @@ trait ComponentUtilities
 
     protected $tdAttributesCallback;
 
-    protected string $layout;
+    protected ?string $layout = null;
 
-    protected string $slot;
+    protected ?string $slot = null;
 
-    protected string $extends;
+    protected ?string $extends = null;
 
-    protected string $section;
+    protected ?string $section = null;
 
     protected bool $collapsingColumnsStatus = true;
 

--- a/src/Traits/Configuration/ComponentConfiguration.php
+++ b/src/Traits/Configuration/ComponentConfiguration.php
@@ -247,4 +247,32 @@ trait ComponentConfiguration
 
         return $this;
     }
+
+    public function setLayout(string $layout): self
+    {
+        $this->layout = $layout;
+
+        return $this;
+    }
+
+    public function setSlot(string $slot): self
+    {
+        $this->slot = $slot;
+
+        return $this;
+    }
+
+    public function setExtends(string $layout): self
+    {
+        $this->extends = $layout;
+
+        return $this;
+    }
+
+    public function setSection(string $section): self
+    {
+        $this->section = $section;
+
+        return $this;
+    }
 }

--- a/src/Traits/Configuration/ComponentConfiguration.php
+++ b/src/Traits/Configuration/ComponentConfiguration.php
@@ -275,4 +275,32 @@ trait ComponentConfiguration
 
         return $this;
     }
+
+    public function setLayout(string $layout): self
+    {
+        $this->layout = $layout;
+
+        return $this;
+    }
+
+    public function setSlot(string $slot): self
+    {
+        $this->slot = $slot;
+
+        return $this;
+    }
+
+    public function setExtends(string $layout): self
+    {
+        $this->extends = $layout;
+
+        return $this;
+    }
+
+    public function setSection(string $section): self
+    {
+        $this->section = $section;
+
+        return $this;
+    }
 }

--- a/src/Traits/Configuration/ComponentConfiguration.php
+++ b/src/Traits/Configuration/ComponentConfiguration.php
@@ -275,32 +275,4 @@ trait ComponentConfiguration
 
         return $this;
     }
-
-    public function setLayout(string $layout): self
-    {
-        $this->layout = $layout;
-
-        return $this;
-    }
-
-    public function setSlot(string $slot): self
-    {
-        $this->slot = $slot;
-
-        return $this;
-    }
-
-    public function setExtends(string $layout): self
-    {
-        $this->extends = $layout;
-
-        return $this;
-    }
-
-    public function setSection(string $section): self
-    {
-        $this->section = $section;
-
-        return $this;
-    }
 }

--- a/src/Traits/Helpers/ComponentHelpers.php
+++ b/src/Traits/Helpers/ComponentHelpers.php
@@ -57,9 +57,19 @@ trait ComponentHelpers
         return $this->model;
     }
 
+    public function hasExtends()
+    {
+        return $this->extends !== null;
+    }
+
     public function getExtends()
     {
         return $this->extends;
+    }
+
+    public function hasSection()
+    {
+        return $this->section !== null;
     }
 
     public function getSection()
@@ -67,9 +77,19 @@ trait ComponentHelpers
         return $this->section;
     }
 
+    public function hasSlot()
+    {
+        return $this->slot !== null;
+    }
+
     public function getSlot()
     {
         return $this->slot;
+    }
+
+    public function hasLayout()
+    {
+        return $this->layout !== null;
     }
 
     public function getLayout()

--- a/src/Traits/Helpers/ComponentHelpers.php
+++ b/src/Traits/Helpers/ComponentHelpers.php
@@ -57,6 +57,26 @@ trait ComponentHelpers
         return $this->model;
     }
 
+    public function getExtends()
+    {
+        return $this->extends;
+    }
+
+    public function getSection()
+    {
+        return $this->section;
+    }
+
+    public function getSlot()
+    {
+        return $this->slot;
+    }
+
+    public function getLayout()
+    {
+        return $this->layout;
+    }
+
     public function setTheme(): void
     {
         $theme = $this->getTheme();

--- a/tests/Traits/Configuration/ComponentConfigurationTest.php
+++ b/tests/Traits/Configuration/ComponentConfigurationTest.php
@@ -138,6 +138,34 @@ class ComponentConfigurationTest extends TestCase
     }
 
     /** @test */
+    public function can_set_extends(): void
+    {
+        $this->basicTable->setExtends('app.layout');
+        $this->assertEquals('app.layout', $this->basicTable->getExtends());
+    }
+
+    /** @test */
+    public function can_set_layout(): void
+    {
+        $this->basicTable->setLayout('app.layout');
+        $this->assertEquals('app.layout', $this->basicTable->getLayout());
+    }
+
+    /** @test */
+    public function can_set_section(): void
+    {
+        $this->basicTable->setSection('content');
+        $this->assertEquals('content', $this->basicTable->getSection());
+    }
+
+    /** @test */
+    public function can_set_slot(): void
+    {
+        $this->basicTable->setSlot('my_slot');
+        $this->assertEquals('my_slot', $this->basicTable->getSlot());
+    }
+
+    /** @test */
     public function can_set_offline_indicator_status(): void
     {
         $this->assertTrue($this->basicTable->getOfflineIndicatorStatus());


### PR DESCRIPTION
This PR adds different configuration options for setting up a full-page component for livewire
https://livewire.laravel.com/docs/components#full-page-components

The following methods have been added:

- `setLayout` for setting layout for component (https://livewire.laravel.com/docs/components#per-component-layout-configuration)
- `setSlot`
- `setExtends`
- `setSection`
