### PR TITLE
Switch to using Composer\InstalledVersions for AboutCommand

### DIFF
--- a/src/LaravelLivewireTablesServiceProvider.php
+++ b/src/LaravelLivewireTablesServiceProvider.php
@@ -14,7 +14,11 @@ class LaravelLivewireTablesServiceProvider extends ServiceProvider
     public function boot(): void
     {
 
-        AboutCommand::add('Rappasoft Laravel Livewire Tables', fn () => ['Version' => '3.2.7']);
+        if (class_exists(AboutCommand::class) && class_exists(\Composer\InstalledVersions::class)) {
+            AboutCommand::add('Rappasoft Laravel Livewire Tables', [
+                'Version' => \Composer\InstalledVersions::getPrettyVersion('rappasoft/laravel-livewire-tables'),
+            ]);
+        }
 
         $this->mergeConfigFrom(
             __DIR__.'/../config/livewire-tables.php', 'livewire-tables'


### PR DESCRIPTION
Switch to using Composer\InstalledVersions for AboutCommand to reduce necessity to update ServiceProvider with a new version for each release.

This also makes it easier for identifying which branch is in use when undertaking development

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
