### PR TITLE
Change traits to booted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## UNRELEASED
 ### Bug Fixes
-- Ensure mount() is called prior to bundler() executing
+- Ensure mount() is called prior to bundler() executing by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1603
 
 ## [v3.1.5] - 2023-12-09
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## UNRELEASED
+### Bug Fixes
+- Ensure mount() is called prior to bundler() executing
+
 ## [v3.1.5] - 2023-12-09
 ### New Features
 - Add capability to use as a Full Page Component by @amshehzad and @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1580

--- a/docs/misc/lifecycle-hooks.md
+++ b/docs/misc/lifecycle-hooks.md
@@ -8,10 +8,10 @@ With the migration to Livewire 3, there we are implementing several Lifecycle Ho
 You may use these either in your Table Component, or in a trait
 
 ## configuring
-This is called immediately prior to the configure() method being called
+This is called immediately prior to the configure() method being called.  This will be overridden by anything you define in configure()
 
 ## configured
-This is called immediately after the configure() method is called
+This is called immediately after the configure() method is called.  This will override anything you define in configure()
 
 ## settingColumns
 This is called prior to setting up the available Columns via the columns() method

--- a/resources/laravel-livewire-tables.js
+++ b/resources/laravel-livewire-tables.js
@@ -1,2 +1,2 @@
 import './css/laravel-livewire-tables.min.css'
-import './js/laravel-livewire-tables.js'
+import './js/laravel-livewire-tables.min.js'

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -56,7 +56,7 @@ trait ComponentUtilities
     /**
      * Runs configure() with Lifecycle Hooks on each Lifecycle
      */
-    public function bootComponentUtilities(): void
+    public function bootedComponentUtilities(): void
     {
         // Fire Lifecycle Hooks for configuring
         $this->callHook('configuring');

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -45,7 +45,7 @@ trait WithColumnSelect
         return [];
     }
 
-    public function bootWithColumnSelect(): void
+    public function bootedWithColumnSelect(): void
     {
         $this->setupColumnSelect();
     }

--- a/src/Traits/WithColumns.php
+++ b/src/Traits/WithColumns.php
@@ -31,7 +31,7 @@ trait WithColumns
     /**
      * Sets up Columns
      */
-    public function bootWithColumns(): void
+    public function bootedWithColumns(): void
     {
         $this->columns = collect();
 

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -18,7 +18,7 @@ trait WithData
     /**
      * Sets up the Builder instance
      */
-    public function bootWithData(): void
+    public function bootedWithData(): void
     {
         //Sets up the Builder Instance
         $this->setBuilder($this->builder());

--- a/src/Traits/WithSecondaryHeader.php
+++ b/src/Traits/WithSecondaryHeader.php
@@ -18,6 +18,11 @@ trait WithSecondaryHeader
 
     protected $secondaryHeaderTdAttributesCallback;
 
+    public function bootedWithSecondaryHeader(): void
+    {
+        $this->setupSecondaryHeader();
+    }
+
     public function setupSecondaryHeader(): void
     {
         foreach ($this->getColumns() as $column) {
@@ -27,8 +32,4 @@ trait WithSecondaryHeader
         }
     }
 
-    public function bootWithSecondaryHeader(): void
-    {
-        $this->setupSecondaryHeader();
-    }
 }

--- a/src/Traits/WithSecondaryHeader.php
+++ b/src/Traits/WithSecondaryHeader.php
@@ -31,5 +31,4 @@ trait WithSecondaryHeader
             }
         }
     }
-
 }

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -3,8 +3,8 @@
 namespace Rappasoft\LaravelLivewireTables\Tests;
 
 use Livewire\Livewire;
-use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\NoPrimaryKeyTable;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\NoColumnsTable;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\NoPrimaryKeyTable;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 
 class DataTableComponentTest extends TestCase
@@ -98,5 +98,4 @@ class DataTableComponentTest extends TestCase
         $table->render();
 
     }
-    
 }

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -4,6 +4,7 @@ namespace Rappasoft\LaravelLivewireTables\Tests;
 
 use Livewire\Livewire;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\NoPrimaryKeyTable;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\NoColumnsTable;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 
 class DataTableComponentTest extends TestCase
@@ -79,4 +80,23 @@ class DataTableComponentTest extends TestCase
         // control
         $this->assertTrue(filter_var('http://[9/$].dev', FILTER_VALIDATE_URL) === false);
     }
