### PR TITLE
Fix for setFilter - allows setting values at mount/boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## UNRELEASED
+- Fix for setFilter (allowing setFilter at boot/mount)
+
+## [3.0.0-beta.7] - 2023-10-25
 - Add wire:navigate option for clickable rows
 
 ## [3.0.0-beta.6] - 2023-10-25

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -132,14 +132,16 @@ trait FilterHelpers
     }
 
     /**
-     * @param  mixed  $value
-     * @return mixed
+     * @param  string $filterKey
+     * @param  mixed $value
+     * @return void
      */
     #[On('set-filter')]
-    public function setFilter(string $filterKey, $value)
+    public function setFilter(string $filterKey, mixed $value): void
     {
-        return $this->appliedFilters[$filterKey] = $this->filterComponents[$filterKey] = $value;
+        $this->appliedFilters[$filterKey] = $this->filterComponents[$filterKey] = $value;
     }
+
 
     public function selectAllFilterOptions(string $filterKey): void
     {

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -138,7 +138,7 @@ trait FilterHelpers
     #[On('set-filter')]
     public function setFilter(string $filterKey, $value)
     {
-        return $this->filterComponents[$filterKey] = $value;
+        return $this->appliedFilters[$filterKey] = $this->filterComponents[$filterKey] = $value;
     }
 
     public function selectAllFilterOptions(string $filterKey): void

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -131,17 +131,11 @@ trait FilterHelpers
         });
     }
 
-    /**
-     * @param  string $filterKey
-     * @param  mixed $value
-     * @return void
-     */
     #[On('set-filter')]
     public function setFilter(string $filterKey, mixed $value): void
     {
         $this->appliedFilters[$filterKey] = $this->filterComponents[$filterKey] = $value;
     }
-
 
     public function selectAllFilterOptions(string $filterKey): void
     {


### PR DESCRIPTION
Addresses a bug where the split approach does not update both arrays, causing the filter to not actually apply correctly when set on boot/mount

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
