### PR TITLE
Set actions position

### DIFF
--- a/docs/misc/actions.md
+++ b/docs/misc/actions.md
@@ -21,6 +21,39 @@ This is used to set attributes for the "div" that wraps all defined Action Butto
     }
 ```
 
+### setActionsLeft
+
+Displays the Actions above the Toolbar, justified to the left
+
+```php
+    public function configure(): void
+    {
+        $this->setActionsLeft();
+    }
+```
+
+### setActionsCenter
+
+Displays the Actions above the Toolbar, justified to the center
+
+```php
+    public function configure(): void
+    {
+        $this->setActionsCenter();
+    }
+```
+
+### setActionsRight
+
+Displays the Actions above the Toolbar, justified to the right
+
+```php
+    public function configure(): void
+    {
+        $this->setActionsRight();
+    }
+```
+
 ### actions()
 
 Define your actions using the actions() method:

--- a/docs/misc/actions.md
+++ b/docs/misc/actions.md
@@ -21,9 +21,31 @@ This is used to set attributes for the "div" that wraps all defined Action Butto
     }
 ```
 
+### setActionsInToolbarEnabled
+
+Displays the Actions within the Toolbar.  Default is displaying above the Toolbar.
+
+```php
+    public function configure(): void
+    {
+        $this->setActionsInToolbarEnabled();
+    }
+```
+
+### setActionsInToolbarDisabled
+
+Displays the Actions above the Toolbar, default behaviour
+```php
+    public function configure(): void
+    {
+        $this->setActionsInToolbarDisabled();
+    }
+```
+
+
 ### setActionsLeft
 
-Displays the Actions above the Toolbar, justified to the left
+Displays the Actions justified to the left
 
 ```php
     public function configure(): void
@@ -34,7 +56,7 @@ Displays the Actions above the Toolbar, justified to the left
 
 ### setActionsCenter
 
-Displays the Actions above the Toolbar, justified to the center
+Displays the Actions justified to the center
 
 ```php
     public function configure(): void
@@ -45,7 +67,7 @@ Displays the Actions above the Toolbar, justified to the center
 
 ### setActionsRight
 
