### PR TITLE
Remove Component from Column, move getRows into ComputedProperty

### DIFF
--- a/.github/workflows/run-phpstan.yml
+++ b/.github/workflows/run-phpstan.yml
@@ -84,7 +84,7 @@ jobs:
         run: composer update --${{ matrix.stability }} --no-interaction
 
       - name: Install PHPStan
-        run: composer require nunomaduro/larastan:^2.0 --dev --no-interaction
+        run: composer require larastan/larastan:^2.0 --dev --no-interaction
 
       - name: Run PHPStan Tests
         run: ./vendor/bin/phpstan analyse

--- a/resources/views/components/pagination.blade.php
+++ b/resources/views/components/pagination.blade.php
@@ -1,5 +1,4 @@
 @aware(['component','isTailwind','isBootstrap','isBootstrap4','isBootstrap5'])
-@props(['rows'])
 
 @if ($component->hasConfigurableAreaFor('before-pagination'))
     @include($component->getConfigurableAreaFor('before-pagination'), $component->getParametersForConfigurableArea('before-pagination'))
@@ -10,13 +9,13 @@
         @if ($component->paginationVisibilityIsEnabled())
             <div class="mt-4 px-4 md:p-0 sm:flex justify-between items-center space-y-4 sm:space-y-0">
                 <div>
-                    @if ($component->paginationIsEnabled() && $component->isPaginationMethod('standard') && $rows->lastPage() > 1)
+                    @if ($component->paginationIsEnabled() && $component->isPaginationMethod('standard') && $this->getRows->lastPage() > 1)
                         <p class="paged-pagination-results text-sm text-gray-700 leading-5 dark:text-white">
                             @if($component->showPaginationDetails())
                                 <span>@lang('Showing')</span>
-                                <span class="font-medium">{{ $rows->firstItem() }}</span>
+                                <span class="font-medium">{{ $this->getRows->firstItem() }}</span>
                                 <span>@lang('to')</span>
-                                <span class="font-medium">{{ $rows->lastItem() }}</span>
+                                <span class="font-medium">{{ $this->getRows->lastItem() }}</span>
                                 <span>@lang('of')</span>
                                 <span class="font-medium"><span x-text="paginationTotalItemCount"></span></span>
                                 <span>@lang('results')</span>
@@ -26,23 +25,23 @@
                         <p class="paged-pagination-results text-sm text-gray-700 leading-5 dark:text-white">
                             @if($component->showPaginationDetails())
                                 <span>@lang('Showing')</span>
-                                <span class="font-medium">{{ $rows->firstItem() }}</span>
+                                <span class="font-medium">{{ $this->getRows->firstItem() }}</span>
                                 <span>@lang('to')</span>
-                                <span class="font-medium">{{ $rows->lastItem() }}</span>
+                                <span class="font-medium">{{ $this->getRows->lastItem() }}</span>
                             @endif
                         </p>
                     @elseif ($component->paginationIsEnabled() && $component->isPaginationMethod('cursor'))
                     @else
                         <p class="total-pagination-results text-sm text-gray-700 leading-5 dark:text-white">
                             @lang('Showing')
-                            <span class="font-medium">{{ $rows->count() }}</span>
+                            <span class="font-medium">{{ $this->getRows->count() }}</span>
                             @lang('results')
                         </p>
                     @endif
                 </div>
 
                 @if ($component->paginationIsEnabled())
-                    {{ $rows->links('livewire-tables::specific.tailwind.'.(!$component->isPaginationMethod('standard') ? 'simple-' : '').'pagination') }}
+                    {{ $this->getRows->links('livewire-tables::specific.tailwind.'.(!$component->isPaginationMethod('standard') ? 'simple-' : '').'pagination') }}
                 @endif
             </div>
         @endif
@@ -50,18 +49,18 @@
 @elseif ($isBootstrap4)
     <div >
         @if ($component->paginationVisibilityIsEnabled())
-            @if ($component->paginationIsEnabled() && $component->isPaginationMethod('standard') && $rows->lastPage() > 1)
+            @if ($component->paginationIsEnabled() && $component->isPaginationMethod('standard') && $this->getRows->lastPage() > 1)
                 <div class="row mt-3">
                     <div class="col-12 col-md-6 overflow-auto">
-                        {{ $rows->links('livewire-tables::specific.bootstrap-4.pagination') }}
+                        {{ $this->getRows->links('livewire-tables::specific.bootstrap-4.pagination') }}
                     </div>
 
                     <div class="col-12 col-md-6 text-center text-md-right text-muted">
                         @if($component->showPaginationDetails())
                             <span>@lang('Showing')</span>
-                            <strong>{{ $rows->count() ? $rows->firstItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->firstItem() : 0 }}</strong>
                             <span>@lang('to')</span>
-                            <strong>{{ $rows->count() ? $rows->lastItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->lastItem() : 0 }}</strong>
                             <span>@lang('of')</span>
                             <strong><span x-text="paginationTotalItemCount"></span></strong>
                             <span>@lang('results')</span>
@@ -71,29 +70,29 @@
             @elseif ($component->paginationIsEnabled() && $component->isPaginationMethod('simple'))
                 <div class="row mt-3">
                     <div class="col-12 col-md-6 overflow-auto">
