### PR TITLE
Add config option to bypass setting User on Events.

### DIFF
--- a/config/livewire-tables.php
+++ b/config/livewire-tables.php
@@ -114,4 +114,14 @@ return [
         'defaultConfig' => [],
     ],
 
+    /**
+     * Configuration options for Events
+     */
+    'events' => [
+        /**
+        * Enable or disable passing the user from Laravel's Auth service to events
+        */
+        'enableUserForEvent' => true,
+    ],
+
 ];

--- a/docs/datatable/events.md
+++ b/docs/datatable/events.md
@@ -55,6 +55,8 @@ There are several events, all in the Rappasoft\LaravelLivewireTables\Events name
 | FilterApplied | Applied when a Filter is applied (not when removed) |  The Table Name ($tableName), Filter Key ($key), Filter Value ($value), Logged In User ($user) |
 | SearchApplied | Applied when a Search is applied (not when removed) | The Table Name ($tableName), Search Term ($value), Logged In User ($user) |
 
+Passing the user with an event is optional and [can be disabled in the config](../start/configuration.md#bypassing-laravels-auth-service).
+
 By default, the Tables will dispatch an event when the Selected Columns is changed, you may customise this behaviour:
 
 #### enableAllEvents

--- a/docs/start/configuration.md
+++ b/docs/start/configuration.md
@@ -81,3 +81,22 @@ You must also make sure you have this Alpine style available globally. Note that
     [x-cloak] { display: none !important; }
 </style>
 ```
+
+## Bypassing Laravel's Auth Service
+
+By default, all [events](../datatable/events#dispatched) will retrieve any currently authenticated user from Laravel's [Auth service](https://laravel.com/docs/authentication) and pass it along with the event.
+
+If your project doesn't include the Illuminate/Auth package, or you otherwise want to prevent this, you can set the `enableUserForEvent` config option to false.
+
+```php
+// config/livewire-tables.php
+return [
+    // ...
+    'events' => [
+        /**
+        * Enable or disable passing the user from Laravel's Auth service to events
+        */
+        'enableUserForEvent' => false,
+    ],
+];
+```

--- a/src/Events/LaravelLivewireTablesEvent.php
+++ b/src/Events/LaravelLivewireTablesEvent.php
@@ -42,7 +42,7 @@ class LaravelLivewireTablesEvent
 
     public function setUserForEvent(): self
     {
-        if (auth()->user()) {
+        if (config('livewire-tables.events.enableUserForEvent', true) && auth()->user()) {
             $this->user = auth()->user();
         }
 

--- a/tests/Events/ColumnsSelectedTest.php
+++ b/tests/Events/ColumnsSelectedTest.php
@@ -80,4 +80,23 @@ final class ColumnsSelectedTest extends TestCase
             return $event->columns == [] && $event->user->id == '1234' && $event->tableName == $this->basicTable->getTableName();
         });
     }
+
+    public function test_user_not_set_on_event_when_a_column_selection_is_updated_and_user_for_event_disabled()
+    {
+        Event::fake();
+
+        config()->set('livewire-tables.events.enableUserForEvent', false);
+
+        $user = new \Illuminate\Foundation\Auth\User;
+        $user->id = '1234';
+        $user->name = 'Bob';
+        $this->actingAs($user);
+
+        $this->basicTable->selectAllColumns();
+
+        Event::assertDispatched(ColumnsSelected::class, function ($event) {
+            $this->assertFalse(isset($event->user), "User set on Event when config is set to disable this behavior");
+            return true;
+        });
+    }
 }

--- a/tests/Events/FilterAppliedTest.php
+++ b/tests/Events/FilterAppliedTest.php
@@ -61,4 +61,23 @@ final class FilterAppliedTest extends TestCase
             return $event->value == 'test value' && $event->user->id == '1234' && $event->key = 'pet_name_filter' && $event->tableName == $this->basicTable->getTableName();
         });
     }
+
+    public function test_user_not_set_on_event_when_a_filter_is_applied_and_user_for_event_disabled()
+    {
+        Event::fake();
+
+        config()->set('livewire-tables.events.enableUserForEvent', false);
+
+        $user = new \Illuminate\Foundation\Auth\User;
+        $user->id = '1234';
+        $user->name = 'Bob';
+        $this->actingAs($user);
+
+        $this->basicTable->enableFilterAppliedEvent()->setFilter('pet_name_filter', 'test value');
+
+        Event::assertDispatched(FilterApplied::class, function ($event) {
+            $this->assertFalse(isset($event->user), "User set on Event when config is set to disable this behavior");
+            return true;
+        });
+    }
 }

--- a/tests/Events/SearchAppliedTest.php
+++ b/tests/Events/SearchAppliedTest.php
@@ -71,4 +71,23 @@ final class SearchAppliedTest extends TestCase
             return $event->value == 'test search value' && $event->user->id == '1234' && $event->tableName == $this->basicTable->getTableName();
         });
     }
+
+    public function test_user_not_set_on_event_when_a_search_is_applied_and_user_for_event_disabled()
+    {
+        Event::fake();
+
+        config()->set('livewire-tables.events.enableUserForEvent', false);
+
+        $user = new \Illuminate\Foundation\Auth\User;
+        $user->id = '1234';
+        $user->name = 'Bob';
+        $this->actingAs($user);
+
+        $this->basicTable->enableSearchAppliedEvent()->setSearch('test')->applySearch();
+
+        Event::assertDispatched(SearchApplied::class, function ($event) {
+            $this->assertFalse(isset($event->user), "User set on Event when config is set to disable this behavior");
+            return true;
+        });
+    }
 }


### PR DESCRIPTION
As discussed in the Discord, I created a config option (enabled by default, preserving current behavior) in order to bypass setting the user from Laravel (if one exists) via the auth() helper within events. In my case this is because I have a non-standard project using Roots Acorn which doesn't include the Illuminate/Auth package being called.

I wasn't 100% on where to add documentation for this. I decided on Getting Started/Configuration, since it's a part of the main library config. I thought about putting it in Datatable/Events, however that seemed more for DataTable configuration and general usage while this is more of an edge case. As a compromise I added a reference and link to the config value's documentation there where it seemed appropriate.

I added tests to each of the three events. I went back and forth and decided to just add one simple test which sets the new config value to false and checks the user isn't set when an event occurs. Since it defaults to true, the other existing tests which check when the user **is** set are implicitly testing that standard case.

All tests are passing locally and after pulling the code into my project it worked as expected there as well.

Feedback welcome, happy to make changes.

### All Submissions:

* [x ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
