### PR TITLE
Add setTrimSearchStringEnabled/setTrimSearchStringDisabled

### DIFF
--- a/docs/search/available-methods.md
+++ b/docs/search/available-methods.md
@@ -168,3 +168,27 @@ public function configure(): void
     $this->setSearchThrottle(1000);
 }
 ```
+
+## setTrimSearchStringEnabled
+
+A new behaviour, which will trim search strings of whitespace at either end
+
+```php
+public function configure(): void
+{
+    // Will trim whitespace from either end of search strings
+    $this->setTrimSearchStringEnabled();
+}
+```
+
+## setTrimSearchStringDisabled
+
+The default behaviour, does not trim search strings of whitespace.
+
+```php
+public function configure(): void
+{
+    // Will not trim whitespace from either end of search strings
+    $this->setTrimSearchStringDisabled();
+}
+```

--- a/src/Traits/Configuration/SearchConfiguration.php
+++ b/src/Traits/Configuration/SearchConfiguration.php
@@ -8,8 +8,14 @@ trait SearchConfiguration
 {
     public function setSearch(string $query): self
     {
-        $this->search = $query;
-
+        if ($this->shouldTrimSearchString())
+        {
+            $this->search = trim($query);
+        }
+        else
+        {
+            $this->search = $query;
+        }
         return $this;
     }
 
@@ -156,4 +162,26 @@ trait SearchConfiguration
 
         return $this;
     }
+
+    public function setTrimSearchString(bool $status): self
+    {
+        $this->trimSearchString = $status;
+
+        return $this;
+    }
+
+    public function setTrimSearchStringEnabled(): self
+    {
+        $this->setTrimSearchString(true);
+
+        return $this;
+    }
+
+    public function setTrimSearchStringDisabled(): self
+    {
+        $this->setTrimSearchString(false);
+
+        return $this;
+    }
+
 }

--- a/src/Traits/Configuration/SearchConfiguration.php
+++ b/src/Traits/Configuration/SearchConfiguration.php
@@ -8,14 +8,12 @@ trait SearchConfiguration
 {
     public function setSearch(string $query): self
     {
-        if ($this->shouldTrimSearchString())
-        {
+        if ($this->shouldTrimSearchString()) {
             $this->search = trim($query);
-        }
-        else
-        {
+        } else {
             $this->search = $query;
         }
+
         return $this;
     }
 
@@ -183,5 +181,4 @@ trait SearchConfiguration
 
         return $this;
     }
-
 }

--- a/src/Traits/Helpers/SearchHelpers.php
+++ b/src/Traits/Helpers/SearchHelpers.php
@@ -135,4 +135,9 @@ trait SearchHelpers
     {
         return count($this->searchFieldAttributes) ? $this->searchFieldAttributes : ['default' => true];
     }
+
+    public function shouldTrimSearchString(): bool
+    {
+        return $this->trimSearchString ?? false;
+    }
 }

--- a/src/Traits/WithSearch.php
+++ b/src/Traits/WithSearch.php
@@ -55,11 +55,10 @@ trait WithSearch
             $searchableColumns = $this->getSearchableColumns();
             $search = $this->getSearch();
 
-            if ($this->shouldTrimSearchString())
-            {
+            if ($this->shouldTrimSearchString()) {
                 $search = trim($search);
             }
-    
+
             $this->callHook('searchUpdated', ['value' => $search]);
             $this->callTraitHook('searchUpdated', ['value' => $search]);
             if ($this->getEventStatusSearchApplied() && $search != null) {
@@ -81,14 +80,12 @@ trait WithSearch
 
         return $this->getBuilder();
     }
-    
+
     public function updatedSearch(string|array|null $value): void
     {
-        if ($this->shouldTrimSearchString() && $this->search != trim($value))
-        {
+        if ($this->shouldTrimSearchString() && $this->search != trim($value)) {
             $this->search = $value = trim($value);
         }
-
 
         $this->resetComputedPage();
 

--- a/src/Traits/WithSearch.php
+++ b/src/Traits/WithSearch.php
@@ -34,6 +34,8 @@ trait WithSearch
 
     protected array $searchFieldAttributes = [];
 
+    protected bool $trimSearchString = false;
+
     protected function queryStringWithSearch(): array
     {
         if ($this->queryStringIsEnabled() && $this->searchIsEnabled()) {
@@ -49,21 +51,28 @@ trait WithSearch
     public function applySearch(): Builder
     {
         if ($this->searchIsEnabled() && $this->hasSearch()) {
-            $searchableColumns = $this->getSearchableColumns();
 
-            $this->callHook('searchUpdated', ['value' => $this->getSearch()]);
-            $this->callTraitHook('searchUpdated', ['value' => $this->getSearch()]);
-            if ($this->getEventStatusSearchApplied() && $this->getSearch() != null) {
-                event(new SearchApplied($this->getTableName(), $this->getSearch()));
+            $searchableColumns = $this->getSearchableColumns();
+            $search = $this->getSearch();
+
+            if ($this->shouldTrimSearchString())
+            {
+                $search = trim($search);
+            }
+    
+            $this->callHook('searchUpdated', ['value' => $search]);
+            $this->callTraitHook('searchUpdated', ['value' => $search]);
+            if ($this->getEventStatusSearchApplied() && $search != null) {
+                event(new SearchApplied($this->getTableName(), $search));
             }
 
             if ($searchableColumns->count()) {
-                $this->setBuilder($this->getBuilder()->where(function ($query) use ($searchableColumns) {
+                $this->setBuilder($this->getBuilder()->where(function ($query) use ($searchableColumns, $search) {
                     foreach ($searchableColumns as $index => $column) {
                         if ($column->hasSearchCallback()) {
-                            ($column->getSearchCallback())($query, $this->getSearch());
+                            ($column->getSearchCallback())($query, $search);
                         } else {
-                            $query->{$index === 0 ? 'where' : 'orWhere'}($column->getColumn(), 'like', '%'.$this->getSearch().'%');
+                            $query->{$index === 0 ? 'where' : 'orWhere'}($column->getColumn(), 'like', '%'.$search.'%');
                         }
                     }
                 }));
@@ -72,9 +81,15 @@ trait WithSearch
 
         return $this->getBuilder();
     }
-
+    
     public function updatedSearch(string|array|null $value): void
     {
+        if ($this->shouldTrimSearchString() && $this->search != trim($value))
+        {
+            $this->search = $value = trim($value);
+        }
+
+
         $this->resetComputedPage();
 
         // Clear bulk actions on search - if enabled

--- a/tests/Traits/Helpers/SearchHelpersTest.php
+++ b/tests/Traits/Helpers/SearchHelpersTest.php
@@ -122,19 +122,19 @@ final class SearchHelpersTest extends TestCase
         $this->basicTable->setTrimSearchStringEnabled();
 
         $this->basicTable->clearSearch();
-        
+
         $this->basicTable->setSearch('Anthony  ');
 
         $this->assertSame('Anthony', $this->basicTable->getSearch());
 
         $this->basicTable->clearSearch();
-        
+
         $this->basicTable->setSearch('   Anthony');
 
         $this->assertSame('Anthony', $this->basicTable->getSearch());
 
         $this->basicTable->clearSearch();
-        
+
         $this->basicTable->setSearch('   Anthony   ');
 
         $this->assertSame('Anthony', $this->basicTable->getSearch());
@@ -142,12 +142,10 @@ final class SearchHelpersTest extends TestCase
         $this->basicTable->clearSearch();
 
         $this->basicTable->setTrimSearchStringDisabled();
-        
+
         $this->basicTable->setSearch('   Anthony   ');
 
         $this->assertSame('   Anthony   ', $this->basicTable->getSearch());
 
     }
-
-
 }

--- a/tests/Traits/Helpers/SearchHelpersTest.php
+++ b/tests/Traits/Helpers/SearchHelpersTest.php
@@ -112,4 +112,42 @@ final class SearchHelpersTest extends TestCase
 
         $this->assertTrue($this->basicTable->hasSearchPlaceholder());
     }
+
+    public function test_can_trim_whitespace_from_search(): void
+    {
+        $this->basicTable->setSearch('Anthony  ');
+
+        $this->assertSame('Anthony  ', $this->basicTable->getSearch());
+
+        $this->basicTable->setTrimSearchStringEnabled();
+
+        $this->basicTable->clearSearch();
+        
+        $this->basicTable->setSearch('Anthony  ');
+
+        $this->assertSame('Anthony', $this->basicTable->getSearch());
+
+        $this->basicTable->clearSearch();
+        
+        $this->basicTable->setSearch('   Anthony');
+
+        $this->assertSame('Anthony', $this->basicTable->getSearch());
+
+        $this->basicTable->clearSearch();
+        
+        $this->basicTable->setSearch('   Anthony   ');
+
+        $this->assertSame('Anthony', $this->basicTable->getSearch());
+
+        $this->basicTable->clearSearch();
+
+        $this->basicTable->setTrimSearchStringDisabled();
+        
+        $this->basicTable->setSearch('   Anthony   ');
+
+        $this->assertSame('   Anthony   ', $this->basicTable->getSearch());
+
+    }
+
+
 }


### PR DESCRIPTION
## setTrimSearchStringEnabled

A new behaviour, which will trim search strings of whitespace at either end

```php
public function configure(): void
{
    // Will trim whitespace from either end of search strings
    $this->setTrimSearchStringEnabled();
}
```

## setTrimSearchStringDisabled

The default behaviour, does not trim search strings of whitespace.

```php
public function configure(): void
{
    // Will not trim whitespace from either end of search strings
    $this->setTrimSearchStringDisabled();
}
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
