### PR TITLE
Update Loading Placeholder - Add Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## UNRELEASED
+### New Features
+- Additional Loading Placeholder methods
+
 ## [v3.2.0] - 2023-01-04
 ### Tweaks
 - Migration to new Core Traits, and de-duplication of code by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1623 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## UNRELEASED
 ### New Features
-- Additional Loading Placeholder methods
+- Additional Loading Placeholder methods by @lrljoe
 
 ## [v3.2.0] - 2023-01-04
 ### Tweaks

--- a/docs/misc/loading-placeholder.md
+++ b/docs/misc/loading-placeholder.md
@@ -47,7 +47,23 @@ You may use this method to set custom text for the placeholder:
         $this->setLoadingPlaceholderContent('Text To Display');
     }
 ```
-### setLoadingPlaceHolderWrapperAttributes
+
+### setLoadingPlaceholderContentBlade
+
+You may use this method to set a custom content blade.  This will be wrapped in a <tr> and <td> element (which can be customised as below).
+
+```php
+    public function configure(): void
+    {
+        $this->setLoadingPlaceholderContentBlade('path-to-content-blade');
+    }
+```
+
+### setLoadingPlaceholderBlade
+
+As an alternative to the setLoadingPlaceholderContentBlade, you may over-ride the default content entirely, in which case you **must** begin and end your custom blade with a <tr></tr> element to avoid DOM issues.
+
+### setLoadingPlaceHolderWrapperAttributes (deprecated)
 
 This method allows you to customise the attributes for the &lt;tr&gt; element used as a Placeholder when the table is loading.  Similar to other setAttribute methods, this accepts a range of attributes, and a boolean "default", which will enable/disable the default attributes.
 
@@ -55,6 +71,31 @@ This method allows you to customise the attributes for the &lt;tr&gt; element us
     public function configure(): void
     {
         $this->setLoadingPlaceHolderWrapperAttributes([
+            'class' => 'text-bold',
+            'default' => false,
+        ]);
+    }
+
+```
+### setLoadingPlaceHolderTrAttributes
+This method allows you to customise the attributes for the &lt;tr&gt; element used as a Placeholder when the table is loading.  Similar to other setAttribute methods, this accepts a range of attributes, and a boolean "default", which will enable/disable the default attributes.
+```php
+    public function configure(): void
+    {
+        $this->setLoadingPlaceHolderTrAttributes([
+            'class' => 'text-bold',
+            'default' => false,
+        ]);
+    }
+
+```
+
+### setLoadingPlaceHolderTdAttributes
+This method allows you to customise the attributes for the &lt;td&gt; element used as a Placeholder when the table is loading.  Similar to other setAttribute methods, this accepts a range of attributes, and a boolean "default", which will enable/disable the default attributes.
+```php
+    public function configure(): void
+    {
+        $this->setLoadingPlaceHolderTdAttributes([
             'class' => 'text-bold',
             'default' => false,
         ]);
@@ -76,3 +117,4 @@ This method allows you to customise the attributes for the &lt;div&gt; element t
     }
 
 ```
+

--- a/docs/misc/loading-placeholder.md
+++ b/docs/misc/loading-placeholder.md
@@ -37,6 +37,14 @@ Use this method to disable the loading placeholder:
     }
 ```
 
+### Content of Loading Placeholder
+
+There are several options to set the Loading Placeholder content for the Table.
+
+Option 1 - Define plain-text content to display in the loading table row using setLoadingPlaceholderContent()
+Option 2 - Replace content of the loading table row using setLoadingPlaceHolderContentBlade()
+Option 3 - Replace the loading table row using setLoadingPlaceHolderBlade()
+
 ### setLoadingPlaceholderContent
 
 You may use this method to set custom text for the placeholder:
@@ -63,7 +71,16 @@ You may use this method to set a custom content blade.  This will be wrapped in 
 
 As an alternative to the setLoadingPlaceholderContentBlade, you may over-ride the default content entirely, in which case you **must** begin and end your custom blade with a <tr></tr> element to avoid DOM issues.
 
-### setLoadingPlaceHolderWrapperAttributes (deprecated)
+```php
+    public function configure(): void
+    {
+        $this->setLoadingPlaceholderBlade('path-to-placeholder-blade');
+    }
+```
+
+### Styling & Customisation
+
+#### setLoadingPlaceHolderWrapperAttributes (deprecated)
 
 This method allows you to customise the attributes for the &lt;tr&gt; element used as a Placeholder when the table is loading.  Similar to other setAttribute methods, this accepts a range of attributes, and a boolean "default", which will enable/disable the default attributes.
 
@@ -77,7 +94,8 @@ This method allows you to customise the attributes for the &lt;tr&gt; element us
     }
 
 ```
