### PR TITLE
Fix ColorColumn for Bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## UNRELEASED
+### Bug Fixes
+- Fix ColorColumn display on Bootstrap
+
 ## [v3.1.5] - 2023-12-09
 ### New Features
 - Add capability to use as a Full Page Component by @amshehzad and @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1580

--- a/resources/views/includes/columns/color.blade.php
+++ b/resources/views/includes/columns/color.blade.php
@@ -1,10 +1,11 @@
 <div @class([
                 'items-center content-center place-content-center place-items-center' => $isTailwind,
+                'p-4' => !$isTailwind
             ])
 >
     <div {{ $attributeBag->class([
             'h-6 w-6 rounded-md self-center' => $isTailwind && ($attributeBag['default'] ?? (empty($attributeBag['class']) || (!empty($attributeBag['class']) && ($attributeBag['default'] ?? false)))),
-            
+            'w-100 p-4 mb-4' => !$isTailwind && ($attributeBag['default'] ?? (empty($attributeBag['class']) || (!empty($attributeBag['class']) && ($attributeBag['default'] ?? false)))),
         ]) }}
         @style([
             "background-color: {$color}" => $color,


### PR DESCRIPTION
This adds some missing default classes for the ColorColumn when using Bootstrap.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
