### PR TITLE
[Bug] Auto Inject Assets: Only if component rendered

### DIFF
--- a/src/Features/AutoInjectRappasoftAssets.php
+++ b/src/Features/AutoInjectRappasoftAssets.php
@@ -4,6 +4,7 @@ namespace Rappasoft\LaravelLivewireTables\Features;
 
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Livewire\ComponentHook;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Mechanisms\RappasoftFrontendAssets;
 
 use function Livewire\on;
@@ -33,6 +34,10 @@ class AutoInjectRappasoftAssets extends ComponentHook
             app('events')->listen(RequestHandled::class, function (RequestHandled $handled) {
 
                 if (! static::$shouldInjectRappasoftAssets && ! static::$shouldInjectRappasoftThirdPartyAssets) {
+                    return;
+                }
+
+                if (! static::$hasRenderedAComponentThisRequest) {
                     return;
                 }
 
@@ -73,7 +78,9 @@ class AutoInjectRappasoftAssets extends ComponentHook
 
     public function dehydrate(): void
     {
-        static::$hasRenderedAComponentThisRequest = true;
+        if ($this->component instanceof DataTableComponent){
+            static::$hasRenderedAComponentThisRequest = true;
+        }
     }
 
     public static function injectAssets(mixed $html): string


### PR DESCRIPTION
Regression from 65ce4947ab58b77fb3e454423202edd17e414e49 #1371

Fixes: #1587

Check if component is instanceof DataTableComponent so as not to inject on every livewire page, only ones with a datatable component

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
