### PR TITLE
Revert tableName to be public

### DIFF
--- a/src/Traits/ComponentUtilities.php
+++ b/src/Traits/ComponentUtilities.php
@@ -24,7 +24,8 @@ trait ComponentUtilities
 
     protected array $relationships = [];
 
-    protected string $tableName = 'table';
+    #[Locked]
+    public string $tableName = 'table';
 
     #[Locked]
     public ?string $dataTableFingerprint;


### PR DESCRIPTION
This reverts tableName to be a public attribute as a quick fix.

This will be modified along with other items to get/initial rather than entangling in a future revision

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
