### PR TITLE
Add SetFilterDefaultValue to DateRange Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## [v3.3.4] - UNRELEASED
+### New Features
+- Added capability to setFilterDefaultValue for a DateRangeFilter by @lrljoe
+
 ## [v3.3.3] - 2024-07-23
 ### New Features
 - Add additional DateRangeFilter options by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1793

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [v3.3.4] - UNRELEASED
 ### New Features
-- Added capability to setFilterDefaultValue for a DateRangeFilter by @lrljoe
+- Added capability to setFilterDefaultValue for a DateRangeFilter by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1796
 
 ## [v3.3.3] - 2024-07-23
 ### New Features

--- a/docs/filter-types/filters-daterange.md
+++ b/docs/filter-types/filters-daterange.md
@@ -75,7 +75,11 @@ You may use this to set a default value for the filter that will be applied on f
         ->setFilterDefaultValue(['minDate' => '2024-05-05', 'maxDate' => '2024-06-06'])
 ```
 or
-
+```
+    DateRangeFilter::make('EMail Verified Range')
+        ->setFilterDefaultValue(['min' => '2024-05-05', 'max' => '2024-06-06'])
+```
+or
 ```
     DateRangeFilter::make('EMail Verified Range')
         ->setFilterDefaultValue(['2024-05-05', '2024-06-06'])

--- a/docs/filter-types/filters-daterange.md
+++ b/docs/filter-types/filters-daterange.md
@@ -66,6 +66,21 @@ A full list of options is below, please see the Flatpickr documentation for refe
 | time_24hr | Boolean | false | Displays time picker in 24 hour mode without AM/PM selection when enabled. | 
 | weekNumbers | Boolean | false | Enables display of week numbers in calendar. | 
 
+## setFilterDefaultValue
+
+You may use this to set a default value for the filter that will be applied on first load (but may be cleared by the user).  This should be an array:
+
+```
+    DateRangeFilter::make('EMail Verified Range')
+        ->setFilterDefaultValue(['minDate' => '2024-05-05', 'maxDate' => '2024-06-06'])
+```
+or
+
+```
+    DateRangeFilter::make('EMail Verified Range')
+        ->setFilterDefaultValue(['2024-05-05', '2024-06-06'])
+```
+
 
 ## Configuration
 By default, this filter will inject the Flatpickr JS Library and CSS. However, you can customise this behaviour using the configuration file.

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -63,7 +63,7 @@ class MakeCommand extends Command implements PromptsForMissingInput
             $this->argument('name')
         );
 
