### PR TITLE
v3 - Column - Allow Enum in ReturnType for Column getContent/renderContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## UNRELEASED
+- Fix Return Type hinting to allow Enum columns
+
 ## [3.0.0-beta.4] - 2023-10-17
 - Introduction of Loading Placeholder
 - Docs livewire namespace fix [Here](https://github.com/rappasoft/laravel-livewire-tables/pull/1420)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## UNRELEASED
-- Fix Return Type hinting to allow Enum columns
+- Fix Return Type hinting for Column Rendering to allow Enum columns
 
 ## [3.0.0-beta.4] - 2023-10-17
 - Introduction of Loading Placeholder

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -93,7 +93,7 @@ trait ColumnHelpers
     }
 
     // TODO: Test
-    public function renderContents(Model $row): null|string|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    public function renderContents(Model $row): mixed
     {
         if ($this->shouldCollapseOnMobile() && $this->shouldCollapseOnTablet()) {
             throw new DataTableConfigurationException('You should only specify a columns should collapse on mobile OR tablet, not both.');
@@ -102,8 +102,8 @@ trait ColumnHelpers
         return $this->getContents($row);
     }
 
-    // TODO: Test
-    public function getContents(Model $row): null|string|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    // TODO: Improve TypeHinting & Tests
+    public function getContents(Model $row): mixed
     {
         if ($this->isLabel()) {
             $value = call_user_func($this->getLabelCallback(), $row, $this);

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -93,7 +93,7 @@ trait ColumnHelpers
     }
 
     // TODO: Test
-    public function renderContents(Model $row): mixed
+    public function renderContents(Model $row): null|string|\BackedEnum|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         if ($this->shouldCollapseOnMobile() && $this->shouldCollapseOnTablet()) {
             throw new DataTableConfigurationException('You should only specify a columns should collapse on mobile OR tablet, not both.');
@@ -102,8 +102,8 @@ trait ColumnHelpers
         return $this->getContents($row);
     }
 
-    // TODO: Improve TypeHinting & Tests
-    public function getContents(Model $row): mixed
+    // TODO: Test
+    public function getContents(Model $row): null|string|\BackedEnum|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         if ($this->isLabel()) {
             $value = call_user_func($this->getLabelCallback(), $row, $this);


### PR DESCRIPTION
This fix is to allow casted columns via Enum.

Tests for this will follow in future versions.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
