### PR TITLE
Fix bug #1997 - Found the issue elsewhere also, so I fixed them too.

### DIFF
--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -20,8 +20,8 @@
 @if ($isTailwind)
     <th scope="col" {{
         $attributes->merge($customThAttributes)
-            ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => ($customThAttributes['default-colors'] ?? true || $customThAttributes['default'] ?? true)])
-            ->class(['px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => ($customThAttributes['default-styling'] ?? true || $customThAttributes['default'] ?? true)])
+            ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
+            ->class(['px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true))])
             ->class(['hidden' => $column->shouldCollapseAlways()])
             ->class(['hidden md:table-cell' => $column->shouldCollapseOnMobile()])
             ->class(['hidden lg:table-cell' => $column->shouldCollapseOnTablet()])
@@ -35,8 +35,8 @@
                 <button wire:click="sortBy('{{ $column->getColumnSortKey() }}')"
                     {{
                         $attributes->merge($customSortButtonAttributes)
-                            ->class(['text-gray-500 dark:text-gray-400' => ($customSortButtonAttributes['default-colors'] ?? true || $customSortButtonAttributes['default'] ?? true)])    
-                            ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none' => ($customSortButtonAttributes['default-styling'] ?? true || $customSortButtonAttributes['default'] ?? true)])
+                            ->class(['text-gray-500 dark:text-gray-400' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
+                            ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
                     }}
                 >
@@ -71,7 +71,7 @@
                     wire:click="sortBy('{{ $column->getColumnSortKey() }}')"
                     {{
                         $attributes->merge($customSortButtonAttributes)
-                            ->class(['' => ($customSortButtonAttributes['default-styling'] ?? true || $customSortButtonAttributes['default'] ?? true)])
+                            ->class(['' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
                     }}
                 >
@@ -79,7 +79,7 @@
 
                     <x-livewire-tables::table.th.sort-icons :$direction                     {{
                         $attributes->merge($customSortButtonAttributes)
-                            ->class(['' => ($customSortButtonAttributes['default-colors'] ?? true || $customSortButtonAttributes['default'] ?? true)])
+                            ->class(['' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
                     }}
                 />

--- a/resources/views/components/table/th/plain.blade.php
+++ b/resources/views/components/table/th/plain.blade.php
@@ -4,8 +4,8 @@
 <th x-cloak {{ $attributes }} scope="col"
     {{ 
         $attributes->merge($customAttributes)->class([
-            'table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left bg-gray-50 dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised' => ($isTailwind) && ($customAttributes['default-colors'] ?? true || $customAttributes['default'] ?? true),
-            'laravel-livewire-tables-reorderingMinimised' => ($isBootstrap) && ($customAttributes['default-colors'] ?? true || $customAttributes['default'] ?? true),
+            'table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left bg-gray-50 dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised' => ($isTailwind) && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
+            'laravel-livewire-tables-reorderingMinimised' => ($isBootstrap) && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
         ])
     }}
     @if($hideUntilReorder) :class="!reorderDisplayColumn && 'w-0 p-0 hidden'" @endif

--- a/resources/views/components/table/th/reorder.blade.php
+++ b/resources/views/components/table/th/reorder.blade.php
@@ -6,8 +6,8 @@
 <x-livewire-tables::table.th.plain x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $tableName }}-thead-reorder" :displayMinimisedOnReorder="false" 
     {{ 
         $attributes->merge($customThAttributes)
-            ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => ($customThAttributes['default-colors'] ?? true || $customThAttributes['default'] ?? true)])
-            ->class(['table-cell px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => ($customThAttributes['default-styling'] ?? true || $customThAttributes['default'] ?? true)])
+            ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
+            ->class(['table-cell px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true))])
             ->class(['laravel-livewire-tables-reorderingMinimised' => ($isBootstrap) && ($customThAttributes['default'] ?? true)])
     }}
 >

--- a/resources/views/components/tools/toolbar/items/search-field.blade.php
+++ b/resources/views/components/tools/toolbar/items/search-field.blade.php
@@ -12,10 +12,10 @@
             {{ 
                 $attributes->merge($this->getSearchFieldAttributes())
                 ->class([
-                    'block w-full rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 rounded-none rounded-l-md focus:ring-0 focus:border-gray-300' => $this->isTailwind && $this->hasSearch() && ($this->getSearchFieldAttributes()['default'] ?? true || $this->getSearchFieldAttributes()['default-styling'] ?? true),
-                    'block w-full rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 rounded-md focus:ring focus:ring-opacity-50' => $this->isTailwind && !$this->hasSearch()  && ($this->getSearchFieldAttributes()['default'] ?? true || $this->getSearchFieldAttributes()['default-styling'] ?? true),
-                    'border-gray-300 dark:bg-gray-700 dark:text-white dark:border-gray-600 focus:border-gray-300' => $this->isTailwind && $this->hasSearch()  && ($this->getSearchFieldAttributes()['default'] ?? true || $this->getSearchFieldAttributes()['default-colors'] ?? true),
-                    'border-gray-300 dark:bg-gray-700 dark:text-white dark:border-gray-600 focus:border-indigo-300 focus:ring-indigo-200' => $this->isTailwind && !$this->hasSearch()  && ($this->getSearchFieldAttributes()['default'] ?? true || $this->getSearchFieldAttributes()['default-colors'] ?? true),
+                    'block w-full rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 rounded-none rounded-l-md focus:ring-0 focus:border-gray-300' => $this->isTailwind && $this->hasSearch() && (($this->getSearchFieldAttributes()['default'] ?? true) || ($this->getSearchFieldAttributes()['default-styling'] ?? true)),
+                    'block w-full rounded-md shadow-sm transition duration-150 ease-in-out sm:text-sm sm:leading-5 rounded-md focus:ring focus:ring-opacity-50' => $this->isTailwind && !$this->hasSearch()  && (($this->getSearchFieldAttributes()['default'] ?? true) || ($this->getSearchFieldAttributes()['default-styling'] ?? true)),
+                    'border-gray-300 dark:bg-gray-700 dark:text-white dark:border-gray-600 focus:border-gray-300' => $this->isTailwind && $this->hasSearch()  && (($this->getSearchFieldAttributes()['default'] ?? true) || ($this->getSearchFieldAttributes()['default-colors'] ?? true)),
+                    'border-gray-300 dark:bg-gray-700 dark:text-white dark:border-gray-600 focus:border-indigo-300 focus:ring-indigo-200' => $this->isTailwind && !$this->hasSearch()  && (($this->getSearchFieldAttributes()['default'] ?? true) || ($this->getSearchFieldAttributes()['default-colors'] ?? true)),
 
                     'form-control' => $this->isBootstrap && $this->getSearchFieldAttributes()['default'] ?? true,
                 ])


### PR DESCRIPTION
Hopefully I have done it correctly this time.

This pull request is to fix bug #1997 .

I have found this issue in multiple places where there is incorrect brackets in conjunction with coalescing operator (??).

Example:

```PHP
$input1 = false;
$input2 = true;
return ($input1 ?? true || $input2 ?? true); // Will always return value of $input1 unless null
```

Fixed:

```PHP
return (($input1 ?? true) || $input2 ?? true); // Will only return true if either (or both) $input1 or $input2 are null or true.
```

