### PR TITLE
Fix sort array url query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## [v3.4.5] - 2024-08-10
+### Bug Fixes
+- Fix sort queryString bug by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1835
+
 ## [v3.4.4] - 2024-08-10
 ### New Features
 - Boolean/Toggle Filter by @lrljoe in https://github.com/rappasoft/laravel-livewire-tables/pull/1830

--- a/src/Traits/Helpers/SortingHelpers.php
+++ b/src/Traits/Helpers/SortingHelpers.php
@@ -19,9 +19,19 @@ trait SortingHelpers
 
     public function getSorts(): array
     {
+        foreach ($this->sorts as $column => $direction) {
+            if (is_array($direction)) {
+                foreach ($direction as $colAppend => $actualDirection) {
+                    $this->sorts[$column.'.'.$colAppend] = $actualDirection;
+                    unset($this->sorts[$column]);
+                }
+            }
+
+        }
+
         return $this->sorts;
     }
-
+    
     /**
      * @param  array<mixed>  $sorts
      * @return array<mixed>

--- a/src/Traits/Helpers/SortingHelpers.php
+++ b/src/Traits/Helpers/SortingHelpers.php
@@ -31,7 +31,7 @@ trait SortingHelpers
 
         return $this->sorts;
     }
-    
+
     /**
      * @param  array<mixed>  $sorts
      * @return array<mixed>


### PR DESCRIPTION
This PR fixes an issue where the QueryString for Sorts is converted to dot notation, and throws an error on subsequent refreshes

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