-### setLoadingPlaceHolderTrAttributes
+
+#### setLoadingPlaceHolderTrAttributes
 This method allows you to customise the attributes for the &lt;tr&gt; element used as a Placeholder when the table is loading.  Similar to other setAttribute methods, this accepts a range of attributes, and a boolean "default", which will enable/disable the default attributes.
 ```php
     public function configure(): void
@@ -90,7 +108,7 @@ This method allows you to customise the attributes for the &lt;tr&gt; element us
 
 ```
 
-### setLoadingPlaceHolderTdAttributes
+#### setLoadingPlaceHolderTdAttributes
 This method allows you to customise the attributes for the &lt;td&gt; element used as a Placeholder when the table is loading.  Similar to other setAttribute methods, this accepts a range of attributes, and a boolean "default", which will enable/disable the default attributes.
 ```php
     public function configure(): void
@@ -103,7 +121,7 @@ This method allows you to customise the attributes for the &lt;td&gt; element us
 
 ```
 
-### setLoadingPlaceHolderIconAttributes
+#### setLoadingPlaceHolderIconAttributes
 
 This method allows you to customise the attributes for the &lt;div&gt; element that is used solely for the PlaceholderIcon.  Similar to other setAttribute methods, this accepts a range of attributes, and a boolean "default", which will enable/disable the default attributes.
 

--- a/resources/views/components/includes/loading.blade.php
+++ b/resources/views/components/includes/loading.blade.php
@@ -18,7 +18,7 @@ $customAttributes['loader-icon'] = $component->getLoadingPlaceHolderIconAttribut
     >
         <td colspan="{{ $colCount }}"
             {{
-                $attributes->merge($customAcomponent->getLoadingPlaceholderTdAttributes());
+                $attributes->merge($component->getLoadingPlaceholderTdAttributes());
             }}
         >
         @if($this->hasLoadingPlaceholderContentBlade())

--- a/resources/views/components/includes/loading.blade.php
+++ b/resources/views/components/includes/loading.blade.php
@@ -2,13 +2,13 @@
 @props(['colCount' => 1])
 
 @php
-$customAttributes['loader-wrapper'] = $component->getLoadingPlaceHolderWrapperAttributes();
+$customAttributes['loader-wrapper'] = $component->getLoadingPlaceholderTrAttributes();
+$customAttributes['loader-column'] = $component->getLoadingPlaceholderTdAttributes();
 $customAttributes['loader-icon'] = $component->getLoadingPlaceHolderIconAttributes();
 @endphp
 @if($this->hasLoadingPlaceholderBlade())
     @include($this->getLoadingPlaceHolderBlade(), ['colCount' => $colCount])
 @else
-
     <tr wire:key="{{ $tableName }}-loader" class="hidden d-none"
     {{
         $attributes->merge($customAttributes['loader-wrapper'])
@@ -17,7 +17,14 @@ $customAttributes['loader-icon'] = $component->getLoadingPlaceHolderIconAttribut
     }}
     wire:loading.class.remove="hidden d-none"
     >
-        <td colspan="{{ $colCount }}">
+        <td colspan="{{ $colCount }}"
+            {{
+                $attributes->merge($customAttributes['loader-column']);
+            }}
+        >
+        @if($this->hasLoadingPlaceholderContentBlade())
+            @include($this->getLoadingPlaceHolderContentBlade(), ['colCount' => $colCount])
+        @else
             <div class="h-min self-center align-middle text-center">
                 <div class="lds-hourglass"
                 {{
@@ -27,9 +34,11 @@ $customAttributes['loader-icon'] = $component->getLoadingPlaceHolderIconAttribut
                             ->except('default');
                 }}
                 ></div>
-                <div>{{ $component->getLoadingPlaceholderContent() }}</div>
+                <div>
+                    {{ $component->getLoadingPlaceholderContent() }}
+                </div>
             </div>
+        @endif
         </td>
     </tr>
-
 @endif

--- a/resources/views/components/includes/loading.blade.php
+++ b/resources/views/components/includes/loading.blade.php
@@ -3,7 +3,6 @@
 
 @php
 $customAttributes['loader-wrapper'] = $component->getLoadingPlaceholderTrAttributes();
-$customAttributes['loader-column'] = $component->getLoadingPlaceholderTdAttributes();
 $customAttributes['loader-icon'] = $component->getLoadingPlaceHolderIconAttributes();
 @endphp
 @if($this->hasLoadingPlaceholderBlade())
@@ -19,7 +18,7 @@ $customAttributes['loader-icon'] = $component->getLoadingPlaceHolderIconAttribut
     >
         <td colspan="{{ $colCount }}"
             {{
-                $attributes->merge($customAttributes['loader-column']);
+                $attributes->merge($customAcomponent->getLoadingPlaceholderTdAttributes());
             }}
         >
         @if($this->hasLoadingPlaceholderContentBlade())

--- a/src/Traits/Configuration/LoadingPlaceholderConfiguration.php
+++ b/src/Traits/Configuration/LoadingPlaceholderConfiguration.php
@@ -60,14 +60,12 @@ trait LoadingPlaceholderConfiguration
         return $this;
     }
 
