### PR TITLE
Merge Column Attributes Back in if Sortable

### DIFF
--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -30,7 +30,14 @@
                             ->except(['default', 'wire:key'])
                     }}
                 >
-                    <span>{{ $column->getTitle() }}</span>
+                    <span {{
+        $attributes->merge($customAttributes)
+            ->class(['text-left text-xs font-medium whitespace-nowrap text-gray-500 uppercase tracking-wider dark:bg-gray-800 dark:text-gray-400' => $customAttributes['default'] ?? true])
+            ->class(['hidden' => $column->shouldCollapseAlways()])
+            ->class(['hidden md:table-cell' => $column->shouldCollapseOnMobile()])
+            ->class(['hidden lg:table-cell' => $column->shouldCollapseOnTablet()])
+            ->except('default')
+        }}>{{ $column->getTitle() }}</span>
 
                     <span class="relative flex items-center">
                         @if ($direction === 'asc')


### PR DESCRIPTION
This re-merges attributes for the Column TH Span - if it is sortable

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