-Displays the Actions above the Toolbar, justified to the right
+Displays the Actions justified to the right
 
 ```php
     public function configure(): void

--- a/resources/views/components/includes/actions.blade.php
+++ b/resources/views/components/includes/actions.blade.php
@@ -4,7 +4,9 @@
             ->class(['' => $this->isTailwind && $this->getActionWrapperAttributes['default-colors'] ?? true])
             ->class(['d-flex flex-cols py-2 space-x-2' => $this->isBootstrap && $this->getActionWrapperAttributes['default-styling'] ?? true])
             ->class(['' => $this->isBootstrap && $this->getActionWrapperAttributes['default-colors'] ?? true])
-            ->class([$this->getActionsPosition => true])
+            ->class(['justify-start' => $this->getActionsPosition == 'left'])
+            ->class(['justify-center' => $this->getActionsPosition == 'center'])
+            ->class(['justify-end' => $this->getActionsPosition == 'right'])
             ->except(['default-styling','default-colors'])
         }} >
     @foreach($this->getActions as $action)

--- a/resources/views/components/includes/actions.blade.php
+++ b/resources/views/components/includes/actions.blade.php
@@ -1,9 +1,10 @@
 <div {{ $attributes
-            ->merge($this->getActionWrapperAttributes())
-            ->class(['flex flex-cols justify-center' => $this->isTailwind && $this->getActionWrapperAttributes()['default-styling'] ?? true])
-            ->class(['' => $this->isTailwind && $this->getActionWrapperAttributes()['default-colors'] ?? true])
-            ->class(['d-flex flex-cols justify-center' => $this->isBootstrap && $this->getActionWrapperAttributes()['default-styling'] ?? true])
-            ->class(['' => $this->isBootstrap && $this->getActionWrapperAttributes()['default-colors'] ?? true])
+            ->merge($this->getActionWrapperAttributes)
+            ->class(['flex flex-cols py-2 space-x-2' => $this->isTailwind && $this->getActionWrapperAttributes['default-styling'] ?? true])
+            ->class(['' => $this->isTailwind && $this->getActionWrapperAttributes['default-colors'] ?? true])
+            ->class(['d-flex flex-cols py-2 space-x-2' => $this->isBootstrap && $this->getActionWrapperAttributes['default-styling'] ?? true])
+            ->class(['' => $this->isBootstrap && $this->getActionWrapperAttributes['default-colors'] ?? true])
+            ->class([$this->getActionsPosition => true])
             ->except(['default-styling','default-colors'])
         }} >
     @foreach($this->getActions as $action)

--- a/resources/views/components/includes/actions.blade.php
+++ b/resources/views/components/includes/actions.blade.php
@@ -7,6 +7,8 @@
             ->class(['justify-start' => $this->getActionsPosition == 'left'])
             ->class(['justify-center' => $this->getActionsPosition == 'center'])
             ->class(['justify-end' => $this->getActionsPosition == 'right'])
+            ->class(['pl-2' => $this->showActionsInToolbar && $this->getActionsPosition == 'left'])
+            ->class(['pr-2' => $this->showActionsInToolbar && $this->getActionsPosition == 'right'])
             ->except(['default-styling','default-colors'])
         }} >
     @foreach($this->getActions as $action)

--- a/resources/views/components/tools/toolbar.blade.php
+++ b/resources/views/components/tools/toolbar.blade.php
@@ -36,6 +36,10 @@
             <x-livewire-tables::tools.toolbar.items.filter-button />
         @endif
 
+        @if($this->hasActions && $this->showActionsInToolbar && $this->getActionsPosition == 'left')
+            <x-livewire-tables::includes.actions/>    
+        @endif
+
         @if ($this->hasConfigurableAreaFor('toolbar-left-end'))
             <div x-cloak x-show="!currentlyReorderingStatus" @class([
                 'mb-3 mb-md-0 input-group' => $this->isBootstrap,
@@ -54,6 +58,10 @@
     >
         @if ($this->hasConfigurableAreaFor('toolbar-right-start'))
             @include($this->getConfigurableAreaFor('toolbar-right-start'), $this->getParametersForConfigurableArea('toolbar-right-start'))
+        @endif
+
+        @if($this->hasActions && $this->showActionsInToolbar && $this->getActionsPosition == 'right')
+            <x-livewire-tables::includes.actions/>    
         @endif
 
         @if ($this->showBulkActionsDropdownAlpine() && $this->shouldAlwaysHideBulkActionsDropdownOption != true)

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -8,7 +8,7 @@
 
 <div x-data="laravellivewiretable($wire, '{{ $this->showBulkActionsDropdownAlpine() }}', '{{ $tableId }}', '{{ $primaryKey }}')">
     <x-livewire-tables::wrapper :component="$this" :tableName="$tableName" :$primaryKey :$isTailwind :$isBootstrap :$isBootstrap4 :$isBootstrap5>
-        @if(method_exists($this,'hasActions') && $this->hasActions())
+        @if($this->hasActions && !$this->showActionsInToolbar)
             <x-livewire-tables::includes.actions/>    
         @endif
     

--- a/src/Traits/Configuration/ActionsConfiguration.php
+++ b/src/Traits/Configuration/ActionsConfiguration.php
@@ -10,7 +10,7 @@ trait ActionsConfiguration
 
         return $this;
     }
-    
+
     public function setActionsInToolbar(): self
     {
         $this->displayActionsInToolbar = true;
@@ -25,18 +25,16 @@ trait ActionsConfiguration
 
     public function setActionsLeft(): self
     {
-        $this->actionsPosition = "left";
+        $this->actionsPosition = 'left';
     }
 
     public function setActionsCenter(): self
     {
-        $this->actionsPosition = "center";
+        $this->actionsPosition = 'center';
     }
 
     public function setActionsRight(): self
     {
-        $this->actionsPosition = "right";
+        $this->actionsPosition = 'right';
     }
-
-
 }

--- a/src/Traits/Configuration/ActionsConfiguration.php
+++ b/src/Traits/Configuration/ActionsConfiguration.php
@@ -11,11 +11,21 @@ trait ActionsConfiguration
         return $this;
     }
 
-    public function setActionsInToolbar(): self
+    public function setActionsInToolbar(bool $status): self
     {
-        $this->displayActionsInToolbar = true;
+        $this->displayActionsInToolbar = $status;
 
         return $this;
+    }
+
+    public function setActionsInToolbarEnabled(): self
+    {
+        return $this->setActionsInToolbar(true);
+    }
+
+    public function setActionsInToolbarDisabled(): self
+    {
+        return $this->setActionsInToolbar(false);
     }
 
     protected function setActionsPosition(string $position): self

--- a/src/Traits/Configuration/ActionsConfiguration.php
+++ b/src/Traits/Configuration/ActionsConfiguration.php
@@ -18,31 +18,25 @@ trait ActionsConfiguration
         return $this;
     }
 
-    public function setActionsPosition(string $position): self
+    protected function setActionsPosition(string $position): self
     {
-        $this->actionsPosition = $position;
+        $this->actionsPosition = ($position == 'left' || $position == 'center' || $position == 'right') ? $position : 'right';
 
         return $this;
     }
 
     public function setActionsLeft(): self
     {
-        $this->actionsPosition = 'left';
-
-        return $this;
+        return $this->setActionsPosition('left');
     }
 
     public function setActionsCenter(): self
     {
-        $this->actionsPosition = 'center';
-
-        return $this;
+        return $this->setActionsPosition('center');
     }
 
     public function setActionsRight(): self
     {
-        $this->actionsPosition = 'right';
-
-        return $this;
+        return $this->setActionsPosition('right');
     }
 }

--- a/src/Traits/Configuration/ActionsConfiguration.php
+++ b/src/Traits/Configuration/ActionsConfiguration.php
@@ -6,7 +6,7 @@ trait ActionsConfiguration
 {
     public function setActionWrapperAttributes(array $actionWrapperAttributes): self
     {
-        $this->actionWrapperAttributes = [...['default-styling' => true, 'default-colors' => true], ...$actionWrapperAttributes];
+        $this->actionWrapperAttributes = [...$this->actionWrapperAttributes, ...$actionWrapperAttributes];
 
         return $this;
     }
@@ -21,20 +21,28 @@ trait ActionsConfiguration
     public function setActionsPosition(string $position): self
     {
         $this->actionsPosition = $position;
+
+        return $this;
     }
 
     public function setActionsLeft(): self
     {
         $this->actionsPosition = 'left';
+
+        return $this;
     }
 
     public function setActionsCenter(): self
     {
         $this->actionsPosition = 'center';
+
+        return $this;
     }
 
     public function setActionsRight(): self
     {
         $this->actionsPosition = 'right';
+
+        return $this;
     }
 }

--- a/src/Traits/Configuration/ActionsConfiguration.php
+++ b/src/Traits/Configuration/ActionsConfiguration.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Configuration;
+
+trait ActionsConfiguration
+{
+    public function setActionWrapperAttributes(array $actionWrapperAttributes): self
+    {
+        $this->actionWrapperAttributes = [...['default-styling' => true, 'default-colors' => true], ...$actionWrapperAttributes];
+
+        return $this;
+    }
+    
+    public function setActionsInToolbar(): self
+    {
+        $this->displayActionsInToolbar = true;
+
+        return $this;
+    }
+
+    public function setActionsPosition(string $position): self
+    {
+        $this->actionsPosition = $position;
+    }
+
+    public function setActionsLeft(): self
+    {
+        $this->actionsPosition = "left";
+    }
+
+    public function setActionsCenter(): self
+    {
+        $this->actionsPosition = "center";
+    }
+
+    public function setActionsRight(): self
+    {
+        $this->actionsPosition = "right";
+    }
+
+
+}

--- a/src/Traits/Helpers/ActionsHelpers.php
+++ b/src/Traits/Helpers/ActionsHelpers.php
@@ -15,15 +15,28 @@ trait ActionsHelpers
     }
 
     #[Computed]
-    public function showActionsInToolbar(): bool
+    public function getActionsPosition(): string
     {
-        return $this->displayActionsInToolbar ?? false;
+        switch ($this->actionsPosition) {
+            case "left":
+                return "justify-start";
+                break;
+            case "center":
+                return "justify-center";
+                break;
+            case "right":
+                return "justify-end";
+                break;
+            default:
+                return "justify-end";
+        }
+        
     }
 
     #[Computed]
     public function getActionWrapperAttributes(): array
     {
-        return [...['default-styling' => true, 'default-colors' => true], ...$this->actionWrapperAttributes];
+        return [...['class' => '', 'default-styling' => true, 'default-colors' => true], ...$this->actionWrapperAttributes];
     }
 
     #[Computed]

--- a/src/Traits/Helpers/ActionsHelpers.php
+++ b/src/Traits/Helpers/ActionsHelpers.php
@@ -2,13 +2,12 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
 
-use Livewire\Attributes\Computed;
 use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
 use Rappasoft\LaravelLivewireTables\Views\Action;
 
 trait ActionsHelpers
 {
-
     #[Computed]
     public function showActionsInToolbar(): bool
     {

--- a/src/Traits/Helpers/ActionsHelpers.php
+++ b/src/Traits/Helpers/ActionsHelpers.php
@@ -17,20 +17,7 @@ trait ActionsHelpers
     #[Computed]
     public function getActionsPosition(): string
     {
-        switch ($this->actionsPosition) {
-            case 'left':
-                return 'justify-start';
-                break;
-            case 'center':
-                return 'justify-center';
-                break;
-            case 'right':
-                return 'justify-end';
-                break;
-            default:
-                return 'justify-end';
-        }
-
+        return $this->actionsPosition ?? 'right';
     }
 
     #[Computed]

--- a/src/Traits/Helpers/ActionsHelpers.php
+++ b/src/Traits/Helpers/ActionsHelpers.php
@@ -18,19 +18,19 @@ trait ActionsHelpers
     public function getActionsPosition(): string
     {
         switch ($this->actionsPosition) {
-            case "left":
-                return "justify-start";
+            case 'left':
+                return 'justify-start';
                 break;
-            case "center":
-                return "justify-center";
+            case 'center':
+                return 'justify-center';
                 break;
-            case "right":
-                return "justify-end";
+            case 'right':
+                return 'justify-end';
                 break;
             default:
-                return "justify-end";
+                return 'justify-end';
         }
-        
+
     }
 
     #[Computed]

--- a/src/Traits/Helpers/ActionsHelpers.php
+++ b/src/Traits/Helpers/ActionsHelpers.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
+
+use Livewire\Attributes\Computed;
+use Illuminate\Support\Collection;
+use Rappasoft\LaravelLivewireTables\Views\Action;
+
+trait ActionsHelpers
+{
+
+    #[Computed]
+    public function showActionsInToolbar(): bool
+    {
+        return $this->displayActionsInToolbar ?? false;
+    }
+
+    #[Computed]
+    public function showActionsInToolbar(): bool
+    {
+        return $this->displayActionsInToolbar ?? false;
+    }
+
+    #[Computed]
+    public function getActionWrapperAttributes(): array
+    {
+        return [...['default-styling' => true, 'default-colors' => true], ...$this->actionWrapperAttributes];
+    }
+
+    #[Computed]
+    public function hasActions(): bool
+    {
+        return (new Collection($this->actions()))
+            ->filter(fn ($action) => $action instanceof Action)->count() > 0;
+    }
+
+    #[Computed]
+    public function getActions(): Collection
+    {
+        return (new Collection($this->actions()))
+            ->filter(fn ($action) => $action instanceof Action)
+            ->each(function (Action $action, int $key) {
+                $action->setTheme($this->getTheme());
+            });
+
+    }
+}

--- a/src/Traits/WithActions.php
+++ b/src/Traits/WithActions.php
@@ -20,5 +20,4 @@ trait WithActions
     {
         return [];
     }
-
 }

--- a/src/Traits/WithActions.php
+++ b/src/Traits/WithActions.php
@@ -2,47 +2,23 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits;
 
-use Illuminate\Support\Collection;
-use Livewire\Attributes\Computed;
-use Rappasoft\LaravelLivewireTables\Views\Action;
+use Rappasoft\LaravelLivewireTables\Traits\Configuration\ActionsConfiguration;
+use Rappasoft\LaravelLivewireTables\Traits\Helpers\ActionsHelpers;
 
 trait WithActions
 {
+    use ActionsConfiguration,
+        ActionsHelpers;
+
     protected array $actionWrapperAttributes = ['default-styling' => true, 'default-colors' => true];
+
+    protected bool $displayActionsInToolbar = false;
+
+    protected string $actionsPosition = 'right';
 
     protected function actions(): array
     {
         return [];
     }
 
-    public function setActionWrapperAttributes(array $actionWrapperAttributes): self
-    {
-        $this->actionWrapperAttributes = [...['default-styling' => true, 'default-colors' => true], ...$actionWrapperAttributes];
-
-        return $this;
-    }
-
-    #[Computed]
-    public function getActionWrapperAttributes(): array
-    {
-        return [...['default-styling' => true, 'default-colors' => true], ...$this->actionWrapperAttributes];
-    }
-
-    #[Computed]
-    public function hasActions(): bool
-    {
-        return (new Collection($this->actions()))
-            ->filter(fn ($action) => $action instanceof Action)->count() > 0;
-    }
-
-    #[Computed]
-    public function getActions(): Collection
-    {
-        return (new Collection($this->actions()))
-            ->filter(fn ($action) => $action instanceof Action)
-            ->each(function (Action $action, int $key) {
-                $action->setTheme($this->getTheme());
-            });
-
-    }
 }

--- a/src/Traits/WithActions.php
+++ b/src/Traits/WithActions.php
@@ -10,7 +10,7 @@ trait WithActions
     use ActionsConfiguration,
         ActionsHelpers;
 
-    protected array $actionWrapperAttributes = ['default-styling' => true, 'default-colors' => true];
+    protected array $actionWrapperAttributes = ['class' => '', 'default-styling' => true, 'default-colors' => true];
 
     protected bool $displayActionsInToolbar = false;
 

--- a/src/Views/Traits/Actions/HasActionAttributes.php
+++ b/src/Views/Traits/Actions/HasActionAttributes.php
@@ -6,18 +6,18 @@ use Illuminate\View\ComponentAttributeBag;
 
 trait HasActionAttributes
 {
-    protected array $actionAttributes = ['default-styling' => true, 'default-colors' => true];
+    protected array $actionAttributes = ['class' => '', 'default-styling' => true, 'default-colors' => true];
 
     public function setActionAttributes(array $actionAttributes): self
     {
-        $this->actionAttributes = [...['default-styling' => true, 'default-colors' => true], ...$actionAttributes];
+        $this->actionAttributes = [...$this->actionAttributes, ...$actionAttributes];
 
         return $this;
     }
 
     public function getActionAttributes(): ComponentAttributeBag
     {
-        $actionAttributes = [...['default-styling' => true, 'default-colors' => true], ...$this->actionAttributes];
+        $actionAttributes = [...['class' => '', 'default-styling' => true, 'default-colors' => true], ...$this->actionAttributes];
 
         if (! $this->hasWireAction() && method_exists($this, 'getRoute')) {
             $actionAttributes['href'] = $this->getRoute();

--- a/src/Views/Traits/Core/HasIcon.php
+++ b/src/Views/Traits/Core/HasIcon.php
@@ -9,7 +9,7 @@ trait HasIcon
 {
     public ?string $icon;
 
-    public array $iconAttributes = ['default-styling' => true];
+    public array $iconAttributes = ['class' => '', 'default-styling' => true];
 
     public bool $iconRight = true;
 
@@ -32,14 +32,14 @@ trait HasIcon
 
     public function setIconAttributes(array $iconAttributes): self
     {
-        $this->iconAttributes = [...['default-styling' => true], ...$iconAttributes];
+        $this->iconAttributes = [...$this->iconAttributes, ...$iconAttributes];
 
         return $this;
     }
 
     public function getIconAttributes(): ComponentAttributeBag
     {
-        return new ComponentAttributeBag([...['default-styling' => true], ...$this->iconAttributes]);
+        return new ComponentAttributeBag([...['class' => '', 'default-styling' => true], ...$this->iconAttributes]);
     }
 
     public function getIconRight(): bool

--- a/tests/Traits/Visuals/ActionsVisualsTest.php
+++ b/tests/Traits/Visuals/ActionsVisualsTest.php
@@ -80,7 +80,6 @@ final class ActionsVisualsTest extends TestCase
 
     }
 
-
     public function test_can_align_actions_right(): void
     {
         $petsTable = (new class extends PetsTable

--- a/tests/Traits/Visuals/ActionsVisualsTest.php
+++ b/tests/Traits/Visuals/ActionsVisualsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Visuals;
+
+use Livewire\Livewire;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+final class ActionsVisualsTest extends TestCase
+{
+    public function test_can_align_actions_left(): void
+    {
+        $petsTable = (new class extends PetsTable
+        {
+            use \Rappasoft\LaravelLivewireTables\Traits\WithActions;
+
+            public function actions(): array
+            {
+                return [
+                    \Rappasoft\LaravelLivewireTables\Views\Actions\Action::make('Test Edit 1')
+                        ->setRoute('dashboard24'),
+                ];
+            }
+
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+                $this->setActionWrapperAttributes(['class' => 'flex flex-cols space-x-4 py-4', 'default-styling' => false]);
+                $this->setActionsLeft();
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        });
+        Livewire::test($petsTable)
+            ->assertSeeHtml('<div class="justify-start flex flex-cols space-x-4 py-4" >');
+
+    }
+
+    public function test_can_align_actions_center(): void
+    {
+        $petsTable = (new class extends PetsTable
+        {
+            use \Rappasoft\LaravelLivewireTables\Traits\WithActions;
+
+            public function actions(): array
+            {
+                return [
+                    \Rappasoft\LaravelLivewireTables\Views\Actions\Action::make('Test Edit 1')
+                        ->setRoute('dashboard24'),
+                ];
+            }
+
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+                $this->setActionWrapperAttributes(['class' => 'flex flex-cols space-x-4 py-4', 'default-styling' => false]);
+                $this->setActionsCenter();
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        });
+        Livewire::test($petsTable)
+            ->assertSeeHtml('<div class="justify-center flex flex-cols space-x-4 py-4" >');
+
+    }
+
+
+    public function test_can_align_actions_right(): void
+    {
+        $petsTable = (new class extends PetsTable
+        {
+            use \Rappasoft\LaravelLivewireTables\Traits\WithActions;
+
+            public function actions(): array
+            {
+                return [
+                    \Rappasoft\LaravelLivewireTables\Views\Actions\Action::make('Test Edit 1')
+                        ->setRoute('dashboard24'),
+                ];
+            }
+
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+                $this->setActionWrapperAttributes(['class' => 'flex flex-cols space-x-4 py-4', 'default-styling' => false]);
+                $this->setActionsRight();
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        });
+        Livewire::test($petsTable)
+            ->assertSeeHtml('<div class="justify-end flex flex-cols space-x-4 py-4" >');
+
+    }
+}

--- a/tests/Views/Actions/ActionTest.php
+++ b/tests/Views/Actions/ActionTest.php
@@ -361,13 +361,13 @@ final class ActionTest extends TestCase
             }
         });
 
-        $this->assertSame('justify-end', $petsTable->getActionsPosition());
+        $this->assertSame('right', $petsTable->getActionsPosition());
         $petsTable->setActionsLeft();
-        $this->assertSame('justify-start', $petsTable->getActionsPosition());
+        $this->assertSame('left', $petsTable->getActionsPosition());
         $petsTable->setActionsCenter();
-        $this->assertSame('justify-center', $petsTable->getActionsPosition());
+        $this->assertSame('center', $petsTable->getActionsPosition());
         $petsTable->setActionsRight();
-        $this->assertSame('justify-end', $petsTable->getActionsPosition());
+        $this->assertSame('right', $petsTable->getActionsPosition());
 
     }
 }

--- a/tests/Views/Actions/ActionTest.php
+++ b/tests/Views/Actions/ActionTest.php
@@ -200,7 +200,6 @@ final class ActionTest extends TestCase
     {
         $petsTable = (new class extends PetsTable
         {
-
             public function configure(): void
             {
                 $this->setPrimaryKey('id');
@@ -342,12 +341,10 @@ final class ActionTest extends TestCase
         $this->assertStringContainsString('<a class="focus:border-indigo-300 focus:ring-indigo-200 justify-center text-center items-center inline-flex space-x-2 rounded-md border shadow-sm px-4 py-2 text-sm font-medium focus:ring focus:ring-opacity-50 dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800" href="dashboard22"', $action->render());
     }
 
-
     public function test_can_set_action_position(): void
     {
         $petsTable = (new class extends PetsTable
         {
-
             public function configure(): void
             {
                 $this->setPrimaryKey('id');

--- a/tests/Views/Actions/ActionTest.php
+++ b/tests/Views/Actions/ActionTest.php
@@ -398,5 +398,4 @@ final class ActionTest extends TestCase
         $this->assertFalse($petsTable->showActionsInToolbar());
 
     }
-
 }

--- a/tests/Views/Actions/ActionTest.php
+++ b/tests/Views/Actions/ActionTest.php
@@ -370,4 +370,33 @@ final class ActionTest extends TestCase
         $this->assertSame('right', $petsTable->getActionsPosition());
 
     }
+
+    public function test_can_set_action_toolbar(): void
+    {
+        $petsTable = (new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        });
+
+        $this->assertFalse($petsTable->showActionsInToolbar());
+        $petsTable->setActionsInToolbarEnabled();
+        $this->assertTrue($petsTable->showActionsInToolbar());
+        $petsTable->setActionsInToolbarDisabled();
+        $this->assertFalse($petsTable->showActionsInToolbar());
+
+    }
+
 }

--- a/tests/Views/Actions/ActionTest.php
+++ b/tests/Views/Actions/ActionTest.php
@@ -54,10 +54,10 @@ final class ActionTest extends TestCase
         $this->assertFalse($action->hasIcon());
 
         $action->setIconAttributes(['class' => 'font-sm text-sm']);
-        $bag = new \Illuminate\View\ComponentAttributeBag(['default-styling' => true, 'class' => 'font-sm text-sm']);
+        $bag = new \Illuminate\View\ComponentAttributeBag(['class' => 'font-sm text-sm', 'default-styling' => true]);
 
         $this->assertSame($bag->getAttributes(), $action->getIconAttributes()->getAttributes());
-        $this->assertSame(['default-styling' => true, 'class' => 'font-sm text-sm'], $action->iconAttributes);
+        $this->assertSame(['class' => 'font-sm text-sm', 'default-styling' => true], $action->iconAttributes);
 
     }
 
@@ -94,6 +94,7 @@ final class ActionTest extends TestCase
             ->wireNavigate()
             ->route('dashboard2');
         $this->assertSame((new ComponentAttributeBag([
+            'class' => '',
             'default-styling' => true,
             'default-colors' => true,
             'href' => 'dashboard2',
@@ -101,33 +102,33 @@ final class ActionTest extends TestCase
 
         $action->setActionAttributes(['class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800', 'default-styling' => true, 'default-colors' => true]);
         $this->assertSame((new ComponentAttributeBag([
+            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'default-styling' => true,
             'default-colors' => true,
-            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'href' => 'dashboard2',
         ]))->getAttributes(), $action->getActionAttributes()->getAttributes());
 
         $action->setActionAttributes(['class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800', 'default-styling' => true, 'default-colors' => true]);
         $this->assertSame((new ComponentAttributeBag([
+            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'default-styling' => true,
             'default-colors' => true,
-            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'href' => 'dashboard2',
         ]))->getAttributes(), $action->getActionAttributes()->getAttributes());
 
         $action->setActionAttributes(['class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800', 'default-styling' => true, 'default-colors' => false]);
         $this->assertSame((new ComponentAttributeBag([
+            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'default-styling' => true,
             'default-colors' => false,
-            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'href' => 'dashboard2',
         ]))->getAttributes(), $action->getActionAttributes()->getAttributes());
 
         $action->setActionAttributes(['class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800', 'default-colors' => false]);
         $this->assertSame((new ComponentAttributeBag([
+            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'default-styling' => true,
             'default-colors' => false,
-            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'href' => 'dashboard2',
         ]))->getAttributes(), $action->getActionAttributes()->getAttributes());
 
@@ -199,7 +200,6 @@ final class ActionTest extends TestCase
     {
         $petsTable = (new class extends PetsTable
         {
-            use \Rappasoft\LaravelLivewireTables\Traits\WithActions;
 
             public function configure(): void
             {
@@ -216,19 +216,19 @@ final class ActionTest extends TestCase
                 return $items;
             }
         });
-        $this->assertSame(['default-styling' => true, 'default-colors' => true], $petsTable->getActionWrapperAttributes());
+        $this->assertSame(['class' => '', 'default-styling' => true, 'default-colors' => true], $petsTable->getActionWrapperAttributes());
         $petsTable->setActionWrapperAttributes(['default-styling' => false, 'class' => 'bg-blue-500']);
         $this->assertSame([
+            'class' => 'bg-blue-500',
             'default-styling' => false,
             'default-colors' => true,
-            'class' => 'bg-blue-500',
         ], $petsTable->getActionWrapperAttributes());
 
         $petsTable->setActionWrapperAttributes(['default-colors' => false, 'class' => 'bg-red-500']);
         $this->assertSame([
-            'default-styling' => true,
-            'default-colors' => false,
             'class' => 'bg-red-500',
+            'default-styling' => false,
+            'default-colors' => false,
         ], $petsTable->getActionWrapperAttributes());
 
     }
@@ -239,9 +239,9 @@ final class ActionTest extends TestCase
             ->setActionAttributes(['class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800', 'default-styling' => true, 'default-colors' => true])
             ->route('dashboard22');
         $this->assertSame((new ComponentAttributeBag([
+            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'default-styling' => true,
             'default-colors' => true,
-            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'href' => 'dashboard22',
         ]))->getAttributes(), $action->getActionAttributes()->getAttributes());
     }
@@ -254,9 +254,9 @@ final class ActionTest extends TestCase
             ->setWireAction('wire:click')
             ->setWireActionParams('testactionparams');
         $this->assertSame((new ComponentAttributeBag([
+            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'default-styling' => true,
             'default-colors' => true,
-            'class' => 'dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800',
             'href' => '#',
         ]))->getAttributes(), $action->getActionAttributes()->getAttributes());
     }
@@ -265,8 +265,6 @@ final class ActionTest extends TestCase
     {
         $petsTable = (new class extends PetsTable
         {
-            use \Rappasoft\LaravelLivewireTables\Traits\WithActions;
-
             public function actions(): array
             {
                 return [
@@ -342,5 +340,37 @@ final class ActionTest extends TestCase
             ->route('dashboard22');
 
         $this->assertStringContainsString('<a class="focus:border-indigo-300 focus:ring-indigo-200 justify-center text-center items-center inline-flex space-x-2 rounded-md border shadow-sm px-4 py-2 text-sm font-medium focus:ring focus:ring-opacity-50 dark:bg-green-500 dark:text-white dark:border-green-600 dark:hover:border-green-900 dark:hover:bg-green-800" href="dashboard22"', $action->render());
+    }
+
+
+    public function test_can_set_action_position(): void
+    {
+        $petsTable = (new class extends PetsTable
+        {
+
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        });
+
+        $this->assertSame('justify-end', $petsTable->getActionsPosition());
+        $petsTable->setActionsLeft();
+        $this->assertSame('justify-start', $petsTable->getActionsPosition());
+        $petsTable->setActionsCenter();
+        $this->assertSame('justify-center', $petsTable->getActionsPosition());
+        $petsTable->setActionsRight();
+        $this->assertSame('justify-end', $petsTable->getActionsPosition());
+
     }
 }


### PR DESCRIPTION
Add setActionsPosition

### setActionsLeft

Displays the Actions above the Toolbar, justified to the left

```php
    public function configure(): void
    {
        $this->setActionsLeft();
    }
```

### setActionsCenter

Displays the Actions above the Toolbar, justified to the center

```php
    public function configure(): void
    {
        $this->setActionsCenter();
    }
```

### setActionsRight

Displays the Actions above the Toolbar, justified to the right

```php
    public function configure(): void
    {
        $this->setActionsRight();
    }
```


### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