-                        {{ $rows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
+                        {{ $this->getRows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
                     </div>
 
                     <div class="col-12 col-md-6 text-center text-md-right text-muted">
                         @if($component->showPaginationDetails())
                             <span>@lang('Showing')</span>
-                            <strong>{{ $rows->count() ? $rows->firstItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->firstItem() : 0 }}</strong>
                             <span>@lang('to')</span>
-                            <strong>{{ $rows->count() ? $rows->lastItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->lastItem() : 0 }}</strong>
                         @endif
                     </div>
                 </div>
             @elseif ($component->paginationIsEnabled() && $component->isPaginationMethod('cursor'))
                 <div class="row mt-3">
                     <div class="col-12 col-md-6 overflow-auto">
-                        {{ $rows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
+                        {{ $this->getRows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
                     </div>
                 </div>
             @else
                 <div class="row mt-3">
                     <div class="col-12 text-muted">
                         @lang('Showing')
-                        <strong>{{ $rows->count() }}</strong>
+                        <strong>{{ $this->getRows->count() }}</strong>
                         @lang('results')
                     </div>
                 </div>
@@ -103,17 +102,17 @@
 @elseif ($isBootstrap5)
     <div >
         @if ($component->paginationVisibilityIsEnabled())
-            @if ($component->paginationIsEnabled() && $component->isPaginationMethod('standard') && $rows->lastPage() > 1)
+            @if ($component->paginationIsEnabled() && $component->isPaginationMethod('standard') && $this->getRows->lastPage() > 1)
                 <div class="row mt-3">
                     <div class="col-12 col-md-6 overflow-auto">
-                        {{ $rows->links('livewire-tables::specific.bootstrap-4.pagination') }}
+                        {{ $this->getRows->links('livewire-tables::specific.bootstrap-4.pagination') }}
                     </div>
                     <div class="col-12 col-md-6 text-center text-md-end text-muted">
                         @if($component->showPaginationDetails())
                             <span>@lang('Showing')</span>
-                            <strong>{{ $rows->count() ? $rows->firstItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->firstItem() : 0 }}</strong>
                             <span>@lang('to')</span>
-                            <strong>{{ $rows->count() ? $rows->lastItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->lastItem() : 0 }}</strong>
                             <span>@lang('of')</span>
                             <strong><span x-text="paginationTotalItemCount"></span></strong>
                             <span>@lang('results')</span>
@@ -123,28 +122,28 @@
             @elseif ($component->paginationIsEnabled() && $component->isPaginationMethod('simple'))
                 <div class="row mt-3">
                     <div class="col-12 col-md-6 overflow-auto">
-                        {{ $rows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
+                        {{ $this->getRows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
                     </div>
                     <div class="col-12 col-md-6 text-center text-md-end text-muted">
                         @if($component->showPaginationDetails())
                             <span>@lang('Showing')</span>
-                            <strong>{{ $rows->count() ? $rows->firstItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->firstItem() : 0 }}</strong>
                             <span>@lang('to')</span>
-                            <strong>{{ $rows->count() ? $rows->lastItem() : 0 }}</strong>
+                            <strong>{{ $this->getRows->count() ? $this->getRows->lastItem() : 0 }}</strong>
                         @endif
                     </div>
                 </div>
             @elseif ($component->paginationIsEnabled() && $component->isPaginationMethod('cursor'))
                 <div class="row mt-3">
                     <div class="col-12 col-md-6 overflow-auto">
-                        {{ $rows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
+                        {{ $this->getRows->links('livewire-tables::specific.bootstrap-4.simple-pagination') }}
                     </div>
                 </div>
             @else
                 <div class="row mt-3">
                     <div class="col-12 text-muted">
                         @lang('Showing')
-                        <strong>{{ $rows->count() }}</strong>
+                        <strong>{{ $this->getRows->count() }}</strong>
                         @lang('results')
                     </div>
                 </div>

--- a/resources/views/components/table/tr/bulk-actions.blade.php
+++ b/resources/views/components/table/tr/bulk-actions.blade.php
@@ -1,5 +1,4 @@
 @aware(['component', 'tableName','isTailwind','isBootstrap'])
-@props(['rows'])
 
 @if ($component->bulkActionsAreEnabled() && $component->hasBulkActions())
     @php

--- a/resources/views/components/table/tr/footer.blade.php
+++ b/resources/views/components/table/tr/footer.blade.php
@@ -1,5 +1,5 @@
 @aware(['component', 'tableName'])
-@props(['rows'])
+@props(['rows', 'selectedVisibleColumns'])
 
 <x-livewire-tables::table.tr.plain
     :customAttributes="$this->getFooterTrAttributes($rows)"
@@ -17,12 +17,19 @@
         <x-livewire-tables::table.td.collapsed-columns :displayMinimisedOnReorder="true" rowIndex="-1" :hidden="true" wire:key="{{ $tableName.'-footer-collapse' }}" />
     @endif
 
-    @foreach($this->getColumns() as $colIndex => $column)
-        @continue($column->isHidden())
-        @continue($this->columnSelectIsEnabled() && ! $this->columnSelectIsEnabledForColumn($column))
-        @continue($column->isReorderColumn() && !$this->getCurrentlyReorderingStatus && $this->getHideReorderColumnUnlessReorderingStatus())
+    @foreach($selectedVisibleColumns as $colIndex => $column)
         <x-livewire-tables::table.td.plain :displayMinimisedOnReorder="true"  wire:key="{{ $tableName .'-footer-shown-'.$colIndex }}" :column="$column" :customAttributes="$this->getFooterTdAttributes($column, $rows, $colIndex)">
-            {{ $column->getFooterContents($rows, $this->getFilterGenericData) }}
+
+            @if($column->hasFooter() && $column->hasFooterCallback())
+                @if($column->footerCallbackIsFilter())
+                    {{ $column->getFooterFilter($column->getFooterCallback(), $this->getFilterGenericData) }}
+                @elseif($column->footerCallbackIsString())
+                    {{ $column->getFooterFilter($this->getFilterByKey($column->getFooterCallback()), $this->getFilterGenericData) }}
+                @else
+                    {{ $column->getFooterContents($rows) }}
+                @endif
+            @endif
+
         </x-livewire-tables::table.td.plain>
     @endforeach
 </x-livewire-tables::table.tr.plain>

--- a/resources/views/components/table/tr/footer.blade.php
+++ b/resources/views/components/table/tr/footer.blade.php
@@ -1,8 +1,8 @@
 @aware(['component', 'tableName'])
-@props(['rows', 'selectedVisibleColumns'])
+@props(['selectedVisibleColumns'])
 
 <x-livewire-tables::table.tr.plain
-    :customAttributes="$this->getFooterTrAttributes($rows)"
+    :customAttributes="$this->getFooterTrAttributes($this->getRows)"
     wire:key="{{ $tableName .'-footer' }}"
 >
     {{-- Adds a Column For Bulk Actions--}}
@@ -18,7 +18,7 @@
     @endif
 
     @foreach($selectedVisibleColumns as $colIndex => $column)
-        <x-livewire-tables::table.td.plain :displayMinimisedOnReorder="true"  wire:key="{{ $tableName .'-footer-shown-'.$colIndex }}" :column="$column" :customAttributes="$this->getFooterTdAttributes($column, $rows, $colIndex)">
+        <x-livewire-tables::table.td.plain :displayMinimisedOnReorder="true"  wire:key="{{ $tableName .'-footer-shown-'.$colIndex }}" :column="$column" :customAttributes="$this->getFooterTdAttributes($column, $this->getRows, $colIndex)">
 
             @if($column->hasFooter() && $column->hasFooterCallback())
                 @if($column->footerCallbackIsFilter())
@@ -26,7 +26,7 @@
                 @elseif($column->footerCallbackIsString())
                     {{ $column->getFooterFilter($this->getFilterByKey($column->getFooterCallback()), $this->getFilterGenericData) }}
                 @else
-                    {{ $column->getFooterContents($rows) }}
+                    {{ $column->getFooterContents($this->getRows) }}
                 @endif
             @endif
 

--- a/resources/views/components/table/tr/secondary-header.blade.php
+++ b/resources/views/components/table/tr/secondary-header.blade.php
@@ -1,8 +1,8 @@
 @aware(['component', 'tableName'])
-@props(['rows', 'selectedVisibleColumns'])
+@props(['selectedVisibleColumns'])
 
 <x-livewire-tables::table.tr.plain
-    :customAttributes="$this->getSecondaryHeaderTrAttributes($rows)"
+    :customAttributes="$this->getSecondaryHeaderTrAttributes($this->getRows)"
     wire:key="{{ $tableName .'-secondary-header' }}"
 >
     {{-- TODO: Remove --}}
@@ -17,14 +17,14 @@
     @endif
 
     @foreach($selectedVisibleColumns as $colIndex => $column)
-        <x-livewire-tables::table.td.plain :column="$column" :displayMinimisedOnReorder="true" wire:key="{{ $tableName .'-secondary-header-show-'.$column->getSlug() }}"  :customAttributes="$this->getSecondaryHeaderTdAttributes($column, $rows, $colIndex)">
+        <x-livewire-tables::table.td.plain :column="$column" :displayMinimisedOnReorder="true" wire:key="{{ $tableName .'-secondary-header-show-'.$column->getSlug() }}"  :customAttributes="$this->getSecondaryHeaderTdAttributes($column, $this->getRows, $colIndex)">
             @if($column->hasSecondaryHeader() && $column->hasSecondaryHeaderCallback())
                 @if( $column->secondaryHeaderCallbackIsFilter())
                     {{ $column->getSecondaryHeaderFilter($column->getSecondaryHeaderCallback(), $this->getFilterGenericData) }}    
                 @elseif($column->secondaryHeaderCallbackIsString())
                     {{ $column->getSecondaryHeaderFilter($this->getFilterByKey($column->getSecondaryHeaderCallback()), $this->getFilterGenericData) }}
                 @else
-                    {{ $column->getSecondaryHeaderContents($rows) }}
+                    {{ $column->getSecondaryHeaderContents($this->getRows) }}
                 @endif
             @endif
         </x-livewire-tables::table.td.plain>

--- a/resources/views/components/table/tr/secondary-header.blade.php
+++ b/resources/views/components/table/tr/secondary-header.blade.php
@@ -18,7 +18,15 @@
 
     @foreach($selectedVisibleColumns as $colIndex => $column)
         <x-livewire-tables::table.td.plain :column="$column" :displayMinimisedOnReorder="true" wire:key="{{ $tableName .'-secondary-header-show-'.$column->getSlug() }}"  :customAttributes="$this->getSecondaryHeaderTdAttributes($column, $rows, $colIndex)">
-            {{ $column->getSecondaryHeaderContents($rows, $this->getFilterGenericData) }}
+            @if($column->hasSecondaryHeader() && $column->hasSecondaryHeaderCallback())
+                @if( $column->secondaryHeaderCallbackIsFilter())
+                    {{ $column->getSecondaryHeaderFilter($column->getSecondaryHeaderCallback(), $this->getFilterGenericData) }}    
+                @elseif($column->secondaryHeaderCallbackIsString())
+                    {{ $column->getSecondaryHeaderFilter($this->getFilterByKey($column->getSecondaryHeaderCallback()), $this->getFilterGenericData) }}
+                @else
+                    {{ $column->getSecondaryHeaderContents($rows) }}
+                @endif
+            @endif
         </x-livewire-tables::table.td.plain>
     @endforeach
 </x-livewire-tables::table.tr.plain>

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -41,7 +41,7 @@
             </x-slot>
 
             @if($this->secondaryHeaderIsEnabled() && $this->hasColumnsWithSecondaryHeader())
-                <x-livewire-tables::table.tr.secondary-header :rows="$rows" :$selectedVisibleColumns  />
+                <x-livewire-tables::table.tr.secondary-header :$selectedVisibleColumns  />
             @endif
             @if($this->hasDisplayLoadingPlaceholder())
                 <x-livewire-tables::includes.loading colCount="{{ $this->columns->count()+1 }}" />
@@ -49,10 +49,10 @@
 
 
             @if($this->showBulkActionsSections)
-                <x-livewire-tables::table.tr.bulk-actions :rows="$rows" :displayMinimisedOnReorder="true" />
+                <x-livewire-tables::table.tr.bulk-actions  :displayMinimisedOnReorder="true" />
             @endif
 
-            @forelse ($rows as $rowIndex => $row)
+            @forelse ($this->getRows as $rowIndex => $row)
                 <x-livewire-tables::table.tr wire:key="{{ $tableName }}-row-wrap-{{ $row->{$primaryKey} }}" :row="$row" :rowIndex="$rowIndex">
                     @if($this->getCurrentlyReorderingStatus)
                         <x-livewire-tables::table.td.reorder x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $tableName }}-row-reorder-{{ $row->{$primaryKey} }}" :rowID="$tableName.'-'.$row->{$this->getPrimaryKey()}" :rowIndex="$rowIndex" />
@@ -85,15 +85,15 @@
             @if ($this->footerIsEnabled() && $this->hasColumnsWithFooter())
                 <x-slot name="tfoot">
                     @if ($this->useHeaderAsFooterIsEnabled())
-                        <x-livewire-tables::table.tr.secondary-header :rows="$rows" :$selectedVisibleColumns />
+                        <x-livewire-tables::table.tr.secondary-header  :$selectedVisibleColumns />
                     @else
-                        <x-livewire-tables::table.tr.footer :rows="$rows"  :$selectedVisibleColumns />
+                        <x-livewire-tables::table.tr.footer  :$selectedVisibleColumns />
                     @endif
                 </x-slot>
             @endif
         </x-livewire-tables::table>
 
-        <x-livewire-tables::pagination :rows="$rows" />
+        <x-livewire-tables::pagination  />
 
         @includeIf($customView)
     </x-livewire-tables::wrapper>

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -85,9 +85,9 @@
             @if ($this->footerIsEnabled() && $this->hasColumnsWithFooter())
                 <x-slot name="tfoot">
                     @if ($this->useHeaderAsFooterIsEnabled())
-                        <x-livewire-tables::table.tr.secondary-header :rows="$rows"  />
+                        <x-livewire-tables::table.tr.secondary-header :rows="$rows" :$selectedVisibleColumns />
                     @else
-                        <x-livewire-tables::table.tr.footer :rows="$rows"  />
+                        <x-livewire-tables::table.tr.footer :rows="$rows"  :$selectedVisibleColumns />
                     @endif
                 </x-slot>
             @endif

--- a/resources/views/includes/columns/boolean.blade.php
+++ b/resources/views/includes/columns/boolean.blade.php
@@ -1,4 +1,4 @@
-@if ($component->isTailwind())
+@if ($isTailwind)
     @if ($status)
         @if ($type === 'icons')
             @if ($successValue === true)
@@ -28,7 +28,7 @@
             @endif
         @endif
     @endif
-@elseif ($component->isBootstrap())
+@elseif ($isBootstrap)
     @if ($status)
         @if ($type === 'icons')
             @if ($successValue === true)

--- a/src/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Traits/Configuration/ColumnConfiguration.php
@@ -11,7 +11,9 @@ trait ColumnConfiguration
         $this->prependedColumns = collect($prependedColumns)
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
-                $column->setComponent($this);
+                $column->setTheme($this->getTheme());
+                $column->setHasTableRowUrl($this->hasTableRowUrl());
+                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
 
                 if ($column->hasField()) {
                     if ($column->isBaseColumn()) {
@@ -30,7 +32,9 @@ trait ColumnConfiguration
         $this->appendedColumns = collect($appendedColumns)
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
-                $column->setComponent($this);
+                $column->setTheme($this->getTheme());
+                $column->setHasTableRowUrl($this->hasTableRowUrl());
+                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
 
                 if ($column->hasField()) {
                     if ($column->isBaseColumn()) {

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -18,7 +18,9 @@ trait ColumnHelpers
         $columns = collect($this->columns())
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
-                $column->setComponent($this);
+                $column->setTheme($this->getTheme());
+                $column->setHasTableRowUrl($this->hasTableRowUrl());
+                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
                 if ($column instanceof AggregateColumn) {
                     if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
                         $this->addExtraWithCount($column->getDataSource());
@@ -207,7 +209,9 @@ trait ColumnHelpers
         return collect($this->prependedColumns ?? $this->prependColumns())
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
-                $column->setComponent($this);
+                $column->setTheme($this->getTheme());
+                $column->setHasTableRowUrl($this->hasTableRowUrl());
+                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
                 if ($column instanceof AggregateColumn) {
                     if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
                         $this->addExtraWithCount($column->getDataSource());
@@ -235,7 +239,9 @@ trait ColumnHelpers
         return collect($this->appendedColumns ?? $this->appendColumns())
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
-                $column->setComponent($this);
+                $column->setTheme($this->getTheme());
+                $column->setHasTableRowUrl($this->hasTableRowUrl());
+                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
                 if ($column instanceof AggregateColumn) {
                     if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
                         $this->addExtraWithCount($column->getDataSource());

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -12,6 +12,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Views\Column;
+use Livewire\Attributes\Computed;
 
 trait WithData
 {
@@ -27,6 +28,7 @@ trait WithData
     /**
      * Retrieves the rows for the executed query
      */
+    #[Computed]
     public function getRows(): Collection|CursorPaginator|Paginator|LengthAwarePaginator
     {
         // Setup the Base Query
@@ -280,13 +282,4 @@ trait WithData
         throw new DataTableConfigurationException('You must either specify a model or implement the builder method.');
     }
 
-    /**
-     * Add Rows And Generic Data to View
-     */
-    public function renderingWithData(\Illuminate\View\View $view, array $data = []): void
-    {
-        $view->with([
-            'rows' => $this->getRows(),
-        ]);
-    }
 }

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -10,9 +10,9 @@ use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Views\Column;
-use Livewire\Attributes\Computed;
 
 trait WithData
 {
@@ -281,5 +281,4 @@ trait WithData
         // If model does not exist
         throw new DataTableConfigurationException('You must either specify a model or implement the builder method.');
     }
-
 }

--- a/src/Views/Columns/BooleanColumn.php
+++ b/src/Views/Columns/BooleanColumn.php
@@ -30,7 +30,8 @@ class BooleanColumn extends Column
         $value = $this->getValue($row);
 
         return view($this->getView())
-            ->withComponent($this->getComponent())
+            ->withIsTailwind($this->isTailwind())
+            ->withIsBootstrap($this->isBootstrap())
             ->withSuccessValue($this->getSuccessValue())
             ->withType($this->getType())
             ->withStatus($this->hasCallback() ? call_user_func($this->getCallback(), $value, $row) : (bool) $value === true);

--- a/src/Views/Columns/ButtonGroupColumn.php
+++ b/src/Views/Columns/ButtonGroupColumn.php
@@ -28,6 +28,8 @@ class ButtonGroupColumn extends Column
         return view($this->getView())
             ->withColumn($this)
             ->withRow($row)
+            ->withIsTailwind($this->isTailwind())
+            ->withIsBootstrap($this->isBootstrap())
             ->withButtons($this->getButtons())
             ->withAttributes($this->hasAttributesCallback() ? app()->call($this->getAttributesCallback(), ['row' => $row]) : []);
     }

--- a/src/Views/Columns/ColorColumn.php
+++ b/src/Views/Columns/ColorColumn.php
@@ -33,8 +33,8 @@ class ColorColumn extends Column
     public function getContents(Model $row): null|string|\Illuminate\Support\HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         return view($this->getView())
-            ->withIsTailwind($this->getComponent()->isTailwind())
-            ->withIsBootstrap($this->getComponent()->isBootstrap())
+            ->withIsTailwind($this->isTailwind())
+            ->withIsBootstrap($this->isBootstrap())
             ->withColor($this->getColor($row))
             ->withAttributeBag($this->getAttributeBag($row));
     }

--- a/src/Views/Columns/ImageColumn.php
+++ b/src/Views/Columns/ImageColumn.php
@@ -32,6 +32,8 @@ class ImageColumn extends Column
 
         return view($this->getView())
             ->withColumn($this)
+            ->withIsTailwind($this->isTailwind())
+            ->withIsBootstrap($this->isBootstrap())
             ->withPath(app()->call($this->getLocationCallback(), ['row' => $row]))
             ->withAttributes($this->hasAttributesCallback() ? app()->call($this->getAttributesCallback(), ['row' => $row]) : []);
     }

--- a/src/Views/Columns/LinkColumn.php
+++ b/src/Views/Columns/LinkColumn.php
@@ -37,6 +37,8 @@ class LinkColumn extends Column
 
         return view($this->getView())
             ->withColumn($this)
+            ->withIsTailwind($this->isTailwind())
+            ->withIsBootstrap($this->isBootstrap())
             ->withTitle(app()->call($this->getTitleCallback(), ['row' => $row]))
             ->withPath(app()->call($this->getLocationCallback(), ['row' => $row]))
             ->withAttributes($this->hasAttributesCallback() ? app()->call($this->getAttributesCallback(), ['row' => $row]) : []);

--- a/src/Views/Columns/WireLinkColumn.php
+++ b/src/Views/Columns/WireLinkColumn.php
@@ -38,6 +38,8 @@ class WireLinkColumn extends Column
 
         return view($this->getView())
             ->withColumn($this)
+            ->withIsTailwind($this->isTailwind())
+            ->withIsBootstrap($this->isBootstrap())
             ->withTitle(app()->call($this->getTitleCallback(), ['row' => $row]))
             ->withPath(app()->call($this->getActionCallback(), ['row' => $row]))
             ->withAttributes($this->hasAttributesCallback() ? app()->call($this->getAttributesCallback(), ['row' => $row]) : []);

--- a/src/Views/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Views/Traits/Configuration/ColumnConfiguration.php
@@ -83,4 +83,25 @@ trait ColumnConfiguration
     {
         $this->displayColumnLabel = $status;
     }
+
+    public function setTheme(string $theme): self
+    {
+        $this->theme = $theme;
+
+        return $this;
+    }
+
+    public function setHasTableRowUrl(bool $hasTableRowUrl): self
+    {
+        $this->hasTableRowUrl = $hasTableRowUrl;
+
+        return $this;
+    }
+
+    public function setIsReorderColumn(bool $isReorderColumn): self
+    {
+        $this->isReorderColumn = $isReorderColumn;
+
+        return $this;
+    }
 }

--- a/src/Views/Traits/Core/HasFooter.php
+++ b/src/Views/Traits/Core/HasFooter.php
@@ -59,7 +59,8 @@ trait HasFooter
     public function footerCallbackIsFilter(): bool
     {
         $callback = $this->getFooterCallback();
-        return ($callback instanceof Filter);
+
+        return $callback instanceof Filter;
     }
 
     /**
@@ -77,6 +78,7 @@ trait HasFooter
             if ($this->isHtml()) {
                 return new HtmlString($value);
             }
+
             return $value;
         } else {
             throw new DataTableConfigurationException('The footer callback must be a closure, filter object, or filter key if using footerFilter().');
@@ -92,7 +94,7 @@ trait HasFooter
         } else {
             throw new DataTableConfigurationException('The footer callback must be a closure, filter object, or filter key if using footerFilter().');
         }
+
         return null;
     }
-
 }

--- a/src/Views/Traits/Core/HasFooter.php
+++ b/src/Views/Traits/Core/HasFooter.php
@@ -51,35 +51,48 @@ trait HasFooter
         return $this->footerCallback;
     }
 
+    public function footerCallbackIsString(): bool
+    {
+        return is_string($this->getFooterCallback());
+    }
+
+    public function footerCallbackIsFilter(): bool
+    {
+        $callback = $this->getFooterCallback();
+        return ($callback instanceof Filter);
+    }
+
     /**
      * @param  mixed  $rows
      * @return mixed
      */
-    public function getFooterContents($rows, array $filterGenericData)
+    public function getFooterContents($rows)
     {
         $value = null;
         $callback = $this->getFooterCallback();
 
-        if ($this->hasFooterCallback()) {
-            if (is_callable($callback)) {
-                $value = call_user_func($callback, $rows);
+        if (is_callable($callback)) {
+            $value = call_user_func($callback, $rows);
 
-                if ($this->isHtml()) {
-                    return new HtmlString($value);
-                }
-            } elseif ($callback instanceof Filter) {
-                return $callback->setFilterPosition('footer')->setGenericDisplayData($filterGenericData)->render();
-            } elseif (is_string($callback)) {
-                $filter = $this->getComponent()->getFilterByKey($callback);
-
-                if ($filter instanceof Filter) {
-                    return $filter->setFilterPosition('footer')->setGenericDisplayData($filterGenericData)->render();
-                }
-            } else {
-                throw new DataTableConfigurationException('The footer callback must be a closure, filter object, or filter key if using footerFilter().');
+            if ($this->isHtml()) {
+                return new HtmlString($value);
             }
+            return $value;
+        } else {
+            throw new DataTableConfigurationException('The footer callback must be a closure, filter object, or filter key if using footerFilter().');
         }
 
-        return $value;
+        return null;
     }
+
+    public function getFooterFilter(?Filter $filter, array $filterGenericData)
+    {
+        if ($filter !== null && $filter instanceof Filter) {
+            return $filter->setFilterPosition('footer')->setGenericDisplayData($filterGenericData)->render();
+        } else {
+            throw new DataTableConfigurationException('The footer callback must be a closure, filter object, or filter key if using footerFilter().');
+        }
+        return null;
+    }
+
 }

--- a/src/Views/Traits/Core/HasFooter.php
+++ b/src/Views/Traits/Core/HasFooter.php
@@ -65,9 +65,8 @@ trait HasFooter
 
     /**
      * @param  mixed  $rows
-     * @return mixed
      */
-    public function getFooterContents($rows)
+    public function getFooterContents($rows): string|HtmlString
     {
         $value = null;
         $callback = $this->getFooterCallback();
@@ -83,18 +82,14 @@ trait HasFooter
         } else {
             throw new DataTableConfigurationException('The footer callback must be a closure, filter object, or filter key if using footerFilter().');
         }
-
-        return null;
     }
 
-    public function getFooterFilter(?Filter $filter, array $filterGenericData)
+    public function getFooterFilter(?Filter $filter, array $filterGenericData): \Illuminate\Contracts\Foundation\Application|\Illuminate\View\Factory|\Illuminate\View\View|string
     {
         if ($filter !== null && $filter instanceof Filter) {
             return $filter->setFilterPosition('footer')->setGenericDisplayData($filterGenericData)->render();
         } else {
             throw new DataTableConfigurationException('The footer callback must be a closure, filter object, or filter key if using footerFilter().');
         }
-
-        return null;
     }
 }

--- a/src/Views/Traits/Core/HasSecondaryHeader.php
+++ b/src/Views/Traits/Core/HasSecondaryHeader.php
@@ -65,9 +65,8 @@ trait HasSecondaryHeader
 
     /**
      * @param  mixed  $rows
-     * @return mixed
      */
-    public function getSecondaryHeaderContents($rows)
+    public function getSecondaryHeaderContents($rows): string|HtmlString
     {
         $value = null;
         $callback = $this->getSecondaryHeaderCallback();
@@ -82,18 +81,14 @@ trait HasSecondaryHeader
         } else {
             throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
         }
-
-        return null;
     }
 
-    public function getSecondaryHeaderFilter(?Filter $filter, array $filterGenericData)
+    public function getSecondaryHeaderFilter(?Filter $filter, array $filterGenericData): \Illuminate\Contracts\Foundation\Application|\Illuminate\View\Factory|\Illuminate\View\View|string
     {
         if ($filter !== null && $filter instanceof Filter) {
             return $filter->setFilterPosition('header')->setGenericDisplayData($filterGenericData)->render();
         } else {
             throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
         }
-
-        return null;
     }
 }

--- a/src/Views/Traits/Core/HasSecondaryHeader.php
+++ b/src/Views/Traits/Core/HasSecondaryHeader.php
@@ -51,36 +51,47 @@ trait HasSecondaryHeader
         return $this->secondaryHeaderCallback;
     }
 
+    public function secondaryHeaderCallbackIsString(): bool
+    {
+        return is_string($this->getSecondaryHeaderCallback());
+    }
+
+    public function secondaryHeaderCallbackIsFilter(): bool
+    {
+        $callback = $this->getSecondaryHeaderCallback();
+        return ($callback instanceof Filter);
+    }
+
     /**
      * @param  mixed  $rows
      * @return mixed
      */
-    public function getSecondaryHeaderContents($rows, array $filterGenericData)
+    public function getSecondaryHeaderContents($rows)
     {
         $value = null;
         $callback = $this->getSecondaryHeaderCallback();
 
-        if ($this->hasSecondaryHeaderCallback()) {
-            if (is_callable($callback)) {
-                $value = call_user_func($callback, $rows);
-                if ($this->isHtml()) {
-                    return new HtmlString($value);
-                }
-            } elseif ($callback instanceof Filter) {
-                return $callback->setFilterPosition('header')->setGenericDisplayData($filterGenericData)->render();
-            } elseif (is_string($callback)) {
-                $filter = $this->getComponent()->getFilterByKey($callback);
-
-                if ($filter instanceof Filter) {
-                    return $filter->setFilterPosition('header')->setGenericDisplayData($filterGenericData)->render();
-                } else {
-                    throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
-                }
-            } else {
-                throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
+        if (is_callable($callback)) {
+            $value = call_user_func($callback, $rows);
+            if ($this->isHtml()) {
+                return new HtmlString($value);
             }
+            return $value;
+        } else {
+            throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
         }
-
-        return $value;
+        return null;
     }
+
+
+    public function getSecondaryHeaderFilter(?Filter $filter, array $filterGenericData)
+    {
+        if ($filter !== null && $filter instanceof Filter) {
+            return $filter->setFilterPosition('header')->setGenericDisplayData($filterGenericData)->render();
+        }  else {
+            throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
+        }
+        return null;
+    }
+
 }

--- a/src/Views/Traits/Core/HasSecondaryHeader.php
+++ b/src/Views/Traits/Core/HasSecondaryHeader.php
@@ -59,7 +59,8 @@ trait HasSecondaryHeader
     public function secondaryHeaderCallbackIsFilter(): bool
     {
         $callback = $this->getSecondaryHeaderCallback();
-        return ($callback instanceof Filter);
+
+        return $callback instanceof Filter;
     }
 
     /**
@@ -76,22 +77,23 @@ trait HasSecondaryHeader
             if ($this->isHtml()) {
                 return new HtmlString($value);
             }
+
             return $value;
         } else {
             throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
         }
+
         return null;
     }
-
 
     public function getSecondaryHeaderFilter(?Filter $filter, array $filterGenericData)
     {
         if ($filter !== null && $filter instanceof Filter) {
             return $filter->setFilterPosition('header')->setGenericDisplayData($filterGenericData)->render();
-        }  else {
+        } else {
             throw new DataTableConfigurationException('The secondary header callback must be a closure, filter object, or filter key if using secondaryHeaderFilter().');
         }
+
         return null;
     }
-
 }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -187,7 +187,7 @@ trait ColumnHelpers
     public function isClickable(): bool
     {
         return $this->clickable &&
-            $this->component->hasTableRowUrl() &&
+            $this->getHasTableRowUrl() &&
             ! $this instanceof LinkColumn;
     }
 
@@ -204,5 +204,32 @@ trait ColumnHelpers
     public function getColumnLabelStatus(): bool
     {
         return $this->displayColumnLabel ?? true;
+    }
+
+
+    public function getHasTableRowUrl()
+    {
+        return $this->hasTableRowUrl;
+    }
+    
+
+    public function isTailwind(): bool
+    {
+        return $this->theme != 'bootstrap-4' && $this->theme != 'bootstrap-5';
+    }
+
+    public function isBootstrap(): bool
+    {
+        return $this->theme == 'bootstrap-4' || $this->theme == 'bootstrap-5';
+    }
+
+    public function isBootstrap4(): bool
+    {
+        return $this->theme == 'bootstrap-4';
+    }
+
+    public function isBootstrap5(): bool
+    {
+        return $this->theme == 'bootstrap-5';
     }
 }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -230,4 +230,10 @@ trait ColumnHelpers
     {
         return $this->theme == 'bootstrap-5';
     }
+
+    public function getIsReorderColumn(): bool
+    {
+        return $this->isReorderColumn;
+    }
+
 }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -206,7 +206,7 @@ trait ColumnHelpers
         return $this->displayColumnLabel ?? true;
     }
 
-    public function getHasTableRowUrl()
+    public function getHasTableRowUrl(): bool
     {
         return $this->hasTableRowUrl;
     }

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -147,7 +147,7 @@ trait ColumnHelpers
 
     public function isReorderColumn(): bool
     {
-        return $this->getField() === $this->component->getDefaultReorderColumn();
+        return $this->isReorderColumn;
     }
 
     public function hasFormatter(): bool
@@ -206,10 +206,12 @@ trait ColumnHelpers
         return $this->displayColumnLabel ?? true;
     }
 
+
     public function getHasTableRowUrl()
     {
         return $this->hasTableRowUrl;
     }
+    
 
     public function isTailwind(): bool
     {

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -206,12 +206,10 @@ trait ColumnHelpers
         return $this->displayColumnLabel ?? true;
     }
 
-
     public function getHasTableRowUrl()
     {
         return $this->hasTableRowUrl;
     }
-    
 
     public function isTailwind(): bool
     {

--- a/src/Views/Traits/Helpers/ColumnHelpers.php
+++ b/src/Views/Traits/Helpers/ColumnHelpers.php
@@ -235,5 +235,4 @@ trait ColumnHelpers
     {
         return $this->isReorderColumn;
     }
-
 }

--- a/src/Views/Traits/IsColumn.php
+++ b/src/Views/Traits/IsColumn.php
@@ -54,4 +54,11 @@ trait IsColumn
     protected bool $clickable = true;
 
     protected ?string $customSlug = null;
+
+    protected bool $hasTableRowUrl = false;
+
+    protected string $theme = 'tailwind';
+
+    protected bool $isReorderColumn = false;
+
 }

--- a/src/Views/Traits/IsColumn.php
+++ b/src/Views/Traits/IsColumn.php
@@ -60,5 +60,4 @@ trait IsColumn
     protected string $theme = 'tailwind';
 
     protected bool $isReorderColumn = false;
-
 }

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -82,7 +82,6 @@ class DataTableComponentTest extends TestCase
         $table->bootedWithColumnSelect();
         $table->bootedWithSecondaryHeader();
         $table->booted();
-        $table->renderingWithData($view, []);
         $table->renderingWithPagination($view, []);
         $table->render();
 

--- a/tests/DataTransferObjects/DebuggableDataTest.php
+++ b/tests/DataTransferObjects/DebuggableDataTest.php
@@ -19,6 +19,7 @@ final class DebuggableDataTest extends TestCase
 
     public function test_check_all_default_dto_elements()
     {
+        $this->basicTable->getRows();
         $debuggableDTO = new DebuggableData($this->basicTable);
         $debuggableArray = $debuggableDTO->toArray();
 

--- a/tests/Http/Livewire/PetsTable.php
+++ b/tests/Http/Livewire/PetsTable.php
@@ -107,7 +107,7 @@ class PetsTable extends DataTableComponent
     public function filters(): array
     {
         return [
-            MultiSelectFilter::make('Breed','breed')
+            MultiSelectFilter::make('Breed', 'breed')
                 ->options(
                     Breed::query()
                         ->orderBy('name')

--- a/tests/Http/Livewire/PetsTable.php
+++ b/tests/Http/Livewire/PetsTable.php
@@ -107,7 +107,7 @@ class PetsTable extends DataTableComponent
     public function filters(): array
     {
         return [
-            MultiSelectFilter::make('Breed')
+            MultiSelectFilter::make('Breed','breed')
                 ->options(
                     Breed::query()
                         ->orderBy('name')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -103,7 +103,6 @@ class TestCase extends Orchestra
         $this->basicTable->bootedWithColumnSelect();
         $this->basicTable->bootedWithSecondaryHeader();
         $this->basicTable->booted();
-        $this->basicTable->renderingWithData($view, []);
         $this->basicTable->renderingWithPagination($view, []);
         $this->basicTable->render();
     }
@@ -119,7 +118,6 @@ class TestCase extends Orchestra
         $this->breedsTable->bootedWithColumnSelect();
         $this->breedsTable->bootedWithSecondaryHeader();
         $this->breedsTable->booted();
-        $this->breedsTable->renderingWithData($view, []);
         $this->breedsTable->renderingWithPagination($view, []);
         $this->breedsTable->render();
     }
@@ -135,7 +133,6 @@ class TestCase extends Orchestra
         $this->petOwnerTable->bootedWithColumnSelect();
         $this->petOwnerTable->bootedWithSecondaryHeader();
         $this->petOwnerTable->booted();
-        $this->petOwnerTable->renderingWithData($view, []);
         $this->petOwnerTable->renderingWithPagination($view, []);
         $this->petOwnerTable->render();
     }
@@ -151,7 +148,6 @@ class TestCase extends Orchestra
         $this->speciesTable->bootedWithColumnSelect();
         $this->speciesTable->bootedWithSecondaryHeader();
         $this->speciesTable->booted();
-        $this->speciesTable->renderingWithData($view, []);
         $this->speciesTable->renderingWithPagination($view, []);
         $this->speciesTable->render();
     }
@@ -168,7 +164,6 @@ class TestCase extends Orchestra
         $this->unpaginatedTable->bootedWithColumnSelect();
         $this->unpaginatedTable->bootedWithSecondaryHeader();
         $this->unpaginatedTable->booted();
-        $this->unpaginatedTable->renderingWithData($view, []);
         $this->unpaginatedTable->renderingWithPagination($view, []);
         $this->unpaginatedTable->render();
 

--- a/tests/Traits/Helpers/ColumnHelpersTest.php
+++ b/tests/Traits/Helpers/ColumnHelpersTest.php
@@ -295,8 +295,8 @@ final class ColumnHelpersTest extends TestCase
         $column = $this->basicTable->getColumnBySelectName('breed.name');
         $this->assertTrue($column->hasSecondaryHeader());
         $this->assertTrue($column->hasSecondaryHeaderCallback());
-        
-        $contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey($column->getSecondaryHeaderCallback()),$this->basicTable->getFilterGenericData());
+
+        $contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey($column->getSecondaryHeaderCallback()), $this->basicTable->getFilterGenericData());
         //$contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey('breed'));
         $this->assertStringContainsString('id="table-filter-breed-8-header"', $contents);
     }

--- a/tests/Traits/Helpers/ColumnHelpersTest.php
+++ b/tests/Traits/Helpers/ColumnHelpersTest.php
@@ -273,14 +273,13 @@ final class ColumnHelpersTest extends TestCase
     public function test_can_check_if_column_is_reorder_column(): void
     {
         $column = Column::make('ID', 'id');
-        $column->setComponent($this->basicTable);
 
-        $this->assertFalse($column->isReorderColumn());
+        $this->assertFalse($column->getIsReorderColumn());
 
         $column = Column::make('Sort');
-        $column->setComponent($this->basicTable);
+        $column->setIsReorderColumn($this->basicTable->getDefaultReorderColumn() == $column->getField());
 
-        $this->assertTrue($column->isReorderColumn());
+        $this->assertTrue($column->getIsReorderColumn());
     }
 
     public function test_can_check_if_column_has_secondary_header(): void
@@ -295,7 +294,10 @@ final class ColumnHelpersTest extends TestCase
     {
         $column = $this->basicTable->getColumnBySelectName('breed.name');
         $this->assertTrue($column->hasSecondaryHeader());
-        $contents = $column->getSecondaryHeaderContents(Pet::find(1), $this->basicTable->getFilterGenericData());
+        $this->assertTrue($column->hasSecondaryHeaderCallback());
+        
+        $contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey($column->getSecondaryHeaderCallback()),$this->basicTable->getFilterGenericData());
+        //$contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey('breed'));
         $this->assertStringContainsString('id="table-filter-breed-8-header"', $contents);
     }
 

--- a/tests/Traits/Helpers/PaginationHelpersTest.php
+++ b/tests/Traits/Helpers/PaginationHelpersTest.php
@@ -83,12 +83,14 @@ final class PaginationHelpersTest extends TestCase
 
     public function test_can_check_per_page_displayed_item_count(): void
     {
+        $rows = $this->basicTable->getRows();
         $this->assertSame(5, $this->basicTable->getPerPageDisplayedItemCount());
 
     }
 
     public function test_can_check_per_page_displayed_items(): void
     {
+        $rows = $this->basicTable->getRows();
         $this->assertSame([1, 2, 3, 4, 5], $this->basicTable->getPerPageDisplayedItemIds());
 
     }

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -124,11 +124,11 @@ final class FilterVisualsTest extends TestCase
                             return $builder->whereIn('pets.species_id', $values);
                         })
                         ->setPillsSeparator('<br />'),
-                        
+
                     \Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter::make('Pet Name', 'pet_name_filter')
                         ->filter(function (\Illuminate\Database\Eloquent\Builder $builder, string $value) {
                             return $builder->where('pets.name', '=', $value);
-                        })
+                        }),
                 ];
             }
         })

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -124,7 +124,11 @@ final class FilterVisualsTest extends TestCase
                             return $builder->whereIn('pets.species_id', $values);
                         })
                         ->setPillsSeparator('<br />'),
-
+                        
+                    \Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter::make('Pet Name', 'pet_name_filter')
+                        ->filter(function (\Illuminate\Database\Eloquent\Builder $builder, string $value) {
+                            return $builder->where('pets.name', '=', $value);
+                        })
                 ];
             }
         })

--- a/tests/Traits/WithMountTest.php
+++ b/tests/Traits/WithMountTest.php
@@ -20,7 +20,6 @@ final class WithMountTest extends TestCase
         $table->bootedWithColumnSelect();
         $table->bootedWithSecondaryHeader();
         $table->booted();
-        $table->renderingWithData($view, []);
         $table->renderingWithPagination($view, []);
         $table->render();
         $rows = $table->getRows();
@@ -38,7 +37,6 @@ final class WithMountTest extends TestCase
         $table2->bootedWithColumnSelect();
         $table2->bootedWithSecondaryHeader();
         $table2->booted();
-        $table2->renderingWithData($view, []);
         $table2->renderingWithPagination($view, []);
         $table2->render();
         $rows2 = $table2->getRows();
@@ -55,7 +53,6 @@ final class WithMountTest extends TestCase
         $table3->bootedWithColumnSelect();
         $table3->bootedWithSecondaryHeader();
         $table3->booted();
-        $table3->renderingWithData($view, []);
         $table3->renderingWithPagination($view, []);
         $table3->render();
         $rows3 = $table3->getRows();

--- a/tests/Views/Traits/Configuration/ColumnConfigurationTest.php
+++ b/tests/Views/Traits/Configuration/ColumnConfigurationTest.php
@@ -19,7 +19,6 @@ final class ColumnConfigurationTest extends TestCase
         $this->assertTrue($column->eagerLoadRelationsIsEnabled());
     }
 
-
     public function test_can_set_column_format(): void
     {
         $column = Column::make('Name');

--- a/tests/Views/Traits/Configuration/ColumnConfigurationTest.php
+++ b/tests/Views/Traits/Configuration/ColumnConfigurationTest.php
@@ -19,16 +19,6 @@ final class ColumnConfigurationTest extends TestCase
         $this->assertTrue($column->eagerLoadRelationsIsEnabled());
     }
 
-    public function test_can_set_component_on_column(): void
-    {
-        $column = Column::make('Name');
-
-        $this->assertNull($column->getComponent());
-
-        $column->setComponent($this->basicTable);
-
-        $this->assertSame($this->basicTable, $column->getComponent());
-    }
 
     public function test_can_set_column_format(): void
     {
@@ -80,9 +70,8 @@ final class ColumnConfigurationTest extends TestCase
     {
         $column = Column::make('Name');
 
-        $column->setComponent($this->basicTable);
-
         $this->basicTable->setTableRowUrl(fn ($row) => 'https://example.com');
+        $column->setHasTableRowUrl($this->basicTable->hasTableRowUrl());
 
         $this->assertTrue($column->isClickable());
 


### PR DESCRIPTION
MAJOR CHANGE

- At present the Columns get the Component injected into them
- However - this is only used for a small handful of functions, and is therefore mostly redundant
- In the interest of efficiency, this adds new methods to set the parameters that are retrieved from the Component

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
