### PR TITLE
Change Order of "Getting Started" section

### DIFF
--- a/docs/start/commands.md
+++ b/docs/start/commands.md
@@ -1,6 +1,6 @@
 ---
 title: Commands
-weight: 6
+weight: 5
 ---
 
 ## Generating Datatable Components

--- a/docs/start/commands.md
+++ b/docs/start/commands.md
@@ -7,10 +7,10 @@ weight: 5
 
 To generate a new datatable component you can use the `make:datatable` command:
 
-Create a new datatable component called `UserTable` in `App\Livewire` that uses the `App\Models\User` model.
+Create a new datatable component called `UsersTable` in `App\Livewire` that uses the `App\Models\User` model.
 
 ```bash
-php artisan make:datatable UserTable User
+php artisan make:datatable UsersTable User
 ```
 
 ### Custom Model Path

--- a/docs/start/rendering.md
+++ b/docs/start/rendering.md
@@ -1,6 +1,6 @@
 ---
 title: Rendering
-weight: 5
+weight: 6
 ---
 
 ## Rendering Components


### PR DESCRIPTION
Commands should appear before Rendering

Command and Rendering should both reference "UsersTable" rather than "UserTable" and "UsersTable"

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
