### PR TITLE
Removing old $listeners approach

### DIFF
--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -4,6 +4,7 @@ namespace Rappasoft\LaravelLivewireTables;
 
 use Livewire\Component;
 use Rappasoft\LaravelLivewireTables\Traits\HasAllTraits;
+use Livewire\Attributes\On;
 
 abstract class DataTableComponent extends Component
 {

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -9,18 +9,10 @@ abstract class DataTableComponent extends Component
 {
     use HasAllTraits;
 
-    /** @phpstan-ignore-next-line */
-    protected $listeners = [
-        'refreshDatatable' => '$refresh',
-        'setSort' => 'setSortEvent',
-        'clearSorts' => 'clearSortEvent',
-        'setFilter' => 'setFilterEvent',
-        'clearFilters' => 'clearFilterEvent',
-    ];
-
     /**
      * Runs on every request, immediately after the component is instantiated, but before any other lifecycle methods are called
      */
+    #[On('refreshDatatable')]
     public function boot(): void
     {
         //

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -2,9 +2,9 @@
 
 namespace Rappasoft\LaravelLivewireTables;
 
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Rappasoft\LaravelLivewireTables\Traits\HasAllTraits;
-use Livewire\Attributes\On;
 
 abstract class DataTableComponent extends Component
 {

--- a/src/Traits/Helpers/EventHelpers.php
+++ b/src/Traits/Helpers/EventHelpers.php
@@ -4,7 +4,6 @@ namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
 
 trait EventHelpers
 {
-    
     public function getEventStatus(string $event): bool
     {
         return $this->eventStatuses[$event] ?? false;

--- a/src/Traits/Helpers/EventHelpers.php
+++ b/src/Traits/Helpers/EventHelpers.php
@@ -4,6 +4,7 @@ namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
 
 trait EventHelpers
 {
+    
     public function getEventStatus(string $event): bool
     {
         return $this->eventStatuses[$event] ?? false;

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -133,7 +133,7 @@ trait FilterHelpers
         });
     }
 
-    #[On('setFilter')] 
+    #[On('setFilter')]
     #[On('set-filter')]
     public function setFilter(string $filterKey, mixed $value): void
     {
@@ -163,8 +163,8 @@ trait FilterHelpers
 
         $this->setFilter($filterKey, array_keys($filter->getOptions()));
     }
-    
-    #[On('clearFilters')] 
+
+    #[On('clearFilters')]
     #[On('clear-filters')]
     public function setFilterDefaults(): void
     {

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -133,6 +133,7 @@ trait FilterHelpers
         });
     }
 
+    #[On('setFilter')] 
     #[On('set-filter')]
     public function setFilter(string $filterKey, mixed $value): void
     {
@@ -162,7 +163,8 @@ trait FilterHelpers
 
         $this->setFilter($filterKey, array_keys($filter->getOptions()));
     }
-
+    
+    #[On('clearFilters')] 
     #[On('clear-filters')]
     public function setFilterDefaults(): void
     {

--- a/src/Traits/Helpers/SortingHelpers.php
+++ b/src/Traits/Helpers/SortingHelpers.php
@@ -39,6 +39,7 @@ trait SortingHelpers
         return $this->sorts[$field] ?? null;
     }
 
+    #[On('setSort')] 
     #[On('set-sort')]
     public function setSort(string $field, string $direction): string
     {
@@ -58,6 +59,7 @@ trait SortingHelpers
     /**
      * Clear the sorts array
      */
+    #[On('clearSorts')] 
     #[On('clearsorts')]
     public function clearSorts(): void
     {

--- a/src/Traits/Helpers/SortingHelpers.php
+++ b/src/Traits/Helpers/SortingHelpers.php
@@ -39,7 +39,7 @@ trait SortingHelpers
         return $this->sorts[$field] ?? null;
     }
 
-    #[On('setSort')] 
+    #[On('setSort')]
     #[On('set-sort')]
     public function setSort(string $field, string $direction): string
     {
@@ -59,7 +59,7 @@ trait SortingHelpers
     /**
      * Clear the sorts array
      */
-    #[On('clearSorts')] 
+    #[On('clearSorts')]
     #[On('clearsorts')]
     public function clearSorts(): void
     {

--- a/src/Traits/WithEvents.php
+++ b/src/Traits/WithEvents.php
@@ -12,21 +12,25 @@ trait WithEvents
 
     protected array $eventStatuses = ['columnSelected' => true, 'searchApplied' => false, 'filterApplied' => false];
 
+    // No Longer Used
     public function setSortEvent(string $field, string $direction): void
     {
         $this->setSort($field, $direction);
     }
 
+    // No Longer Used
     public function clearSortEvent(): void
     {
         $this->clearSorts();
     }
 
+    // No Longer Used
     public function setFilterEvent(string $filter, string $value): void
     {
         $this->setFilter($filter, $value);
     }
 
+    // No Longer Used
     public function clearFilterEvent(): void
     {
         $this->setFilterDefaults();


### PR DESCRIPTION
This removes the old $listeners approach for events, and uses the Livewire v3 On Attribute instead.

refreshDatatable is bound to boot() of the DataTableComponent, reflecting the original behaviour

The original methods are present, although not used.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