+
+    /** @test */
+    public function minimum_one_column_expected(): void
+    {
+        $this->expectException(\Rappasoft\LaravelLivewireTables\Exceptions\NoColumnsException::class);
+        $table = new NoColumnsTable();
+        $table->boot();
+        $table->bootedComponentUtilities();
+        $table->bootedWithData();
+        $table->bootedWithColumns();
+        $table->bootedWithColumnSelect();
+        $table->bootedWithSecondaryHeader();
+        $table->booted();
+        $table->renderingWithData($view, []);
+        $table->renderingWithPagination($view, []);
+        $table->render();
+
+    }
+    
 }

--- a/tests/Http/Livewire/FailingTables/NoColumnsTable.php
+++ b/tests/Http/Livewire/FailingTables/NoColumnsTable.php
@@ -4,9 +4,16 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables;
 
 use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Tests\Models\{Breed, Pet, Species};
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Filters\{DateFilter,DateTimeFilter,MultiSelectDropdownFilter,MultiSelectFilter,NumberFilter,SelectFilter,TextFilter};
+use Rappasoft\LaravelLivewireTables\Tests\Models\Breed;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateTimeFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\NumberFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter;
 
 class NoColumnsTable extends DataTableComponent
 {
@@ -16,7 +23,6 @@ class NoColumnsTable extends DataTableComponent
     {
         $this->setPrimaryKey('id');
     }
-
 
     public function columns(): array
     {

--- a/tests/Http/Livewire/FailingTables/NoColumnsTable.php
+++ b/tests/Http/Livewire/FailingTables/NoColumnsTable.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables;
+
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Models\{Breed, Pet, Species};
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Filters\{DateFilter,DateTimeFilter,MultiSelectDropdownFilter,MultiSelectFilter,NumberFilter,SelectFilter,TextFilter};
+
+class NoColumnsTable extends DataTableComponent
+{
+    public $model = Pet::class;
+
+    public function configure(): void
+    {
+        $this->setPrimaryKey('id');
+    }
+
+
+    public function columns(): array
+    {
+        return [
+        ];
+    }
+
+    public function filters(): array
+    {
+        return [
+            MultiSelectFilter::make('Breed')
+                ->options(
+                    Breed::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($breed) => $breed->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, array $values) {
+                    return $builder->whereIn('breed_id', $values);
+                }),
+            MultiSelectDropdownFilter::make('Species')
+                ->options(
+                    Species::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($species) => $species->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, array $values) {
+                    return $builder->whereIn('species_id', $values);
+                }),
+            NumberFilter::make('Breed ID', 'breed_id_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->where('breed_id', '=', $value);
+                }),
+
+            TextFilter::make('Pet Name', 'pet_name_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->where('pets.name', '=', $value);
+                }),
+
+            DateFilter::make('Last Visit After Date', 'last_visit_date_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->whereDate('pets.last_visit', '=>', $value);
+                }),
+
+            DateTimeFilter::make('Last Visit Before DateTime', 'last_visit_datetime_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->whereDate('pets.last_visit', '<=', $value);
+                }),
+
+            SelectFilter::make('Breed SelectFilter', 'breed_select_filter')
+                ->options(
+                    Breed::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($breed) => $breed->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->where('breed_id', $value);
+                })
+                ->setCustomFilterLabel('livewire-tables::tests.testFilterLabel')
+                ->setFilterPillBlade('livewire-tables::tests.testFilterPills'),
+        ];
+    }
+}

--- a/tests/Http/Livewire/PetsTableMount.php
+++ b/tests/Http/Livewire/PetsTableMount.php
@@ -4,29 +4,20 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
 
 use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Tests\Models\Breed;
-use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
-use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
+use Rappasoft\LaravelLivewireTables\Tests\Models\{Breed,Pet,Species};
 use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\ImageColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