-        $livewireMakeCommand = new LivewireMakeCommand();
+        $livewireMakeCommand = new LivewireMakeCommand;
 
         if ($livewireMakeCommand->isReservedClassName($name = $this->parser->className())) {
             $this->line("<fg=red;options=bold>Class is reserved:</> {$name}");
@@ -184,7 +184,7 @@ class MakeCommand extends Command implements PromptsForMissingInput
      */
     private function generateColumns(string $modelName): string
     {
-        $model = new $modelName();
+        $model = new $modelName;
 
         if ($model instanceof Model === false) {
             throw new \Exception('Invalid model given.');

--- a/src/Views/Filters/DateRangeFilter.php
+++ b/src/Views/Filters/DateRangeFilter.php
@@ -135,7 +135,7 @@ class DateRangeFilter extends Filter
             if (array_key_exists('maxDate', $value)) {
                 $maxDate = $value['maxDate'];
             } elseif (array_key_exists('max', $value)) {
-                $minDate = $value['max'];
+                $maxDate = $value['max'];
             } elseif (array_key_exists(1, $value)) {
                 $maxDate = $value[1];
             }

--- a/src/Views/Filters/DateRangeFilter.php
+++ b/src/Views/Filters/DateRangeFilter.php
@@ -112,7 +112,7 @@ class DateRangeFilter extends Filter
     {
         return $this->filterDefaultValue ?? [];
     }
-    
+
     public function hasFilterDefaultValue(): bool
     {
         return ! is_null($this->filterDefaultValue);
@@ -120,39 +120,27 @@ class DateRangeFilter extends Filter
 
     public function setFilterDefaultValue($value): self
     {
-        if (is_array($value))
-        {
+        if (is_array($value)) {
             $minDate = '';
             $maxDate = '';
-    
-            if(array_key_exists('minDate',$value))
-            {
+
+            if (array_key_exists('minDate', $value)) {
                 $minDate = $value['minDate'];
-            }
-            elseif(array_key_exists('min',$value))
-            {
+            } elseif (array_key_exists('min', $value)) {
                 $minDate = $value['min'];
-            }
-            elseif(array_key_exists(0,$value))
-            {
+            } elseif (array_key_exists(0, $value)) {
                 $minDate = $value[0];
             }
 
-            if(array_key_exists('maxDate',$value))
-            {
+            if (array_key_exists('maxDate', $value)) {
                 $maxDate = $value['maxDate'];
-            }
-            elseif(array_key_exists('max',$value))
-            {
+            } elseif (array_key_exists('max', $value)) {
                 $minDate = $value['max'];
-            }
-            elseif(array_key_exists(1,$value))
-            {
+            } elseif (array_key_exists(1, $value)) {
                 $maxDate = $value[1];
             }
             $this->filterDefaultValue = ['minDate' => $minDate, 'maxDate' => $maxDate];
-        }
-        else {
+        } else {
             $this->filterDefaultValue = ['minDate' => $value, 'maxDate' => $value];
         }
 

--- a/src/Views/Filters/DateRangeFilter.php
+++ b/src/Views/Filters/DateRangeFilter.php
@@ -108,6 +108,57 @@ class DateRangeFilter extends Filter
         return [];
     }
 
+    public function getFilterDefaultValue(): array
+    {
+        return $this->filterDefaultValue ?? [];
+    }
+    
+    public function hasFilterDefaultValue(): bool
+    {
+        return ! is_null($this->filterDefaultValue);
+    }
+
+    public function setFilterDefaultValue($value): self
+    {
+        if (is_array($value))
+        {
+            $minDate = '';
+            $maxDate = '';
+    
+            if(array_key_exists('minDate',$value))
+            {
+                $minDate = $value['minDate'];
+            }
+            elseif(array_key_exists('min',$value))
+            {
+                $minDate = $value['min'];
+            }
+            elseif(array_key_exists(0,$value))
+            {
+                $minDate = $value[0];
+            }
+
+            if(array_key_exists('maxDate',$value))
+            {
+                $maxDate = $value['maxDate'];
+            }
+            elseif(array_key_exists('max',$value))
+            {
+                $minDate = $value['max'];
+            }
+            elseif(array_key_exists(1,$value))
+            {
+                $maxDate = $value[1];
+            }
+            $this->filterDefaultValue = ['minDate' => $minDate, 'maxDate' => $maxDate];
+        }
+        else {
+            $this->filterDefaultValue = ['minDate' => $value, 'maxDate' => $value];
+        }
+
+        return $this;
+    }
+
     public function getFilterPillValue($value): string|array|null
     {
         $validatedValue = $this->validate($value);

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -55,7 +55,7 @@ class DataTableComponentTest extends TestCase
 
     public function test_default_datatable_fingerprints_will_be_different_for_each_table(): void
     {
-        $mockTable = new class() extends PetsTable {};
+        $mockTable = new class extends PetsTable {};
 
         $this->assertNotSame($this->basicTable->getDataTableFingerprint(), $mockTable->getDataTableFingerprint());
     }
@@ -64,7 +64,7 @@ class DataTableComponentTest extends TestCase
     {
         $mocks = [];
         for ($i = 0; $i < 9; $i++) {
-            $mocks[$i] = new class() extends PetsTable {};
+            $mocks[$i] = new class extends PetsTable {};
             $this->assertFalse(filter_var('http://'.$mocks[$i]->getDataTableFingerprint().'.dev', FILTER_VALIDATE_URL) === false);
         }
         // control
@@ -74,7 +74,7 @@ class DataTableComponentTest extends TestCase
     public function test_minimum_one_column_expected(): void
     {
         $this->expectException(\Rappasoft\LaravelLivewireTables\Exceptions\NoColumnsException::class);
-        $table = new NoColumnsTable();
+        $table = new NoColumnsTable;
         $table->boot();
         $table->bootedComponentUtilities();
         $table->bootedWithData();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,8 +36,8 @@ class TestCase extends Orchestra
 
         if (! Breed::where('id', 1)->get()) {
             include_once __DIR__.'/../database/migrations/create_test_tables.php.stub';
-            (new \CreateTestTables())->down();
-            (new \CreateTestTables())->up();
+            (new \CreateTestTables)->down();
+            (new \CreateTestTables)->up();
 
             Species::insert([
                 ['id' => 1, 'name' => 'Cat'],
@@ -88,7 +88,7 @@ class TestCase extends Orchestra
     protected function setupBasicTable()
     {
         $view = view('livewire-tables::datatable');
-        $this->basicTable = new PetsTable();
+        $this->basicTable = new PetsTable;
         $this->basicTable->boot();
         $this->basicTable->bootedComponentUtilities();
         $this->basicTable->bootedWithData();
@@ -104,7 +104,7 @@ class TestCase extends Orchestra
     protected function setupSpeciesTable()
     {
         $view = view('livewire-tables::datatable');
-        $this->speciesTable = new SpeciesTable();
+        $this->speciesTable = new SpeciesTable;
         $this->speciesTable->boot();
         $this->speciesTable->bootedComponentUtilities();
         $this->speciesTable->bootedWithData();
@@ -121,7 +121,7 @@ class TestCase extends Orchestra
     {
 
         $view = view('livewire-tables::datatable');
-        $this->unpaginatedTable = new PetsTableUnpaginated();
+        $this->unpaginatedTable = new PetsTableUnpaginated;
         $this->unpaginatedTable->boot();
         $this->unpaginatedTable->bootedComponentUtilities();
         $this->unpaginatedTable->bootedWithData();

--- a/tests/Traits/WithMountTest.php
+++ b/tests/Traits/WithMountTest.php
@@ -11,7 +11,7 @@ final class WithMountTest extends TestCase
     {
         $view = view('livewire-tables::datatable');
 
-        $table = new PetsTableMount();
+        $table = new PetsTableMount;
         $table->boot();
         $table->mount(102);
         $table->bootedComponentUtilities();
@@ -29,7 +29,7 @@ final class WithMountTest extends TestCase
         $this->assertNotSame(strtoupper($rows->first()->name), 'CHICO');
         $this->assertNotSame(strtoupper($rows->first()->name), 'CARTMAN');
 
-        $table2 = new PetsTableMount();
+        $table2 = new PetsTableMount;
         $table2->boot();
         $table2->mount(202);
         $table2->bootedComponentUtilities();
@@ -46,7 +46,7 @@ final class WithMountTest extends TestCase
         $this->assertNotSame(strtoupper($rows2->first()->name), 'CARTMAN');
         $this->assertNotSame(strtoupper($rows2->first()->name), 'MAY');
 
-        $table3 = new PetsTableMount();
+        $table3 = new PetsTableMount;
         $table3->boot();
         $table3->mount();
         $table3->bootedComponentUtilities();

--- a/tests/Views/Filters/DateRangeFilterTest.php
+++ b/tests/Views/Filters/DateRangeFilterTest.php
@@ -398,4 +398,34 @@ final class DateRangeFilterTest extends FilterTestCase
         $filter->setCustomView('test-custom-filter-view');
         $this->assertSame('test-custom-filter-view', $filter->getViewPath());
     }
+
+    public function test_can_set_default_value_by_string(): void
+    {
+        $filter = DateRangeFilter::make('Active');
+        $this->assertFalse($filter->hasFilterDefaultValue());
+        $filter->setFilterDefaultValue('2024-04-04');
+        $this->assertTrue($filter->hasFilterDefaultValue());
+        $this->assertSame(['minDate' => '2024-04-04', 'maxDate' => '2024-04-04'], $filter->getFilterDefaultValue());
+
+    }
+
+    public function test_can_set_default_value_by_named_array(): void
+    {
+        $filter = DateRangeFilter::make('Active');
+        $this->assertFalse($filter->hasFilterDefaultValue());
+        $filter->setFilterDefaultValue(['minDate' => '2024-05-04', 'maxDate' => '2024-06-04']);
+        $this->assertTrue($filter->hasFilterDefaultValue());
+        $this->assertSame(['minDate' => '2024-05-04', 'maxDate' => '2024-06-04'], $filter->getFilterDefaultValue());
+
+    }
+
+    public function test_can_set_default_value_by_numbered_array(): void
+    {
+        $filter = DateRangeFilter::make('Active');
+        $this->assertFalse($filter->hasFilterDefaultValue());
+        $filter->setFilterDefaultValue(['2024-06-04', '2024-07-04']);
+        $this->assertTrue($filter->hasFilterDefaultValue());
+        $this->assertSame(['minDate' => '2024-08-04', 'maxDate' => '2024-07-04'], $filter->getFilterDefaultValue());
+    }
+
 }

--- a/tests/Views/Filters/DateRangeFilterTest.php
+++ b/tests/Views/Filters/DateRangeFilterTest.php
@@ -425,6 +425,6 @@ final class DateRangeFilterTest extends FilterTestCase
         $this->assertFalse($filter->hasFilterDefaultValue());
         $filter->setFilterDefaultValue(['2024-06-04', '2024-07-04']);
         $this->assertTrue($filter->hasFilterDefaultValue());
-        $this->assertSame(['minDate' => '2024-08-04', 'maxDate' => '2024-07-04'], $filter->getFilterDefaultValue());
+        $this->assertSame(['minDate' => '2024-06-04', 'maxDate' => '2024-07-04'], $filter->getFilterDefaultValue());
     }
 }

--- a/tests/Views/Filters/DateRangeFilterTest.php
+++ b/tests/Views/Filters/DateRangeFilterTest.php
@@ -427,5 +427,4 @@ final class DateRangeFilterTest extends FilterTestCase
         $this->assertTrue($filter->hasFilterDefaultValue());
         $this->assertSame(['minDate' => '2024-08-04', 'maxDate' => '2024-07-04'], $filter->getFilterDefaultValue());
     }
-
 }

--- a/tests/Views/Filters/DateRangeFilterTest.php
+++ b/tests/Views/Filters/DateRangeFilterTest.php
@@ -419,6 +419,16 @@ final class DateRangeFilterTest extends FilterTestCase
 
     }
 
+    public function test_can_set_default_value_by_short_named_array(): void
+    {
+        $filter = DateRangeFilter::make('Active');
+        $this->assertFalse($filter->hasFilterDefaultValue());
+        $filter->setFilterDefaultValue(['min' => '2024-05-04', 'max' => '2024-06-04']);
+        $this->assertTrue($filter->hasFilterDefaultValue());
+        $this->assertSame(['minDate' => '2024-05-04', 'maxDate' => '2024-06-04'], $filter->getFilterDefaultValue());
+
+    }
+
     public function test_can_set_default_value_by_numbered_array(): void
     {
         $filter = DateRangeFilter::make('Active');


### PR DESCRIPTION
This adds in setFilterDefaultValue for the DateRange filter, e.g:
```
    DateRangeFilter::make('EMail Verified Range')
        ->setFilterDefaultValue(['minDate' => '2024-05-05', 'maxDate' => '2024-06-06'])
```
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
