### PR TITLE
[FIXES #1949] In LaravelLivewireTablesEvent, change the type of $user to Illuminate\Contracts\Auth\Authenticatable

### DIFF
--- a/src/Events/LaravelLivewireTablesEvent.php
+++ b/src/Events/LaravelLivewireTablesEvent.php
@@ -2,7 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Events;
 
-use Illuminate\Foundation\Auth\User;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -16,7 +16,7 @@ class LaravelLivewireTablesEvent
 
     public string|array|null $value;
 
-    public ?User $user;
+    public ?Authenticatable $user;
 
     public function setKeyForEvent(string $key): self
     {


### PR DESCRIPTION
In Rappasoft\LaravelLivewireTables\Events\LaravelLivewireTablesEvent, change the type of $user from Illuminate\Foundation\Auth\User to Illuminate\Contracts\Auth\Authenticatable

Full bug description here: https://github.com/rappasoft/laravel-livewire-tables/issues/1949

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