-use Rappasoft\LaravelLivewireTables\Views\Filters\DateFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\DateTimeFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\NumberFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter;
+use Rappasoft\LaravelLivewireTables\Views\Columns\{ImageColumn,LinkColumn};
+use Rappasoft\LaravelLivewireTables\Views\Filters\{DateFilter,DateTimeFilter,MultiSelectDropdownFilter,MultiSelectFilter,NumberFilter,SelectFilter,TextFilter};
 
 class PetsTableMount extends DataTableComponent
 {
     public $model = Pet::class;
-
     public ?int $mountBreed = null;
 
-    public function mount(?int $mountBreed)
+    public function mount(?int $mountBreed = null)
     {
-        if (isset($mountBreed)) {
+        if (isset($mountBreed))
+        {
             $this->mountBreed = $mountBreed;
         }
     }
@@ -157,10 +148,10 @@ class PetsTableMount extends DataTableComponent
 
     public function builder(): Builder
     {
-        if (isset($this->mountBreed)) {
-            return Pet::where('breed_id', $this->mountBreed);
+        if (isset($this->mountBreed))
+        {
+            return Pet::where('breed_id',$this->mountBreed);
         }
-
         return Pet::query();
     }
 }

--- a/tests/Http/Livewire/PetsTableMount.php
+++ b/tests/Http/Livewire/PetsTableMount.php
@@ -10,17 +10,23 @@ use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\ImageColumn;
 use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
-use Rappasoft\LaravelLivewireTables\Views\Filters\{DateFilter,DateTimeFilter,MultiSelectDropdownFilter,MultiSelectFilter,NumberFilter,SelectFilter,TextFilter};
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateTimeFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\NumberFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter;
 
 class PetsTableMount extends DataTableComponent
 {
     public $model = Pet::class;
+
     public ?int $mountBreed = null;
 
     public function mount(?int $mountBreed)
     {
-        if (isset($mountBreed))
-        {
+        if (isset($mountBreed)) {
             $this->mountBreed = $mountBreed;
         }
     }
@@ -151,10 +157,10 @@ class PetsTableMount extends DataTableComponent
 
     public function builder(): Builder
     {
-        if (isset($this->mountBreed))
-        {
-            return Pet::where('breed_id',$this->mountBreed);
+        if (isset($this->mountBreed)) {
+            return Pet::where('breed_id', $this->mountBreed);
         }
+
         return Pet::query();
     }
 }

--- a/tests/Http/Livewire/PetsTableMount.php
+++ b/tests/Http/Livewire/PetsTableMount.php
@@ -4,20 +4,29 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
 
 use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Tests\Models\{Breed,Pet,Species};
+use Rappasoft\LaravelLivewireTables\Tests\Models\Breed;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
 use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\{ImageColumn,LinkColumn};
-use Rappasoft\LaravelLivewireTables\Views\Filters\{DateFilter,DateTimeFilter,MultiSelectDropdownFilter,MultiSelectFilter,NumberFilter,SelectFilter,TextFilter};
+use Rappasoft\LaravelLivewireTables\Views\Columns\ImageColumn;
+use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateTimeFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\NumberFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter;
 
 class PetsTableMount extends DataTableComponent
 {
     public $model = Pet::class;
+
     public ?int $mountBreed = null;
 
     public function mount(?int $mountBreed = null)
     {
-        if (isset($mountBreed))
-        {
+        if (isset($mountBreed)) {
             $this->mountBreed = $mountBreed;
         }
     }
@@ -148,10 +157,10 @@ class PetsTableMount extends DataTableComponent
 
     public function builder(): Builder
     {
-        if (isset($this->mountBreed))
-        {
-            return Pet::where('breed_id',$this->mountBreed);
+        if (isset($this->mountBreed)) {
+            return Pet::where('breed_id', $this->mountBreed);
         }
+
         return Pet::query();
     }
 }

--- a/tests/Http/Livewire/PetsTableMount.php
+++ b/tests/Http/Livewire/PetsTableMount.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
+
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Breed;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Columns\ImageColumn;
+use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
+use Rappasoft\LaravelLivewireTables\Views\Filters\{DateFilter,DateTimeFilter,MultiSelectDropdownFilter,MultiSelectFilter,NumberFilter,SelectFilter,TextFilter};
+
+class PetsTableMount extends DataTableComponent
+{
+    public $model = Pet::class;
+    public ?int $mountBreed = null;
+
+    public function mount(?int $mountBreed)
+    {
+        if (isset($mountBreed))
+        {
+            $this->mountBreed = $mountBreed;
+        }
+    }
+
+    public function configure(): void
+    {
+        $this->setPrimaryKey('id');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('ID', 'id')
+                ->sortable()
+                ->setSortingPillTitle('Key')
+                ->setSortingPillDirections('0-9', '9-0'),
+            Column::make('Sort')
+                ->sortable()
+                ->excludeFromColumnSelect(),
+            Column::make('Name')
+                ->sortable()
+                ->secondaryHeader($this->getFilterByKey('pet_name_filter'))
+                ->footerFilter('pet_name_filter')
+                ->searchable(),
+
+            Column::make('Age'),
+
+            Column::make('Breed', 'breed.name')
+                ->secondaryHeaderFilter('breed')
+                ->footer($this->getFilterByKey('breed'))
+                ->sortable(
+                    fn (Builder $query, string $direction) => $query->orderBy('pets.id', $direction)
+                )
+                ->searchable(
+                    fn (Builder $query, $searchTerm) => $query->orWhere('breed.name', $searchTerm)
+                ),
+
+            Column::make('Other')
+                ->label(function ($row, Column $column) {
+                    return 'Other';
+                })
+                ->footer(function ($rows) {
+                    return 'Count: '.$rows->count();
+                }),
+
+            LinkColumn::make('Link')
+                ->title(fn ($row) => 'Edit')
+                ->location(fn ($row) => 'http://www.google.com')
+                ->attributes(fn ($row) => [
+                    'class' => 'rounded-full',
+                    'alt' => $row->name.' Avatar',
+                ]),
+            ImageColumn::make('RowImg')
+                ->location(fn ($row) => 'test'.$row->id)
+                ->attributes(fn ($row) => [
+                    'class' => 'rounded-full',
+                    'alt' => $row->name.' Avatar',
+                ]),
+            Column::make('Last Visit', 'last_visit')
+                ->sortable()
+                ->deselected(),
+        ];
+    }
+
+    public function filters(): array
+    {
+        return [
+            MultiSelectFilter::make('Breed')
+                ->options(
+                    Breed::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($breed) => $breed->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, array $values) {
+                    return $builder->whereIn('breed_id', $values);
+                }),
+            MultiSelectDropdownFilter::make('Species')
+                ->options(
+                    Species::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($species) => $species->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, array $values) {
+                    return $builder->whereIn('species_id', $values);
+                }),
+            NumberFilter::make('Breed ID', 'breed_id_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->where('breed_id', '=', $value);
+                }),
+
+            TextFilter::make('Pet Name', 'pet_name_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->where('pets.name', '=', $value);
+                }),
+
+            DateFilter::make('Last Visit After Date', 'last_visit_date_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->whereDate('pets.last_visit', '=>', $value);
+                }),
+
+            DateTimeFilter::make('Last Visit Before DateTime', 'last_visit_datetime_filter')
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->whereDate('pets.last_visit', '<=', $value);
+                }),
+
+            SelectFilter::make('Breed SelectFilter', 'breed_select_filter')
+                ->options(
+                    Breed::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($breed) => $breed->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, string $value) {
+                    return $builder->where('breed_id', $value);
+                })
+                ->setCustomFilterLabel('livewire-tables::tests.testFilterLabel')
+                ->setFilterPillBlade('livewire-tables::tests.testFilterPills'),
+        ];
+    }
+
+    public function builder(): Builder
+    {
+        if (isset($this->mountBreed))
+        {
+            return Pet::where('breed_id',$this->mountBreed);
+        }
+        return Pet::query();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -79,12 +79,12 @@ class TestCase extends Orchestra
     {
         $view = view('livewire-tables::datatable');
         $this->basicTable = new PetsTable();
-        $this->basicTable->bootComponentUtilities();
         $this->basicTable->boot();
-        $this->basicTable->bootWithData();
-        $this->basicTable->bootWithColumns();
-        $this->basicTable->bootWithColumnSelect();
-        $this->basicTable->bootWithSecondaryHeader();
+        $this->basicTable->bootedComponentUtilities();
+        $this->basicTable->bootedWithData();
+        $this->basicTable->bootedWithColumns();
+        $this->basicTable->bootedWithColumnSelect();
+        $this->basicTable->bootedWithSecondaryHeader();
         $this->basicTable->booted();
         $this->basicTable->renderingWithData($view, []);
         $this->basicTable->renderingWithPagination($view, []);

--- a/tests/Traits/WithMountTest.php
+++ b/tests/Traits/WithMountTest.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Traits;
 
-use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableMount;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableMount;
 
 class WithMountTest extends TestCase
 {
@@ -14,7 +14,7 @@ class WithMountTest extends TestCase
 
         $table = new PetsTableMount();
         $table->boot();
-        $table->mount(4);
+        $table->mount(102);
         $table->bootedComponentUtilities();
         $table->bootedWithData();
         $table->bootedWithColumns();
@@ -26,8 +26,9 @@ class WithMountTest extends TestCase
         $table->render();
         $rows = $table->getRows();
 
-        $this->assertSame(strtoupper($rows->first()->name), 'CARTMAN');
+        $this->assertSame(strtoupper($rows->first()->name), 'MAY');
         $this->assertNotSame(strtoupper($rows->first()->name), 'CHICO');
+        $this->assertNotSame(strtoupper($rows->first()->name), 'CARTMAN');
 
         $table2 = new PetsTableMount();
         $table2->boot();
@@ -44,6 +45,26 @@ class WithMountTest extends TestCase
         $rows2 = $table2->getRows();
         $this->assertSame(strtoupper($rows2->first()->name), 'CHICO');
         $this->assertNotSame(strtoupper($rows2->first()->name), 'CARTMAN');
+        $this->assertNotSame(strtoupper($rows2->first()->name), 'MAY');
+
+        $table3 = new PetsTableMount();
+        $table3->boot();
+        $table3->mount();
+        $table3->bootedComponentUtilities();
+        $table3->bootedWithData();
+        $table3->bootedWithColumns();
+        $table3->bootedWithColumnSelect();
+        $table3->bootedWithSecondaryHeader();
+        $table3->booted();
+        $table3->renderingWithData($view, []);
+        $table3->renderingWithPagination($view, []);
+        $table3->render();
+        $rows3 = $table3->getRows();
+
+        $this->assertSame(strtoupper($rows3->first()->name), 'CARTMAN');
+        $this->assertNotSame(strtoupper($rows3->first()->name), 'CHICO');
+        $this->assertNotSame(strtoupper($rows3->first()->name), 'MAY');
 
     }
+
 }

--- a/tests/Traits/WithMountTest.php
+++ b/tests/Traits/WithMountTest.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Traits;
 
-use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableMount;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 class WithMountTest extends TestCase
 {
@@ -66,5 +66,4 @@ class WithMountTest extends TestCase
         $this->assertNotSame(strtoupper($rows3->first()->name), 'MAY');
 
     }
-
 }

