### PR TITLE
fix: Apply cursor pointer only on clickable columns when using Bootst…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## [v3.2.7] - 2024-06-05
+### Bug Fixes
+- Ensure HTML Columns return HTML correctly by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1737
+
 ## [v3.2.6] - 2024-06-05
 ### New Features
 - Add configurable wire:model for filters by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1699

--- a/resources/views/components/table/td.blade.php
+++ b/resources/views/components/table/td.blade.php
@@ -21,7 +21,7 @@
                 ->class(['d-none' => $component->isBootstrap() && $column && $column->shouldCollapseAlways()])
                 ->class(['d-none d-md-table-cell' => $component->isBootstrap() && $column && $column->shouldCollapseOnMobile()])
                 ->class(['d-none d-lg-table-cell' => $component->isBootstrap() && $column && $column->shouldCollapseOnTablet()])
-                ->style(['cursor:pointer' => $component->isBootstrap()])
+                ->style(['cursor:pointer' => $component->isBootstrap() && $column && $column->isClickable()])
                 ->except('default')
         }}
     >

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -53,7 +53,11 @@
                         @continue($column->isReorderColumn() && !$this->getCurrentlyReorderingStatus() && $this->getHideReorderColumnUnlessReorderingStatus())
 
                         <x-livewire-tables::table.td wire:key="{{ $tableName . '-' . $row->{$this->getPrimaryKey()} . '-datatable-td-' . $column->getSlug() }}"  :column="$column" :colIndex="$colIndex">
-                            {{ $column->renderContents($row) }}
+                            @if($column->isHtml())                            
+                                {!! $column->renderContents($row) !!}
+                            @else
+                                {{ $column->renderContents($row) }}
+                            @endif
                         </x-livewire-tables::table.td>
                     @endforeach
                 </x-livewire-tables::table.tr>

--- a/src/LaravelLivewireTablesServiceProvider.php
+++ b/src/LaravelLivewireTablesServiceProvider.php
@@ -14,7 +14,7 @@ class LaravelLivewireTablesServiceProvider extends ServiceProvider
     public function boot(): void
     {
 
-        AboutCommand::add('Rappasoft Laravel Livewire Tables', fn () => ['Version' => '3.2.6']);
+        AboutCommand::add('Rappasoft Laravel Livewire Tables', fn () => ['Version' => '3.2.7']);
 
         $this->mergeConfigFrom(
             __DIR__.'/../config/livewire-tables.php', 'livewire-tables'


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Issue Fix:

- [x] **What issue does this address?**
  - This change resolves an issue with the cursor styling on table rows **when using Bootstrap**. Previously, `cursor: pointer;` was always applied to all cells, regardless of whether the column was set as clickable. This contradicts the documentation and expected behavior. With this update, the cursor changes to a pointer only when the column is explicitly marked as clickable. 