### PR TITLE
Add Separator customisation for Array Filters for FilterPills

### DIFF
--- a/docs/filter-types/filters-date.md
+++ b/docs/filter-types/filters-date.md
@@ -3,8 +3,6 @@ title: Date Filters
 weight: 2
 ---
 
-## Date Filters
-
 Date filters are HTML date elements.
 
 ```php

--- a/docs/filter-types/filters-daterange.md
+++ b/docs/filter-types/filters-daterange.md
@@ -3,8 +3,6 @@ title: DateRange Filters
 weight: 3
 ---
 
-## DateRange Filters
-
 DateRange filters are Flatpickr based components, and simply filtering by a date range.  If you would like to more smoothly filter your query by a start and end date, you can use the DateRangeFilter:
 
 ```php

--- a/docs/filter-types/filters-datetime.md
+++ b/docs/filter-types/filters-datetime.md
@@ -3,8 +3,6 @@ title: DateTime Filters
 weight: 4
 ---
 
-## DateTime Filters
-
 DateTime filters are HTML datetime-local elements and act the same as date filters.
 
 ```php

--- a/docs/filter-types/filters-livewire-component.md
+++ b/docs/filter-types/filters-livewire-component.md
@@ -3,8 +3,6 @@ title: Livewire Custom Filter (Beta)
 weight: 11
 ---
 
-## Livewire Custom Filter
-
 **IN BETA**
 This feature is currently in beta, and use in production is not recommended.
 

--- a/docs/filter-types/filters-multiselect-dropdown.md
+++ b/docs/filter-types/filters-multiselect-dropdown.md
@@ -3,9 +3,6 @@ title: Multi-Select Dropdown Filters
 weight: 5
 ---
 
-
-## Multi-select dropdown Filters
-
 Multi-select dropdown filters are a simple dropdown list. The user can select multiple options from the list. There is also an 'All' option that will select all values
 
 ```php
@@ -26,4 +23,27 @@ public function filters(): array
             ->setFirstOption('All Tags'),
     ];
 }
+```
+
+## Filter Pills Separator
+
+As this filter returns one or more values, you have the option to utilise a custom separator for the values displayed in the Filter Pills section at the top of the table.  The default is ", ", but you may use any HTML string to separate the selected values
+
+```php
+public function filters(): array
+{
+    return [
+        MultiSelectFilter::make('Tags')
+            ->options(
+                Tag::query()
+                    ->orderBy('name')
+                    ->get()
+                    ->keyBy('id')
+                    ->map(fn($tag) => $tag->name)
+                    ->toArray()
+            )
+            ->setPillsSeparator('<br />'),
+    ];
+}
+
 ```

--- a/docs/filter-types/filters-multiselect.md
+++ b/docs/filter-types/filters-multiselect.md
@@ -3,8 +3,6 @@ title: Multi-Select Filters
 weight: 6
 ---
 
-## Multi-select Filters
-
 Multi-select filters are a list of checkboxes. The user can select multiple options from the list. There is also an 'All' option that will select all values.
 
 ```php
@@ -24,4 +22,27 @@ public function filters(): array
             ),
     ];
 }
+```
+
+## Filter Pills Separator
+
+As this filter returns one or more values, you have the option to utilise a custom separator for the values displayed in the Filter Pills section at the top of the table.  The default is ", ", but you may use any HTML string to separate the selected values
+
+```php
+public function filters(): array
+{
+    return [
+        MultiSelectFilter::make('Tags')
+            ->options(
+                Tag::query()
+                    ->orderBy('name')
+                    ->get()
+                    ->keyBy('id')
+                    ->map(fn($tag) => $tag->name)
+                    ->toArray()
+            )
+            ->setPillsSeparator('<br />'),
+    ];
+}
+
 ```

--- a/docs/filter-types/filters-number-range.md
+++ b/docs/filter-types/filters-number-range.md
@@ -3,8 +3,6 @@ title: NumberRange Filters
 weight: 7
 ---
 
-## NumberRange Filters
-
 NumberRange filters allow for a minimum and maximum value to be input on a single slider.
 
 ```php