--- a/tests/Traits/WithMountTest.php
+++ b/tests/Traits/WithMountTest.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Traits;
 
-use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableMount;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 class WithMountTest extends TestCase
 {
@@ -44,8 +44,6 @@ class WithMountTest extends TestCase
         $rows2 = $table2->getRows();
         $this->assertSame(strtoupper($rows2->first()->name), 'CHICO');
         $this->assertNotSame(strtoupper($rows2->first()->name), 'CARTMAN');
-    
 
     }
-
 }

--- a/tests/Traits/WithMountTest.php
+++ b/tests/Traits/WithMountTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Traits;
+
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableMount;
+
+class WithMountTest extends TestCase
+{
+    /** @test */
+    public function mounttable_gets_correct_first_item(): void
+    {
+        $view = view('livewire-tables::datatable');
+
+        $table = new PetsTableMount();
+        $table->boot();
+        $table->mount(4);
+        $table->bootedComponentUtilities();
+        $table->bootedWithData();
+        $table->bootedWithColumns();
+        $table->bootedWithColumnSelect();
+        $table->bootedWithSecondaryHeader();
+        $table->booted();
+        $table->renderingWithData($view, []);
+        $table->renderingWithPagination($view, []);
+        $table->render();
+        $rows = $table->getRows();
+
+        $this->assertSame(strtoupper($rows->first()->name), 'CARTMAN');
+        $this->assertNotSame(strtoupper($rows->first()->name), 'CHICO');
+
+        $table2 = new PetsTableMount();
+        $table2->boot();
+        $table2->mount(202);
+        $table2->bootedComponentUtilities();
+        $table2->bootedWithData();
+        $table2->bootedWithColumns();
+        $table2->bootedWithColumnSelect();
+        $table2->bootedWithSecondaryHeader();
+        $table2->booted();
+        $table2->renderingWithData($view, []);
+        $table2->renderingWithPagination($view, []);
+        $table2->render();
+        $rows2 = $table2->getRows();
+        $this->assertSame(strtoupper($rows2->first()->name), 'CHICO');
+        $this->assertNotSame(strtoupper($rows2->first()->name), 'CARTMAN');
+    
+
+    }
+
+}


### PR DESCRIPTION
This PR changes the standard events to run on booted() rather than boot(), allowing mount() to take place first.

Additionally adds missing tests for:
- Using mount() in conjunction with builder()
- Ensure mount() is called prior to bundler() executing
- Ensuring that correct Exception is thrown if **no columns** are configured.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
