### PR TITLE
Optionally disable count for simple pagination

### DIFF
--- a/docs/pagination/available-methods.md
+++ b/docs/pagination/available-methods.md
@@ -263,3 +263,36 @@ public function configure(): void
     ]);
 }
 ```
+
+## setShouldRetrieveTotalItemCountStatus
+
+Used when "simple" pagination is being used, allows the enabling/disabling of the "total records" count.  This may be desirable to disable in larger data sets.  This is enabled by default.
+
+```php
+public function configure(): void
+{
+    $this->setShouldRetrieveTotalItemCountStatus(false);
+}
+```
+
+## setShouldRetrieveTotalItemCountEnabled
+
+Used when "simple" pagination is being used, enables the "total records" count.
+
+```php
+public function configure(): void
+{
+    $this->setShouldRetrieveTotalItemCountEnabled();
+}
+```
+
+## setShouldRetrieveTotalItemCountDisabled
+
+Used when "simple" pagination is being used, disables the "total records" count.
+
+```php
+public function configure(): void
+{
+    $this->setShouldRetrieveTotalItemCountDisabled();
+}
+```

--- a/src/Traits/Configuration/PaginationConfiguration.php
+++ b/src/Traits/Configuration/PaginationConfiguration.php
@@ -177,5 +177,4 @@ trait PaginationConfiguration
 
         return $this;
     }
-
 }

--- a/src/Traits/Configuration/PaginationConfiguration.php
+++ b/src/Traits/Configuration/PaginationConfiguration.php
@@ -155,4 +155,27 @@ trait PaginationConfiguration
 
         return $this;
     }
+
+    public function setShouldRetrieveTotalItemCountStatus(bool $status): self
+    {
+        $this->shouldRetrieveTotalItemCount = $status;
+
+        return $this;
+
+    }
+
+    public function setShouldRetrieveTotalItemCountEnabled(): self
+    {
+        $this->setShouldRetrieveTotalItemCountStatus(true);
+
+        return $this;
+    }
+
+    public function setShouldRetrieveTotalItemCountDisabled(): self
+    {
+        $this->setShouldRetrieveTotalItemCountStatus(false);
+
+        return $this;
+    }
+
 }

--- a/src/Traits/Helpers/PaginationHelpers.php
+++ b/src/Traits/Helpers/PaginationHelpers.php
@@ -149,4 +149,10 @@ trait PaginationHelpers
     {
         return $this->perPageFieldAttributes;
     }
+
+    #[Computed]
+    public function getShouldRetrieveTotalItemCount(): bool
+    {
+        return $this->shouldRetrieveTotalItemCount;
+    }
 }

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -80,29 +80,25 @@ trait WithData
                 $this->paginationTotalItemCount = $paginatedResults->total() ?? 0;
 
                 return $paginatedResults;
-            }
-            elseif ($this->isPaginationMethod('simple')) {
+            } elseif ($this->isPaginationMethod('simple')) {
 
-                if ($this->getShouldRetrieveTotalItemCount())
-                {
+                if ($this->getShouldRetrieveTotalItemCount()) {
                     $this->paginationTotalItemCount = $this->getBuilder()->count();
+
                     return $this->getBuilder()->simplePaginate($this->getPerPage() === -1 ? $this->paginationTotalItemCount : $this->getPerPage(), ['*'], $this->getComputedPageName());
-                }
-                else {
+                } else {
                     $this->paginationTotalItemCount = -1;
-                    return $this->getBuilder()->simplePaginate($this->getPerPage() === -1 ? 10 : $this->getPerPage(), ['*'], $this->getComputedPageName());                    
+
+                    return $this->getBuilder()->simplePaginate($this->getPerPage() === -1 ? 10 : $this->getPerPage(), ['*'], $this->getComputedPageName());
                 }
 
-            }
-            elseif ($this->isPaginationMethod('cursor')) {
+            } elseif ($this->isPaginationMethod('cursor')) {
 
                 $this->paginationTotalItemCount = $this->getBuilder()->count();
 
                 return $this->getBuilder()->cursorPaginate($this->getPerPage() === -1 ? $this->paginationTotalItemCount : $this->getPerPage(), ['*'], $this->getComputedPageName());
-            }
-            else
-            {
-                throw new DataTableConfigurationException("Pagination method must be either simple, standard or cursor");
+            } else {
+                throw new DataTableConfigurationException('Pagination method must be either simple, standard or cursor');
             }
         }
 

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -81,20 +81,28 @@ trait WithData
 
                 return $paginatedResults;
             }
+            elseif ($this->isPaginationMethod('simple')) {
 
-            if ($this->isPaginationMethod('simple')) {
-
-                $this->paginationTotalItemCount = $this->getBuilder()->count();
-
-                return $this->getBuilder()->simplePaginate($this->getPerPage() === -1 ? $this->paginationTotalItemCount : $this->getPerPage(), ['*'], $this->getComputedPageName());
+                if ($this->getShouldRetrieveTotalItemCount())
+                {
+                    $this->paginationTotalItemCount = $this->getBuilder()->count();
+                    return $this->getBuilder()->simplePaginate($this->getPerPage() === -1 ? $this->paginationTotalItemCount : $this->getPerPage(), ['*'], $this->getComputedPageName());
+                }
+                else {
+                    $this->paginationTotalItemCount = -1;
+                    return $this->getBuilder()->simplePaginate($this->getPerPage() === -1 ? 10 : $this->getPerPage(), ['*'], $this->getComputedPageName());                    
+                }
 
             }
-
-            if ($this->isPaginationMethod('cursor')) {
+            elseif ($this->isPaginationMethod('cursor')) {
 
                 $this->paginationTotalItemCount = $this->getBuilder()->count();
 
                 return $this->getBuilder()->cursorPaginate($this->getPerPage() === -1 ? $this->paginationTotalItemCount : $this->getPerPage(), ['*'], $this->getComputedPageName());
+            }
+            else
+            {
+                throw new DataTableConfigurationException("Pagination method must be either simple, standard or cursor");
             }
         }
 

--- a/src/Traits/WithPagination.php
+++ b/src/Traits/WithPagination.php
@@ -41,6 +41,9 @@ trait WithPagination
 
     protected array $perPageFieldAttributes = ['default-styling' => true, 'default-colors' => true, 'class' => ''];
 
+    protected bool $shouldRetrieveTotalItemCount = true;
+
+
     public function mountWithPagination(): void
     {
         $sessionPerPage = session()->get($this->getPerPagePaginationSessionKey(), $this->getPerPageAccepted()[0] ?? 10);

--- a/src/Traits/WithPagination.php
+++ b/src/Traits/WithPagination.php
@@ -43,7 +43,6 @@ trait WithPagination
 
     protected bool $shouldRetrieveTotalItemCount = true;
 
-
     public function mountWithPagination(): void
     {
         $sessionPerPage = session()->get($this->getPerPagePaginationSessionKey(), $this->getPerPageAccepted()[0] ?? 10);

--- a/tests/Traits/Helpers/PaginationHelpersTest.php
+++ b/tests/Traits/Helpers/PaginationHelpersTest.php
@@ -141,7 +141,7 @@ final class PaginationHelpersTest extends TestCase
         $this->assertSame(['default-styling' => false, 'default-colors' => true, 'class' => 'bg-blue-500 dark:bg-red-500'], $this->basicTable->getPerPageFieldAttributes());
 
     }
-    
+
     public function test_can_toggle_total_item_count_retrieval(): void
     {
 
@@ -171,5 +171,4 @@ final class PaginationHelpersTest extends TestCase
         $this->assertTrue($this->basicTable->getShouldRetrieveTotalItemCount());
 
     }
-
 }

--- a/tests/Traits/Helpers/PaginationHelpersTest.php
+++ b/tests/Traits/Helpers/PaginationHelpersTest.php
@@ -141,4 +141,35 @@ final class PaginationHelpersTest extends TestCase
         $this->assertSame(['default-styling' => false, 'default-colors' => true, 'class' => 'bg-blue-500 dark:bg-red-500'], $this->basicTable->getPerPageFieldAttributes());
 
     }
+    
+    public function test_can_toggle_total_item_count_retrieval(): void
+    {
+
+        $this->assertTrue($this->basicTable->getShouldRetrieveTotalItemCount());
+
+        $this->basicTable->setShouldRetrieveTotalItemCountDisabled();
+
+        $this->assertFalse($this->basicTable->getShouldRetrieveTotalItemCount());
+
+        $this->basicTable->setShouldRetrieveTotalItemCountEnabled();
+
+        $this->assertTrue($this->basicTable->getShouldRetrieveTotalItemCount());
+
+    }
+
+    public function test_can_toggle_total_item_count_retrieval_via_status(): void
+    {
+
+        $this->assertTrue($this->basicTable->getShouldRetrieveTotalItemCount());
+
+        $this->basicTable->setShouldRetrieveTotalItemCountStatus(false);
+
+        $this->assertFalse($this->basicTable->getShouldRetrieveTotalItemCount());
+
+        $this->basicTable->setShouldRetrieveTotalItemCountStatus(true);
+
+        $this->assertTrue($this->basicTable->getShouldRetrieveTotalItemCount());
+
+    }
+
 }


### PR DESCRIPTION
This PR adds the capability to either disable/enable the "Total Item Count" when using **simple** pagination.

By default, the present "enabled" state is retained.  Disabling this removes one query from the table, which is more performant with larger tables.  This does not impact the UX.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
