### PR TITLE
Set reorder th attributes

### DIFF
--- a/docs/datatable/styling.md
+++ b/docs/datatable/styling.md
@@ -130,6 +130,7 @@ public function configure(): void
 Set a list of attributes to override on the th elements.  
 
 Note: If you are using Bulk Actions, then the th for Bulk Actions is [styled separately](../bulk-actions/customisations).
+Note: If you are using Reorder, then the th for Reorder is [styled separately](../reordering/available-methods).
 
 ```php
 public function configure(): void

--- a/docs/reordering/available-methods.md
+++ b/docs/reordering/available-methods.md
@@ -142,3 +142,19 @@ public function configure(): void
     $this->setDefaultReorderSort('order', 'desc');
 }
 ```
+
+
+## setReorderThAttributes
+
+You may pass an array to this method, which allows you to pass Custom Attributes into the table header for the Reorder Column
+
+```php
+public function configure(): void
+{
+
+    $this->setReorderThAttributes([
+        'class' => 'bg-red-500',
+        'default' => false
+    ]);
+}
+```

--- a/resources/views/components/table/th/reorder.blade.php
+++ b/resources/views/components/table/th/reorder.blade.php
@@ -1,5 +1,12 @@
-@aware(['component', 'tableName'])
+@aware(['tableName'])
 
-<x-livewire-tables::table.th.plain x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $tableName }}-thead-reorder" :displayMinimisedOnReorder="false">
+<x-livewire-tables::table.th.plain x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $tableName }}-thead-reorder" :displayMinimisedOnReorder="false" {{ 
+        $attributes->merge($this->getReorderThAttributes())->class([
+            'table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left bg-gray-50 dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised' => ($this->isTailwind()) && ($this->getReorderThAttributes['default'] ?? true),
+            'laravel-livewire-tables-reorderingMinimised' => ($this->isBootstrap()) && ($this->getReorderThAttributes['default'] ?? true),
+        ])
+    }}
+>
     <div x-cloak x-show="currentlyReorderingStatus"></div>
 </x-livewire-tables::table.th.plain>
+

--- a/src/Traits/Configuration/ReorderingConfiguration.php
+++ b/src/Traits/Configuration/ReorderingConfiguration.php
@@ -91,6 +91,4 @@ trait ReorderingConfiguration
 
         return $this;
     }
-
-
 }

--- a/src/Traits/Configuration/ReorderingConfiguration.php
+++ b/src/Traits/Configuration/ReorderingConfiguration.php
@@ -81,4 +81,16 @@ trait ReorderingConfiguration
 
         return $this;
     }
+
+    /**
+     * Used to set attributes for the <th> for Reorder Column
+     */
+    public function setReorderThAttributes(array $reorderThAttributes): self
+    {
+        $this->reorderThAttributes = [...$this->reorderThAttributes, ...$reorderThAttributes];
+
+        return $this;
+    }
+
+
 }

--- a/src/Traits/Helpers/ReorderingHelpers.php
+++ b/src/Traits/Helpers/ReorderingHelpers.php
@@ -92,7 +92,6 @@ trait ReorderingHelpers
         return $this->getTableName().'-reordering-backup';
     }
 
-    
     /**
      * Used to get attributes for the <th> for Bulk Actions
      *
@@ -103,6 +102,4 @@ trait ReorderingHelpers
     {
         return $this->reorderThAttributes ?? ['default' => true];
     }
-
-
 }

--- a/src/Traits/Helpers/ReorderingHelpers.php
+++ b/src/Traits/Helpers/ReorderingHelpers.php
@@ -91,4 +91,18 @@ trait ReorderingHelpers
     {
         return $this->getTableName().'-reordering-backup';
     }
+
+    
+    /**
+     * Used to get attributes for the <th> for Bulk Actions
+     *
+     * @return array<mixed>
+     */
+    #[Computed]
+    public function getReorderThAttributes(): array
+    {
+        return $this->reorderThAttributes ?? ['default' => true];
+    }
+
+
 }

--- a/src/Traits/WithReordering.php
+++ b/src/Traits/WithReordering.php
@@ -26,6 +26,8 @@ trait WithReordering
 
     public array $orderedItems = [];
 
+    protected array $reorderThAttributes = ['default' => true];
+
     public function setupReordering(): void
     {
         if ($this->reorderIsDisabled()) {

--- a/tests/Traits/Configuration/ReorderingConfigurationTest.php
+++ b/tests/Traits/Configuration/ReorderingConfigurationTest.php
@@ -106,5 +106,4 @@ final class ReorderingConfigurationTest extends TestCase
         $this->assertSame(['default' => true, 'class' => 'bg-red-500', 'style' => 'font:black'], $this->basicTable->getReorderThAttributes());
 
     }
-
 }

--- a/tests/Traits/Configuration/ReorderingConfigurationTest.php
+++ b/tests/Traits/Configuration/ReorderingConfigurationTest.php
@@ -88,4 +88,23 @@ final class ReorderingConfigurationTest extends TestCase
         $this->assertSame('sort2', $this->basicTable->getDefaultReorderColumn());
         $this->assertSame('desc', $this->basicTable->getDefaultReorderDirection());
     }
+
+    public function test_can_set_reorder_th_attributes(): void
+    {
+        $this->assertSame(['default' => true], $this->basicTable->getReorderThAttributes());
+
+        $this->basicTable->setReorderThAttributes(['class' => 'bg-blue-500']);
+
+        $this->assertSame(['default' => true, 'class' => 'bg-blue-500'], $this->basicTable->getReorderThAttributes());
+
+        $this->basicTable->setReorderThAttributes(['class' => 'bg-red-500', 'default' => false]);
+
+        $this->assertSame(['default' => false, 'class' => 'bg-red-500'], $this->basicTable->getReorderThAttributes());
+
+        $this->basicTable->setReorderThAttributes(['style' => 'font:black', 'default' => true]);
+
+        $this->assertSame(['default' => true, 'class' => 'bg-red-500', 'style' => 'font:black'], $this->basicTable->getReorderThAttributes());
+
+    }
+
 }


### PR DESCRIPTION
Allows configuring the "reorder" TH attributes

## setReorderThAttributes

You may pass an array to this method, which allows you to pass Custom Attributes into the table header for the Reorder Column

```php
public function configure(): void
{

    $this->setReorderThAttributes([
        'class' => 'bg-red-500',
        'default' => false
    ]);
}
```

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