-
     public function setLoadingPlaceHolderTrAttributes(array $attributes): self
     {
         $this->loadingPlaceHolderTrAttributes = array_merge(['default' => true], $attributes);
 
         return $this;
     }
-
 
     public function setLoadingPlaceHolderTdAttributes(array $attributes): self
     {
@@ -82,5 +80,4 @@ trait LoadingPlaceholderConfiguration
 
         return $this;
     }
-
 }

--- a/src/Traits/Configuration/LoadingPlaceholderConfiguration.php
+++ b/src/Traits/Configuration/LoadingPlaceholderConfiguration.php
@@ -48,7 +48,7 @@ trait LoadingPlaceholderConfiguration
 
     public function setLoadingPlaceHolderWrapperAttributes(array $attributes): self
     {
-        $this->loadingPlaceHolderWrapperAttributes = $attributes;
+        $this->loadingPlaceHolderTrAttributes = array_merge(['default' => true], $attributes);
 
         return $this;
     }
@@ -59,4 +59,28 @@ trait LoadingPlaceholderConfiguration
 
         return $this;
     }
+
+
+    public function setLoadingPlaceHolderTrAttributes(array $attributes): self
+    {
+        $this->loadingPlaceHolderTrAttributes = array_merge(['default' => true], $attributes);
+
+        return $this;
+    }
+
+
+    public function setLoadingPlaceHolderTdAttributes(array $attributes): self
+    {
+        $this->loadingPlaceHolderTdAttributes = array_merge(['default' => true], $attributes);
+
+        return $this;
+    }
+
+    public function setLoadingPlaceholderContentBlade(string $customBlade): self
+    {
+        $this->loadingPlaceholderContentBlade = $customBlade;
+
+        return $this;
+    }
+
 }

--- a/src/Traits/Helpers/LoadingPlaceholderHelpers.php
+++ b/src/Traits/Helpers/LoadingPlaceholderHelpers.php
@@ -25,6 +25,16 @@ trait LoadingPlaceholderHelpers
 
     }
 
+    public function getLoadingPlaceholderTrAttributes(): array
+    {
+        return count($this->loadingPlaceHolderTrAttributes) ? $this->loadingPlaceHolderTrAttributes : ['default' => true];
+    }
+
+    public function getLoadingPlaceholderTdAttributes(): array
+    {
+        return count($this->loadingPlaceHolderTdAttributes) ? $this->loadingPlaceHolderTdAttributes : ['default' => true];
+    }
+
     public function getLoadingPlaceHolderIconAttributes(): array
     {
         return count($this->loadingPlaceHolderIconAttributes) ? $this->loadingPlaceHolderIconAttributes : ['default' => true];
@@ -32,7 +42,7 @@ trait LoadingPlaceholderHelpers
 
     public function getLoadingPlaceHolderWrapperAttributes(): array
     {
-        return count($this->loadingPlaceHolderWrapperAttributes) ? $this->loadingPlaceHolderWrapperAttributes : ['default' => true];
+        return count($this->loadingPlaceHolderTrAttributes) ? $this->loadingPlaceHolderTrAttributes : ['default' => true];
     }
 
     public function hasLoadingPlaceholderBlade(): bool
@@ -43,5 +53,15 @@ trait LoadingPlaceholderHelpers
     public function getLoadingPlaceHolderBlade(): ?string
     {
         return $this->loadingPlaceholderBlade;
+    }
+
+    public function hasLoadingPlaceholderContentBlade(): bool
+    {
+        return ! is_null($this->getLoadingPlaceHolderContentBlade());
+    }
+
+    public function getLoadingPlaceHolderContentBlade(): ?string
+    {
+        return $this->loadingPlaceholderContentBlade;
     }
 }

--- a/src/Traits/WithLoadingPlaceholder.php
+++ b/src/Traits/WithLoadingPlaceholder.php
@@ -16,9 +16,15 @@ trait WithLoadingPlaceholder
 
     protected ?string $loadingPlaceholderBlade = null;
 
+    protected ?string $loadingPlaceholderContentBlade = null;
+
     protected array $loadingPlaceHolderAttributes = [];
 
     protected array $loadingPlaceHolderIconAttributes = [];
 
     protected array $loadingPlaceHolderWrapperAttributes = [];
+
+    protected array $loadingPlaceHolderTrAttributes = [];
+
+    protected array $loadingPlaceHolderTdAttributes = [];
 }


### PR DESCRIPTION
This fix is to add new methods for controlling the Loading Placeholder content for the table.

This is currently in development, as tests need adjusting.

### setLoadingPlaceholderContent
You may use this method to set custom text for the placeholder:

### setLoadingPlaceholderContentBlade
You may use this method to set a custom content blade.  This will be wrapped in a <tr> and <td> element (which can be customised as below).

### setLoadingPlaceholderBlade
As an alternative to the setLoadingPlaceholderContentBlade, you may over-ride the default content entirely, in which case you **must** begin and end your custom blade with a <tr></tr> element to avoid DOM issues.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
