### PR TITLE
Save filter selection to session (BETA)

### DIFF
--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -177,6 +177,7 @@ Set the filter slide down to collapsed by default
 ```php
 public function configure(): void
 {
+    // Shorthand for $this->setFilterSlideDownDefaultStatus(false)
     $this->setFilterSlideDownDefaultStatusDisabled();
 }
 ```
@@ -191,7 +192,6 @@ public function configure(): void
     $this->storeFiltersInSessionEnabled();
 }
 ```
-
 ### storeFiltersInSessionDisabled
 
 Default behaviour - does not store filters in session

--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -184,7 +184,10 @@ public function configure(): void
 
 ### storeFiltersInSessionEnabled
 
-Optional behaviour - stores filter values in session (specific to table)
+Optional behaviour - stores filter values in the session (specific to table - based on the table name)
+
+#### Exercise Caution 
+If re-using the same Livewire Table Component multiple times in your site, with the same table name, this may cause clashes in filter values
 
 ```php
 public function configure(): void
@@ -194,7 +197,7 @@ public function configure(): void
 ```
 ### storeFiltersInSessionDisabled
 
-Default behaviour - does not store filters in session
+Default behaviour - does not store filters in the session
 
 ```php
 public function configure(): void

--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -182,6 +182,28 @@ public function configure(): void
 }
 ```
 
+### storeFiltersInSessionEnabled
+
+Optional behaviour - stores filter values in session (specific to table)
+
+```php
+public function configure(): void
+{
+    $this->storeFiltersInSessionEnabled();
+}
+```
+
+### storeFiltersInSessionDisabled
+
+Default behaviour - does not store filters in session
+
+```php
+public function configure(): void
+{
+    $this->storeFiltersInSessionDisabled();
+}
+```
+
 
 ----
 

--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -177,7 +177,6 @@ Set the filter slide down to collapsed by default
 ```php
 public function configure(): void
 {
-    // Shorthand for $this->setFilterSlideDownDefaultStatus(false)
     $this->setFilterSlideDownDefaultStatusDisabled();
 }
 ```

--- a/src/Traits/Configuration/SessionStorageConfiguration.php
+++ b/src/Traits/Configuration/SessionStorageConfiguration.php
@@ -4,7 +4,6 @@ namespace Rappasoft\LaravelLivewireTables\Traits\Configuration;
 
 trait SessionStorageConfiguration
 {
-
     protected function storeFiltersInSessionStatus(bool $status): self
     {
         $this->sessionStorageStatus['filters'] = $status;
@@ -16,10 +15,9 @@ trait SessionStorageConfiguration
     {
         return $this->storeFiltersInSessionStatus(true);
     }
-    
+
     protected function storeFiltersInSessionDisabled(): self
     {
-        return $this->storeFiltersInSessionStatus(false);   
+        return $this->storeFiltersInSessionStatus(false);
     }
-
 }

--- a/src/Traits/Configuration/SessionStorageConfiguration.php
+++ b/src/Traits/Configuration/SessionStorageConfiguration.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Configuration;
+
+trait SessionStorageConfiguration
+{
+
+    protected function storeFiltersInSessionStatus(bool $status): self
+    {
+        $this->sessionStorageStatus['filters'] = $status;
+
+        return $this;
+    }
+
+    protected function storeFiltersInSessionEnabled(): self
+    {
+        return $this->storeFiltersInSessionStatus(true);
+    }
+    
+    protected function storeFiltersInSessionDisabled(): self
+    {
+        return $this->storeFiltersInSessionStatus(false);   
+    }
+
+}

--- a/src/Traits/Configuration/SessionStorageConfiguration.php
+++ b/src/Traits/Configuration/SessionStorageConfiguration.php
@@ -11,12 +11,12 @@ trait SessionStorageConfiguration
         return $this;
     }
 
-    protected function storeFiltersInSessionEnabled(): self
+    public function storeFiltersInSessionEnabled(): self
     {
         return $this->storeFiltersInSessionStatus(true);
     }
 
-    protected function storeFiltersInSessionDisabled(): self
+    public function storeFiltersInSessionDisabled(): self
     {
         return $this->storeFiltersInSessionStatus(false);
     }

--- a/src/Traits/HasAllTraits.php
+++ b/src/Traits/HasAllTraits.php
@@ -27,6 +27,7 @@ trait HasAllTraits
         WithRefresh,
         WithReordering,
         WithSecondaryHeader,
+        WithSessionStorage,
         WithTableAttributes,
         WithTools;
 }

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -18,6 +18,8 @@ trait FilterHelpers
      */
     public function mountFilterHelpers(): void
     {
+        $this->restoreFilterValues();
+
         foreach ($this->getFilters() as $filter) {
             if (! isset($this->appliedFilters[$filter->getKey()])) {
                 if ($filter->hasFilterDefaultValue()) {
@@ -145,6 +147,8 @@ trait FilterHelpers
             event(new FilterApplied($this->getTableName(), $filterKey, $value));
         }
         $this->dispatch('filter-was-set', tableName: $this->getTableName(), filterKey: $filterKey, value: $value);
+        $this->storeFilterValues();
+
     }
 
     public function selectAllFilterOptions(string $filterKey): void
@@ -173,6 +177,7 @@ trait FilterHelpers
                 $this->resetFilter($filter);
             }
         }
+
     }
 
     /**
@@ -241,6 +246,7 @@ trait FilterHelpers
         return count($this->getAppliedFiltersWithValues());
     }
 
+
     /**
      * @param  mixed  $filter
      */
@@ -252,6 +258,7 @@ trait FilterHelpers
         $this->callHook('filterReset', ['filter' => $filter->getKey()]);
         $this->callTraitHook('filterReset', ['filter' => $filter->getKey()]);
         $this->setFilter($filter->getKey(), $filter->getDefaultValue());
+
     }
 
     public function getFilterLayout(): string

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -246,7 +246,6 @@ trait FilterHelpers
         return count($this->getAppliedFiltersWithValues());
     }
 
-
     /**
      * @param  mixed  $filter
      */

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -14,7 +14,6 @@ trait SessionStorageHelpers
         return $this->sessionStorageStatus['filters'] ?? false;
     }
 
-
     protected function shouldStoreFiltersInSession(): bool
     {
         return $this->getSessionStorageStatus('filters');
@@ -33,11 +32,11 @@ trait SessionStorageHelpers
         session([$this->getFilterSessionKey() => $this->appliedFilters]);
 
     }
+
     public function restoreFiltersFromSession(): void
     {
         if (session()->has($this->getFilterSessionKey())) {
             $this->appliedFilters = session()->get($this->getFilterSessionKey());
         }
     }
-
 }

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
+
+trait SessionStorageHelpers
+{
+    protected function getSessionStorageStatus(string $name): bool
+    {
+        return $this->sessionStorageStatus[$name] ?? false;
+    }
+
+    protected function getSessionStorageStatusFilters(): bool
+    {
+        return $this->sessionStorageStatus['filters'] ?? false;
+    }
+
+
+    protected function shouldStoreFiltersInSession(): bool
+    {
+        return $this->getSessionStorageStatus('filters');
+    }
+
+    public function getFilterSessionKey(): string
+    {
+        return $this->getTableName().'-filter-backup';
+    }
+
+    public function storeFiltersInSession(): void
+    {
+        if (session()->has($this->getFilterSessionKey())) {
+            session()->forget($this->getFilterSessionKey());
+        }
+        session([$this->getFilterSessionKey() => $this->appliedFilters]);
+
+    }
+    public function restoreFiltersFromSession(): void
+    {
+        if (session()->has($this->getFilterSessionKey())) {
+            $this->appliedFilters = session()->get($this->getFilterSessionKey());
+        }
+    }
+
+}

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -22,9 +22,7 @@ trait SessionStorageHelpers
     public function storeFilterValues(): void
     {
         if ($this->shouldStoreFiltersInSession()) {
-            if (session()->has($this->getFilterSessionKey())) {
-                session()->forget($this->getFilterSessionKey());
-            }
+            $this->clearStoredFilterValues();
             session([$this->getFilterSessionKey() => $this->appliedFilters]);
         }
     }

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -24,11 +24,9 @@ trait SessionStorageHelpers
         return $this->getTableName().'-filter-backup';
     }
 
-
     public function storeFilterValues(): void
     {
-        if($this->shouldStoreFiltersInSession())
-        {
+        if ($this->shouldStoreFiltersInSession()) {
             if (session()->has($this->getFilterSessionKey())) {
                 session()->forget($this->getFilterSessionKey());
             }
@@ -38,21 +36,18 @@ trait SessionStorageHelpers
 
     public function restoreFilterValues(): void
     {
-        if(empty($this->filterComponents) || empty($this->appliedFilters))
-        {
-            if($this->shouldStoreFiltersInSession())
-            {
+        if (empty($this->filterComponents) || empty($this->appliedFilters)) {
+            if ($this->shouldStoreFiltersInSession()) {
                 if (session()->has($this->getFilterSessionKey())) {
                     $this->filterComponents = $this->appliedFilters = session()->get($this->getFilterSessionKey());
                 }
-            }    
+            }
         }
     }
 
     public function clearStoredFilterValues(): void
     {
-        if($this->shouldStoreFiltersInSession())
-        {
+        if ($this->shouldStoreFiltersInSession()) {
             session([$this->getFilterSessionKey() => []]);
         }
     }

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -11,7 +11,7 @@ trait SessionStorageHelpers
 
     protected function getSessionStorageStatusFilters(): bool
     {
-        return $this->getSessionStorageStatus('filters') ?? false;
+        return $this->getSessionStorageStatus('filters');
     }
 
     protected function shouldStoreFiltersInSession(): bool
@@ -21,7 +21,7 @@ trait SessionStorageHelpers
 
     protected function getFilterSessionKey(): string
     {
-        return $this->getTableName().'-filter-backup';
+        return $this->getTableName().'-stored-filters';
     }
 
     public function storeFilterValues(): void

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -11,7 +11,7 @@ trait SessionStorageHelpers
 
     protected function getSessionStorageStatusFilters(): bool
     {
-        return $this->sessionStorageStatus['filters'] ?? false;
+        return $this->getSessionStorageStatus('filters') ?? false;
     }
 
     protected function shouldStoreFiltersInSession(): bool
@@ -19,24 +19,41 @@ trait SessionStorageHelpers
         return $this->getSessionStorageStatus('filters');
     }
 
-    public function getFilterSessionKey(): string
+    protected function getFilterSessionKey(): string
     {
         return $this->getTableName().'-filter-backup';
     }
 
-    public function storeFiltersInSession(): void
-    {
-        if (session()->has($this->getFilterSessionKey())) {
-            session()->forget($this->getFilterSessionKey());
-        }
-        session([$this->getFilterSessionKey() => $this->appliedFilters]);
 
+    public function storeFilterValues(): void
+    {
+        if($this->shouldStoreFiltersInSession())
+        {
+            if (session()->has($this->getFilterSessionKey())) {
+                session()->forget($this->getFilterSessionKey());
+            }
+            session([$this->getFilterSessionKey() => $this->appliedFilters]);
+        }
     }
 
-    public function restoreFiltersFromSession(): void
+    public function restoreFilterValues(): void
     {
-        if (session()->has($this->getFilterSessionKey())) {
-            $this->appliedFilters = session()->get($this->getFilterSessionKey());
+        if(empty($this->filterComponents) || empty($this->appliedFilters))
+        {
+            if($this->shouldStoreFiltersInSession())
+            {
+                if (session()->has($this->getFilterSessionKey())) {
+                    $this->filterComponents = $this->appliedFilters = session()->get($this->getFilterSessionKey());
+                }
+            }    
+        }
+    }
+
+    public function clearStoredFilterValues(): void
+    {
+        if($this->shouldStoreFiltersInSession())
+        {
+            session([$this->getFilterSessionKey() => []]);
         }
     }
 }

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -41,6 +41,7 @@ trait SessionStorageHelpers
         if ($this->shouldStoreFiltersInSession() && session()->has($this->getFilterSessionKey())) {
             return session()->get($this->getFilterSessionKey());
         }
+
         return [];
     }
 

--- a/src/Traits/Helpers/SessionStorageHelpers.php
+++ b/src/Traits/Helpers/SessionStorageHelpers.php
@@ -9,17 +9,12 @@ trait SessionStorageHelpers
         return $this->sessionStorageStatus[$name] ?? false;
     }
 
-    protected function getSessionStorageStatusFilters(): bool
+    public function shouldStoreFiltersInSession(): bool
     {
         return $this->getSessionStorageStatus('filters');
     }
 
-    protected function shouldStoreFiltersInSession(): bool
-    {
-        return $this->getSessionStorageStatus('filters');
-    }
-
-    protected function getFilterSessionKey(): string
+    public function getFilterSessionKey(): string
     {
         return $this->getTableName().'-stored-filters';
     }
@@ -37,18 +32,22 @@ trait SessionStorageHelpers
     public function restoreFilterValues(): void
     {
         if (empty($this->filterComponents) || empty($this->appliedFilters)) {
-            if ($this->shouldStoreFiltersInSession()) {
-                if (session()->has($this->getFilterSessionKey())) {
-                    $this->filterComponents = $this->appliedFilters = session()->get($this->getFilterSessionKey());
-                }
-            }
+            $this->filterComponents = $this->appliedFilters = $this->getStoredFilterValues();
         }
+    }
+
+    public function getStoredFilterValues(): array
+    {
+        if ($this->shouldStoreFiltersInSession() && session()->has($this->getFilterSessionKey())) {
+            return session()->get($this->getFilterSessionKey());
+        }
+        return [];
     }
 
     public function clearStoredFilterValues(): void
     {
-        if ($this->shouldStoreFiltersInSession()) {
-            session([$this->getFilterSessionKey() => []]);
+        if ($this->shouldStoreFiltersInSession() && session()->has($this->getFilterSessionKey())) {
+            session()->forget($this->getFilterSessionKey());
         }
     }
 }

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -78,6 +78,7 @@ trait WithFilters
                     }
                 }
             }
+            $this->storeFilterValues();
         }
 
         return $this->getBuilder();
@@ -110,5 +111,6 @@ trait WithFilters
             $this->dispatch('filter-was-set', tableName: $this->getTableName(), filterKey: $filter->getKey(), value: $value);
 
         }
+
     }
 }

--- a/src/Traits/WithSessionStorage.php
+++ b/src/Traits/WithSessionStorage.php
@@ -13,4 +13,6 @@ trait WithSessionStorage
     public array $sessionStorageStatus = [
         'filters' => false,
     ];
+
+
 }

--- a/src/Traits/WithSessionStorage.php
+++ b/src/Traits/WithSessionStorage.php
@@ -13,6 +13,4 @@ trait WithSessionStorage
     public array $sessionStorageStatus = [
         'filters' => false,
     ];
-
-
 }

--- a/src/Traits/WithSessionStorage.php
+++ b/src/Traits/WithSessionStorage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits;
+
+use Rappasoft\LaravelLivewireTables\Traits\Configuration\SessionStorageConfiguration;
+use Rappasoft\LaravelLivewireTables\Traits\Helpers\SessionStorageHelpers;
+
+trait WithSessionStorage
+{
+    use SessionStorageConfiguration,
+    SessionStorageHelpers;
+
+    public array $sessionStorageStatus = [
+        'filters' => false,
+    ];
+
+
+}

--- a/src/Traits/WithSessionStorage.php
+++ b/src/Traits/WithSessionStorage.php
@@ -8,11 +8,9 @@ use Rappasoft\LaravelLivewireTables\Traits\Helpers\SessionStorageHelpers;
 trait WithSessionStorage
 {
     use SessionStorageConfiguration,
-    SessionStorageHelpers;
+        SessionStorageHelpers;
 
     public array $sessionStorageStatus = [
         'filters' => false,
     ];
-
-
 }

--- a/tests/Traits/Helpers/SessionStorageHelpersTest.php
+++ b/tests/Traits/Helpers/SessionStorageHelpersTest.php
@@ -24,5 +24,4 @@ final class SessionStorageHelpersTest extends TestCase
     {
         $this->assertSame($this->basicTable->getTableName().'-stored-filters', $this->basicTable->getFilterSessionKey());
     }
-
 }

--- a/tests/Traits/Helpers/SessionStorageHelpersTest.php
+++ b/tests/Traits/Helpers/SessionStorageHelpersTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Traits\Helpers;
+
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+final class SessionStorageHelpersTest extends TestCase
+{
+    public function test_can_get_session_storage_status_for_filters(): void
+    {
+        $this->assertFalse($this->basicTable->shouldStoreFiltersInSession());
+
+        $this->basicTable->storeFiltersInSessionEnabled();
+
+        $this->assertTrue($this->basicTable->shouldStoreFiltersInSession());
+
+        $this->basicTable->storeFiltersInSessionDisabled();
+
+        $this->assertFalse($this->basicTable->shouldStoreFiltersInSession());
+
+    }
+
+    public function test_can_get_session_storage_status_filter_key(): void
+    {
+        $this->assertSame($this->basicTable->getTableName().'-stored-filters', $this->basicTable->getFilterSessionKey());
+    }
+
+}


### PR DESCRIPTION
Adds two new methods for the core Table:

This allows for storing of Filter Values in the Session, these are table-specific. And allow for returning to a Table with the previously set Filter Values.

By default this behaviour is disabled.

### storeFiltersInSessionEnabled

Optional behaviour - stores filter values in session (specific to table)

```php
public function configure(): void
{
    $this->storeFiltersInSessionEnabled();
}
```
### storeFiltersInSessionDisabled

Default behaviour - does not store filters in session

```php
public function configure(): void
{
    $this->storeFiltersInSessionDisabled();
}
```


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