--- a/docs/filter-types/filters-number.md
+++ b/docs/filter-types/filters-number.md
@@ -3,8 +3,6 @@ title: Number Filters
 weight: 8
 ---
 
-## Number Filters
-
 Number filters are just HTML number inputs.
 
 ```php

--- a/docs/filter-types/filters-select.md
+++ b/docs/filter-types/filters-select.md
@@ -3,8 +3,6 @@ title: Select Filters
 weight: 9
 ---
 
-## Select Filters
-
 Select filters are a simple dropdown list. The user selects one choice from the list.
 
 ```php

--- a/docs/filter-types/filters-text.md
+++ b/docs/filter-types/filters-text.md
@@ -3,8 +3,6 @@ title: Text Filters
 weight: 10
 ---
 
-## Text Filters
-
 Text filters are just HTML text fields.
 
 ```php

--- a/docs/filter-types/introduction.md
+++ b/docs/filter-types/introduction.md
@@ -4,3 +4,36 @@ weight: 1
 ---
 
 There are several Filter types available for use, offering a range of capabilities to filter your data.
+
+<ul>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-date">Date Filter</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-daterange">DateRange Filter</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-datetime">DateTime Filter</a>
+    </li>
+        <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-livewire-component">Livewire Component (BETA)</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-multiselect-dropdown">Multi Select Filter (Dropdown)</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-multiselect">Multi-Select Filter (Checkbox)</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-number-range">Number Range Filter</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-number">Number Filter</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-select">Select Filter</a>
+    </li>
+    <li>
+        <a href="https://rappasoft.com/docs/laravel-livewire-tables/v3/filter-types/filters-text">Text Filter</a>
+    </li>
+</ul>

--- a/resources/views/components/tools/filter-pills.blade.php
+++ b/resources/views/components/tools/filter-pills.blade.php
@@ -30,7 +30,17 @@
                             'badge rounded-pill bg-info d-inline-flex align-items-center' => $component->isBootstrap5(),
                         ])
                     >
-                        {{ $filter->getFilterPillTitle() }}: {{ $filter->getFilterPillValue($value) }}
+                        {{ $filter->getFilterPillTitle() }}: 
+                        @php( $filterPillValue = $filter->getFilterPillValue($value))
+                        @php( $separator = method_exists($filter, 'getPillsSeparator') ? $filter->getPillsSeparator() : ', ')
+
+                        @if(is_array($filterPillValue) && !empty($filterPillValue))
+                            @foreach($filterPillValue as $filterPillArrayValue)
+                                {{ $filterPillArrayValue }}{!! $separator !!}
+                            @endforeach
+                        @else
+                            {{ $filterPillValue }}
+                        @endif
 
                         @if ($component->isTailwind())
                             <button

--- a/src/Views/Filters/DateFilter.php
+++ b/src/Views/Filters/DateFilter.php
@@ -28,7 +28,7 @@ class DateFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value): ?string
+    public function getFilterPillValue($value):  string|array|null
     {
         if ($this->validate($value)) {
             return DateTime::createFromFormat('Y-m-d', $value)->format($this->getConfig('pillFormat'));

--- a/src/Views/Filters/DateFilter.php
+++ b/src/Views/Filters/DateFilter.php
@@ -28,7 +28,7 @@ class DateFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value):  string|array|null
+    public function getFilterPillValue($value): string|array|null
     {
         if ($this->validate($value)) {
             return DateTime::createFromFormat('Y-m-d', $value)->format($this->getConfig('pillFormat'));

--- a/src/Views/Filters/DateRangeFilter.php
+++ b/src/Views/Filters/DateRangeFilter.php
@@ -108,7 +108,7 @@ class DateRangeFilter extends Filter
         return [];
     }
 
-    public function getFilterPillValue($value): ?string
+    public function getFilterPillValue($value):  string|array|null
     {
         $validatedValue = $this->validate($value);
 

--- a/src/Views/Filters/DateRangeFilter.php
+++ b/src/Views/Filters/DateRangeFilter.php
@@ -108,7 +108,7 @@ class DateRangeFilter extends Filter
         return [];
     }
 
-    public function getFilterPillValue($value):  string|array|null
+    public function getFilterPillValue($value): string|array|null
     {
         $validatedValue = $this->validate($value);
 

--- a/src/Views/Filters/DateTimeFilter.php
+++ b/src/Views/Filters/DateTimeFilter.php
@@ -28,7 +28,7 @@ class DateTimeFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value): ?string
+    public function getFilterPillValue($value):  string|array|null
     {
         if ($this->validate($value)) {
             return DateTime::createFromFormat('Y-m-d\TH:i', $value)->format($this->getConfig('pillFormat'));

--- a/src/Views/Filters/DateTimeFilter.php
+++ b/src/Views/Filters/DateTimeFilter.php
@@ -28,7 +28,7 @@ class DateTimeFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value):  string|array|null
+    public function getFilterPillValue($value): string|array|null
     {
         if ($this->validate($value)) {
             return DateTime::createFromFormat('Y-m-d\TH:i', $value)->format($this->getConfig('pillFormat'));

--- a/src/Views/Filters/MultiSelectDropdownFilter.php
+++ b/src/Views/Filters/MultiSelectDropdownFilter.php
@@ -37,7 +37,7 @@ class MultiSelectDropdownFilter extends Filter
         return (is_string($value) || is_numeric($value)) ? $value : false;
     }
 
-    public function getFilterPillValue($value): ?string
+    public function getFilterPillValue($value):  string|array|null
     {
         $values = [];
 
@@ -52,7 +52,7 @@ class MultiSelectDropdownFilter extends Filter
             }
         }
 
-        return implode(', ', $values);
+        return $values;
     }
 
     public function isEmpty(mixed $value): bool

--- a/src/Views/Filters/MultiSelectDropdownFilter.php
+++ b/src/Views/Filters/MultiSelectDropdownFilter.php
@@ -37,7 +37,7 @@ class MultiSelectDropdownFilter extends Filter
         return (is_string($value) || is_numeric($value)) ? $value : false;
     }
 
-    public function getFilterPillValue($value):  string|array|null
+    public function getFilterPillValue($value): string|array|null
     {
         $values = [];
 

--- a/src/Views/Filters/MultiSelectFilter.php
+++ b/src/Views/Filters/MultiSelectFilter.php
@@ -34,7 +34,7 @@ class MultiSelectFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value): ?string
+    public function getFilterPillValue($value):  string|array|null
     {
         $values = [];
 
@@ -46,6 +46,6 @@ class MultiSelectFilter extends Filter
             }
         }
 
-        return implode(', ', $values);
+        return $values;
     }
 }

--- a/src/Views/Filters/MultiSelectFilter.php
+++ b/src/Views/Filters/MultiSelectFilter.php
@@ -34,7 +34,7 @@ class MultiSelectFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value):  string|array|null
+    public function getFilterPillValue($value): string|array|null
     {
         $values = [];
 

--- a/src/Views/Filters/NumberRangeFilter.php
+++ b/src/Views/Filters/NumberRangeFilter.php
@@ -86,7 +86,7 @@ class NumberRangeFilter extends Filter
         return [];
     }
 
-    public function getFilterPillValue($values):  string|array|null
+    public function getFilterPillValue($values): string|array|null
     {
         if ($this->validate($values)) {
             return __('Min:').$values['min'].', '.__('Max:').$values['max'];

--- a/src/Views/Filters/NumberRangeFilter.php
+++ b/src/Views/Filters/NumberRangeFilter.php
@@ -86,7 +86,7 @@ class NumberRangeFilter extends Filter
         return [];
     }
 
-    public function getFilterPillValue($values): ?string
+    public function getFilterPillValue($values):  string|array|null
     {
         if ($this->validate($values)) {
             return __('Min:').$values['min'].', '.__('Max:').$values['max'];

--- a/src/Views/Filters/SelectFilter.php
+++ b/src/Views/Filters/SelectFilter.php
@@ -41,7 +41,7 @@ class SelectFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value): ?string
+    public function getFilterPillValue($value):  string|array|null
     {
 
         return $this->getCustomFilterPillValue($value)

--- a/src/Views/Filters/SelectFilter.php
+++ b/src/Views/Filters/SelectFilter.php
@@ -41,7 +41,7 @@ class SelectFilter extends Filter
         return $value;
     }
 
-    public function getFilterPillValue($value):  string|array|null
+    public function getFilterPillValue($value): string|array|null
     {
 
         return $this->getCustomFilterPillValue($value)

--- a/src/Views/Traits/Filters/IsArrayFilter.php
+++ b/src/Views/Traits/Filters/IsArrayFilter.php
@@ -8,6 +8,8 @@ use Rappasoft\LaravelLivewireTables\Views\{Column,Filter};
 
 trait IsArrayFilter
 {
+    public string $pillsSeparator = ',';
+
     /**
      * Get the filter default options.
      */
@@ -32,4 +34,17 @@ trait IsArrayFilter
 
         return empty($value);
     }
+
+    public function getPillsSeparator(): string
+    {
+        return $this->pillsSeparator ?? ', ';
+    }
+
+    public function setPillsSeparator(string $pillsSeparator): self
+    {
+        $this->pillsSeparator = $pillsSeparator;
+
+        return $this;
+    }
+
 }

--- a/src/Views/Traits/Filters/IsArrayFilter.php
+++ b/src/Views/Traits/Filters/IsArrayFilter.php
@@ -8,7 +8,7 @@ use Rappasoft\LaravelLivewireTables\Views\{Column,Filter};
 
 trait IsArrayFilter
 {
-    public string $pillsSeparator = ',';
+    public string $pillsSeparator = ', ';
 
     /**
      * Get the filter default options.

--- a/src/Views/Traits/Filters/IsArrayFilter.php
+++ b/src/Views/Traits/Filters/IsArrayFilter.php
@@ -46,5 +46,4 @@ trait IsArrayFilter
 
         return $this;
     }
-
 }

--- a/src/Views/Traits/Helpers/FilterHelpers.php
+++ b/src/Views/Traits/Helpers/FilterHelpers.php
@@ -70,7 +70,7 @@ trait FilterHelpers
     /**
      * @param  mixed  $value
      */
-    public function getFilterPillValue($value): ?string
+    public function getFilterPillValue($value):  string|array|null
     {
         return $value;
     }

--- a/src/Views/Traits/Helpers/FilterHelpers.php
+++ b/src/Views/Traits/Helpers/FilterHelpers.php
@@ -70,7 +70,7 @@ trait FilterHelpers
     /**
      * @param  mixed  $value
      */
-    public function getFilterPillValue($value):  string|array|null
+    public function getFilterPillValue($value): string|array|null
     {
         return $value;
     }

--- a/tests/Http/Livewire/PetsTableCustomFilters.php
+++ b/tests/Http/Livewire/PetsTableCustomFilters.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
+
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Breed;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
+use Rappasoft\LaravelLivewireTables\Tests\Models\Species;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Columns\ImageColumn;
+use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateTimeFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\NumberFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter;
+
+class PetsTableCustomFilters extends DataTableComponent
+{
+    public $model = Pet::class;
+
+    public string $paginationTest = 'standard';
+
+    public function enableDetailedPagination(string $type = 'standard')
+    {
+        $this->setPerPageAccepted([1, 3, 5, 10, 15, 25, 50])->setPerPage(3);
+        $this->setPaginationMethod($type);
+        $this->setDisplayPaginationDetailsEnabled();
+
+    }
+
+    public function disableDetailedPagination(string $type = 'standard')
+    {
+        $this->setPerPageAccepted([1, 3, 5, 10, 15, 25, 50])->setPerPage(3);
+        $this->setPaginationMethod($type);
+        $this->setDisplayPaginationDetailsDisabled();
+    }
+
+    public function setPaginationTest(string $type)
+    {
+        $this->paginationTest = $type;
+    }
+
+    public function configure(): void
+    {
+        $this->setPrimaryKey('id');
+    }
+
+    public function columns(): array
+    {
+        return [
+            Column::make('ID', 'id')
+                ->sortable()
+                ->setSortingPillTitle('Key')
+                ->setSortingPillDirections('0-9', '9-0'),
+            Column::make('Sort')
+                ->sortable()
+                ->excludeFromColumnSelect(),
+            Column::make('Name')
+                ->sortable()
+                ->secondaryHeader($this->getFilterByKey('pet_name_filter'))
+                ->footerFilter('pet_name_filter')
+                ->searchable(),
+
+            Column::make('Age'),
+
+            Column::make('Breed', 'breed.name')
+                ->secondaryHeaderFilter('breed')
+                ->footer($this->getFilterByKey('breed'))
+                ->sortable(
+                    fn (Builder $query, string $direction) => $query->orderBy('pets.id', $direction)
+                )
+                ->searchable(
+                    fn (Builder $query, $searchTerm) => $query->orWhere('breed.name', $searchTerm)
+                ),
+
+            Column::make('Other')
+                ->label(function ($row, Column $column) {
+                    return 'Other';
+                })
+                ->footer(function ($rows) {
+                    return 'Count: '.$rows->count();
+                }),
+
+            LinkColumn::make('Link')
+                ->title(fn ($row) => 'Edit')
+                ->location(fn ($row) => 'http://www.google.com')
+                ->attributes(fn ($row) => [
+                    'class' => 'rounded-full',
+                    'alt' => $row->name.' Avatar',
+                ]),
+            ImageColumn::make('RowImg')
+                ->location(fn ($row) => 'test'.$row->id)
+                ->attributes(fn ($row) => [
+                    'class' => 'rounded-full',
+                    'alt' => $row->name.' Avatar',
+                ]),
+            Column::make('Last Visit', 'last_visit')
+                ->sortable()
+                ->deselected(),
+        ];
+    }
+
+    public function filters(): array
+    {
+        return [
+            MultiSelectFilter::make('Breed')
+                ->options(
+                    Breed::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($breed) => $breed->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, array $values) {
+                    return $builder->whereIn('breed_id', $values);
+                }),
+            MultiSelectDropdownFilter::make('Species')
+                ->options(
+                    Species::query()
+                        ->orderBy('name')
+                        ->get()
+                        ->keyBy('id')
+                        ->map(fn ($species) => $species->name)
+                        ->toArray()
+                )
+                ->filter(function (Builder $builder, array $values) {
+                    return $builder->whereIn('species_id', $values);
+                })
+                ->setPillsSeparator('<br />'),
+
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,7 +42,7 @@ class TestCase extends Orchestra
                 ['id' => 4, 'name' => 'Bird'],
             ]);
 
-            Breed::insert([ 
+            Breed::insert([
                 ['id' => 1, 'name' => 'American Shorthair', 'species_id' => 1],
                 ['id' => 2, 'name' => 'Maine Coon', 'species_id' => 1],
                 ['id' => 3, 'name' => 'Persian', 'species_id' => 1],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,7 +42,7 @@ class TestCase extends Orchestra
                 ['id' => 4, 'name' => 'Bird'],
             ]);
 
-            Breed::insert([
+            Breed::insert([ 
                 ['id' => 1, 'name' => 'American Shorthair', 'species_id' => 1],
                 ['id' => 2, 'name' => 'Maine Coon', 'species_id' => 1],
                 ['id' => 3, 'name' => 'Persian', 'species_id' => 1],

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -87,6 +87,76 @@ final class FilterVisualsTest extends TestCase
             ->assertDontSee('Applied Filters');
     }
 
+    public function test_filters_pills_separator_is_customisable(): void
+    {
+        Livewire::test(new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id')
+                    ->setShouldAlwaysHideBulkActionsDropdownOptionEnabled();
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        })->set('filterComponents.invalid-filter', [1])
+            ->assertHasNoErrors()
+            ->assertDontSee('Applied Filters');
+    }
+
+    public function test_filters_pills_separator_is_customisable(): void
+    {
+        Livewire::test(new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+            }
+
+            public function filters(): array
+            {
+                return [
+                    MultiSelectFilter::make('Breed')
+                        ->options(
+                            Breed::query()
+                                ->orderBy('name')
+                                ->get()
+                                ->keyBy('id')
+                                ->map(fn ($breed) => $breed->name)
+                                ->toArray()
+                        )
+                        ->filter(function (Builder $builder, array $values) {
+                            return $builder->whereIn('breed_id', $values);
+                        }),
+                    MultiSelectDropdownFilter::make('Species')
+                        ->options(
+                            Species::query()
+                                ->orderBy('name')
+                                ->get()
+                                ->keyBy('id')
+                                ->map(fn ($species) => $species->name)
+                                ->toArray()
+                        )
+                        ->filter(function (Builder $builder, array $values) {
+                            return $builder->whereIn('species_id', $values);
+                        })
+                        ->setPillsSeparator('<br />'),
+        
+                ];
+            }
+        
+        })
+        ->set('filterComponents.species', [1,2])
+        ->assertDontSee('Bulk Actions');
+    }
+
     /*public function test_filter_events_apply_correctly(): void
     {
         Livewire::test(PetsTable::class)

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -148,13 +148,12 @@ final class FilterVisualsTest extends TestCase
                             return $builder->whereIn('species_id', $values);
                         })
                         ->setPillsSeparator('<br />'),
-        
+
                 ];
             }
-        
         })
-        ->set('filterComponents.species', [1,2])
-        ->assertDontSee('Bulk Actions');
+            ->set('filterComponents.species', [1, 2])
+            ->assertDontSee('Bulk Actions');
     }
 
     /*public function test_filter_events_apply_correctly(): void

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -87,29 +87,6 @@ final class FilterVisualsTest extends TestCase
             ->assertDontSee('Applied Filters');
     }
 
-    public function test_filters_pills_separator_is_customisable(): void
-    {
-        Livewire::test(new class extends PetsTable
-        {
-            public function configure(): void
-            {
-                $this->setPrimaryKey('id')
-                    ->setShouldAlwaysHideBulkActionsDropdownOptionEnabled();
-            }
-
-            public function bulkActions(): array
-            {
-                return ['exportBulk' => 'exportBulk'];
-            }
-
-            public function exportBulk($items)
-            {
-                return $items;
-            }
-        })->set('filterComponents.invalid-filter', [1])
-            ->assertHasNoErrors()
-            ->assertDontSee('Applied Filters');
-    }
 
     public function test_filters_pills_separator_is_customisable(): void
     {
@@ -123,29 +100,29 @@ final class FilterVisualsTest extends TestCase
             public function filters(): array
             {
                 return [
-                    MultiSelectFilter::make('Breed')
+                    \Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectFilter::make('Breed')
                         ->options(
-                            Breed::query()
+                            \Rappasoft\LaravelLivewireTables\Tests\Models\Breed::query()
                                 ->orderBy('name')
                                 ->get()
                                 ->keyBy('id')
                                 ->map(fn ($breed) => $breed->name)
                                 ->toArray()
                         )
-                        ->filter(function (Builder $builder, array $values) {
-                            return $builder->whereIn('breed_id', $values);
+                        ->filter(function (\Illuminate\Database\Eloquent\Builder $builder, array $values) {
+                            return $builder->whereIn('pets.breed_id', $values);
                         }),
-                    MultiSelectDropdownFilter::make('Species')
+                    \Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter::make('Species')
                         ->options(
-                            Species::query()
+                            \Rappasoft\LaravelLivewireTables\Tests\Models\Species::query()
                                 ->orderBy('name')
                                 ->get()
                                 ->keyBy('id')
                                 ->map(fn ($species) => $species->name)
                                 ->toArray()
                         )
-                        ->filter(function (Builder $builder, array $values) {
-                            return $builder->whereIn('species_id', $values);
+                        ->filter(function (\Illuminate\Database\Eloquent\Builder $builder, array $values) {
+                            return $builder->whereIn('pets.species_id', $values);
                         })
                         ->setPillsSeparator('<br />'),
 
@@ -153,7 +130,19 @@ final class FilterVisualsTest extends TestCase
             }
         })
             ->set('filterComponents.species', [1, 2])
-            ->assertDontSee('Bulk Actions');
+            ->assertSeeHtmlInOrder([
+                'wire:key="table-filter-pill-species"',
+                'Cat',
+                '<br />',
+                'Dog',
+                '<br />',
+            ])
+            ->set('filterComponents.breed', [1, 2])
+            ->assertSeeHtmlInOrder([
+                'wire:key="table-filter-pill-breed"',
+                'American Shorthair,',
+                'Maine Coon',
+            ]);
     }
 
     /*public function test_filter_events_apply_correctly(): void

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -87,7 +87,6 @@ final class FilterVisualsTest extends TestCase
             ->assertDontSee('Applied Filters');
     }
 
-
     public function test_filters_pills_separator_is_customisable(): void
     {
         Livewire::test(new class extends PetsTable

--- a/tests/Views/Filters/MultiSelectDropdownFilterTest.php
+++ b/tests/Views/Filters/MultiSelectDropdownFilterTest.php
@@ -264,8 +264,8 @@ final class MultiSelectDropdownFilterTest extends TestCase
     public function test_can_set_separator(array $optionsArray): void
     {
         $filter = MultiSelectDropdownFilter::make('Active')->options($optionsArray);
-        $this->assertSame(", ",$filter->getPillsSeparator());
+        $this->assertSame(', ', $filter->getPillsSeparator());
         $filter->setPillsSeparator('<br />');
-        $this->assertSame("<br />",$filter->getPillsSeparator());
+        $this->assertSame('<br />', $filter->getPillsSeparator());
     }
 }

--- a/tests/Views/Filters/MultiSelectDropdownFilterTest.php
+++ b/tests/Views/Filters/MultiSelectDropdownFilterTest.php
@@ -90,8 +90,8 @@ final class MultiSelectDropdownFilterTest extends TestCase
     public function test_can_get_filter_pill_value(array $optionsArray): void
     {
         $filter = MultiSelectDropdownFilter::make('Active')->options($optionsArray);
-        $this->assertSame($optionsArray[1], $filter->getFilterPillValue(['1']));
-        $this->assertSame($optionsArray[1].', '.$optionsArray[2], $filter->getFilterPillValue(['1', '2']));
+        $this->assertSame($optionsArray[1], $filter->getFilterPillValue(['1'])[0]);
+        $this->assertSame([$optionsArray[1], $optionsArray[2]], $filter->getFilterPillValue(['1', '2']));
     }
 
     public function test_can_check_if_filter_has_configs(): void
@@ -258,5 +258,14 @@ final class MultiSelectDropdownFilterTest extends TestCase
         $this->assertSame('live.debounce.500ms', $filter->getWireableMethod());
         $this->assertSame('wire:model.live.debounce.500ms=filterComponents.active', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
 
+    }
+
+    #[Depends('test_array_setup')]
+    public function test_can_set_separator(array $optionsArray): void
+    {
+        $filter = MultiSelectDropdownFilter::make('Active')->options($optionsArray);
+        $this->assertSame(", ",$filter->getPillsSeparator());
+        $filter->setPillsSeparator('<br />');
+        $this->assertSame("<br />",$filter->getPillsSeparator());
     }
 }

--- a/tests/Views/Filters/MultiSelectFilterTest.php
+++ b/tests/Views/Filters/MultiSelectFilterTest.php
@@ -224,6 +224,14 @@ final class MultiSelectFilterTest extends TestCase
 
         $this->assertSame('live.debounce.500ms', $filter->getWireableMethod());
         $this->assertSame('wire:model.live.debounce.500ms=filterComponents.active', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
-
     }
+
+    public function test_can_set_separator(): void
+    {
+        $filter = MultiSelectFilter::make('Active');
+        $this->assertSame(", ",$filter->getPillsSeparator());
+        $filter->setPillsSeparator('<br />');
+        $this->assertSame("<br />",$filter->getPillsSeparator());
+    }
+
 }

--- a/tests/Views/Filters/MultiSelectFilterTest.php
+++ b/tests/Views/Filters/MultiSelectFilterTest.php
@@ -229,9 +229,8 @@ final class MultiSelectFilterTest extends TestCase
     public function test_can_set_separator(): void
     {
         $filter = MultiSelectFilter::make('Active');
-        $this->assertSame(", ",$filter->getPillsSeparator());
+        $this->assertSame(', ', $filter->getPillsSeparator());
         $filter->setPillsSeparator('<br />');
-        $this->assertSame("<br />",$filter->getPillsSeparator());
+        $this->assertSame('<br />', $filter->getPillsSeparator());
     }
-
 }


### PR DESCRIPTION
Adding in option to set a custom Pills Separator for Array type Filters (MultiSelect and MultiSelectDropdown)

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
