### PR TITLE
Default useComputedProperties to False

### DIFF
--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -45,7 +45,7 @@ trait ComponentUtilities
 
     protected array $extraWithAvgs = [];
 
-    protected bool $useComputedProperties = true;
+    protected bool $useComputedProperties = false;
 
     /**
      * Set any configuration options


### PR DESCRIPTION
This defaults the behaviour for useComputedProperties to be false, preventing users with published views from experiencing an error.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
