### PR TITLE
Livewire column doesn't have title() method

### DIFF
--- a/docs/column-types/livewire_component_column.md
+++ b/docs/column-types/livewire_component_column.md
@@ -10,7 +10,6 @@ This is **not recommended** as due to the nature of Livewire, it becomes ineffic
 ## component
 ```
 LivewireComponentColumn::make('Action')
-    ->title(fn($row) => 'Edit')
     ->component('PathToLivewireComponent'),
 
 ```


### PR DESCRIPTION
The Livewire column type doesn't have the `HasTitleCallback` trait, so you can't use `->title()`.

I don't know why there's an edit to the last line.  I'm just editing this file through github.com, so maybe their "diff" is confusing EOF characters.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
