### PR TITLE
Migrate "Updated" from ComponentUtilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
-## [v3.2.0] - 2023-01-04
+## [v3.2.1] - 2024-02-24
+### Bug Fixes
+- Fix collapsing columns not respecting view point collapse points by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1665
+
+### Tweaks
+- Migrate "updated" Search and FilterComponents calls to WithSearch and WithFilters by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1666
+- Allow nullable search/filter values by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1666
+
+## [v3.2.0] - 2024-01-04
 ### Tweaks
 - Migration to new Core Traits, and de-duplication of code by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1623 
 

--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -88,40 +88,6 @@ trait ComponentUtilities
     }
 
     /**
-     * Keep track of any properties on the custom query string key for this specific table
-     */
-    public function updated(string $name, string|array $value): void
-    {
-        if ($name === 'search') {
-            $this->resetComputedPage();
-
-            // Clear bulk actions on search
-            $this->clearSelected();
-            $this->setSelectAllDisabled();
-
-            if ($value === '') {
-                $this->clearSearch();
-            }
-        }
-
-        if (Str::contains($name, 'filterComponents')) {
-            $this->resetComputedPage();
-
-            // Clear bulk actions on filter
-            $this->clearSelected();
-            $this->setSelectAllDisabled();
-
-            // Clear filters on empty value
-            $filterName = Str::after($name, 'filterComponents.');
-            $filter = $this->getFilterByKey($filterName);
-
-            if ($filter && $filter->isEmpty($value)) {
-                $this->resetFilter($filterName);
-            }
-        }
-    }
-
-    /**
      * 1. After the sorting method is hit we need to tell the table to go back into reordering mode
      */
     public function hydrate(): void

--- a/src/Traits/Helpers/TableAttributeHelpers.php
+++ b/src/Traits/Helpers/TableAttributeHelpers.php
@@ -16,7 +16,7 @@ trait TableAttributeHelpers
     }
 
     /**
-     * @return  array<mixed>
+     * @return array<mixed>
      */
     public function getTableWrapperAttributes(): array
     {
@@ -24,7 +24,7 @@ trait TableAttributeHelpers
     }
 
     /**
-     * @return  array<mixed>
+     * @return array<mixed>
      */
     public function getTableAttributes(): array
     {
@@ -32,7 +32,7 @@ trait TableAttributeHelpers
     }
 
     /**
-     * @return  array<mixed>
+     * @return array<mixed>
      */
     public function getTheadAttributes(): array
     {
@@ -40,7 +40,7 @@ trait TableAttributeHelpers
     }
 
     /**
-     * @return  array<mixed>
+     * @return array<mixed>
      */
     public function getTbodyAttributes(): array
     {
@@ -48,7 +48,7 @@ trait TableAttributeHelpers
     }
 
     /**
-     * @return  array<mixed>
+     * @return array<mixed>
      */
     public function getThAttributes(Column $column): array
     {
@@ -56,7 +56,7 @@ trait TableAttributeHelpers
     }
 
     /**
-     * @return  array<mixed>
+     * @return array<mixed>
      */
     public function getThSortButtonAttributes(Column $column): array
     {

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -68,4 +68,21 @@ trait WithFilters
 
         return $this->getBuilder();
     }
+
+    public function updatedFilterComponents(string|array|null $value, string $filterName): void
+    {
+        $this->resetComputedPage();
+
+        // Clear bulk actions on filter
+        $this->clearSelected();
+        $this->setSelectAllDisabled();
+
+        // Clear filters on empty value
+        $filter = $this->getFilterByKey($filterName);
+
+        if ($filter && $filter->isEmpty($value)) {
+            $this->resetFilter($filterName);
+        }
+    }
+
 }

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -84,5 +84,4 @@ trait WithFilters
             $this->resetFilter($filterName);
         }
     }
-
 }

--- a/src/Traits/WithSearch.php
+++ b/src/Traits/WithSearch.php
@@ -65,4 +65,17 @@ trait WithSearch
 
         return $this->getBuilder();
     }
+
+    public function updatedSearch(string|array|null $value): void
+    {
+        $this->resetComputedPage();
+
+        // Clear bulk actions on search
+        $this->clearSelected();
+        $this->setSelectAllDisabled();
+
+        if (is_null($value) || $value === '') {
+            $this->clearSearch();
+        }
+    }
 }


### PR DESCRIPTION
This PR migrates two chunks of code from the ComponentUtilities "updated()" method

Presently, ComponentUtilities contains two checks within it's "updated()" hook:

_if ($name === 'search') {_
and
_if (Str::contains($name, 'filterComponents')) {_

Instead, the underlying functionality for these, is migrated to the _WithSearch_ and _WithFilters_ Traits respectively

This:
- Reduces the number of executions for the ComponentUtilities "updated" method
- Segregates the logical methods into appropriate traits

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
