### PR TITLE
Fixes for Filter Pills - Ensure Invalid Options Are Removed

### DIFF
--- a/resources/views/components/tools/filter-pills.blade.php
+++ b/resources/views/components/tools/filter-pills.blade.php
@@ -15,84 +15,19 @@
 
             @foreach($this->getAppliedFiltersWithValues() as $filterSelectName => $value)
                 @php($filter = $this->getFilterByKey($filterSelectName))
-
-                @continue(is_null($filter))
-                @continue($filter->isHiddenFromPills())
+                @continue(is_null($filter) || $filter->isHiddenFromPills())
+                @php( $filterPillTitle = $filter->getFilterPillTitle())
+                @php( $filterPillValue = $filter->getFilterPillValue($value))
+                @php( $separator = method_exists($filter, 'getPillsSeparator') ? $filter->getPillsSeparator() : ', ')
+                @continue((is_array($filterPillValue) && empty($filterPillValue)))
 
                 @if ($filter->hasCustomPillBlade())
                     @include($filter->getCustomPillBlade(), ['filter' => $filter])
                 @else
-                    <span
-                        wire:key="{{ $tableName }}-filter-pill-{{ $filter->getKey() }}"
-                        @class([
-                            'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900' => $isTailwind,
-                            'badge badge-pill badge-info d-inline-flex align-items-center' => $isBootstrap4,
-                            'badge rounded-pill bg-info d-inline-flex align-items-center' => $isBootstrap5,
-                        ])
-                    >
-                        {{ $filter->getFilterPillTitle() }}: 
-                        @php( $filterPillValue = $filter->getFilterPillValue($value))
-                        @php( $separator = method_exists($filter, 'getPillsSeparator') ? $filter->getPillsSeparator() : ', ')
-
-                        @if(is_array($filterPillValue) && !empty($filterPillValue))
-                            @foreach($filterPillValue as $filterPillArrayValue)
-                                {{ $filterPillArrayValue }}{!! $separator !!}
-                            @endforeach
-                        @else
-                            {{ $filterPillValue }}
-                        @endif
-
-                        @if ($isTailwind)
-                            <button
-                                wire:click="resetFilter('{{ $filter->getKey() }}')"
-                                type="button"
-                                class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:outline-none focus:bg-indigo-500 focus:text-white"
-                            >
-                                <span class="sr-only">@lang('livewire-tables::Remove filter option')</span>
-                                <x-heroicon-m-x-mark class="h-full" />
-                            </button>
-                        @else
-                            <a
-                                href="#"
-                                wire:click="resetFilter('{{ $filter->getKey() }}')"
-                                @class([
-                                    'text-white ml-2' => ($isBootstrap),
-                                ])
-                            >
-                                <span @class([
-                                    'sr-only' => $isBootstrap4,
-                                    'visually-hidden' => $isBootstrap5,
-                                ])>
-                                    @lang('livewire-tables::Remove filter option')
-                                </span>
-                                <x-heroicon-m-x-mark class="laravel-livewire-tables-btn-tiny"  />
-                            </a>
-                        @endif
-                    </span>
+                    <x-livewire-tables::tools.filter-pills.item :$filterPillTitle :$filterPillValue :$filterSelectName :$separator/>
                 @endif
             @endforeach
-
-            @if ($isTailwind)
-                <button
-                    wire:click.prevent="setFilterDefaults"
-                    class="focus:outline-none active:outline-none"
-                >
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-200 dark:text-gray-900">
-                        @lang('livewire-tables::Clear')
-                    </span>
-                </button>
-            @else
-                <a
-                    href="#"
-                    wire:click.prevent="setFilterDefaults"
-                    @class([
-                        'badge badge-pill badge-light' => $isBootstrap4,
-                        'badge rounded-pill bg-light text-dark text-decoration-none' => $isBootstrap5,
-                    ])
-                >
-                    @lang('livewire-tables::Clear')
-                </a>
-            @endif
+            <x-livewire-tables::tools.filter-pills.buttons.reset-all />
         </div>
     </div>
 @endif

--- a/resources/views/components/tools/filter-pills/buttons/reset-all.blade.php
+++ b/resources/views/components/tools/filter-pills/buttons/reset-all.blade.php
@@ -1,0 +1,25 @@
+@aware(['isTailwind','isBootstrap','isBootstrap4','isBootstrap5'])
+@if ($isTailwind)
+    <button
+        wire:click.prevent="setFilterDefaults"
+        @class([
+            "focus:outline-none active:outline-none"
+        ])>
+        <span @class([
+            "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium",
+            "bg-gray-100 text-gray-800 dark:bg-gray-200 dark:text-gray-900"
+            ])>
+            @lang('livewire-tables::Clear')
+        </span>
+    </button>
+@else
+    <a
+        href="#"
+        wire:click.prevent="setFilterDefaults"
+        @class([
+            'badge badge-pill badge-light' => $isBootstrap4,
+            'badge rounded-pill bg-light text-dark text-decoration-none' => $isBootstrap5,
+        ])>
+        @lang('livewire-tables::Clear')
+    </a>
+@endif

--- a/resources/views/components/tools/filter-pills/buttons/reset-filter.blade.php
+++ b/resources/views/components/tools/filter-pills/buttons/reset-filter.blade.php
@@ -1,0 +1,31 @@
+@aware(['tableName','isTailwind','isBootstrap','isBootstrap4','isBootstrap5'])
+@props(['filterKey'])
+@if ($isTailwind)
+    <button
+        wire:click="resetFilter('{{ $filterKey }}')"
+        type="button"
+        @class([
+            "flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center focus:outline-none",
+            "text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:bg-indigo-500 focus:text-white",
+        ])
+    >
+        <span class="sr-only">@lang('livewire-tables::Remove filter option')</span>
+        <x-heroicon-m-x-mark class="h-full" />
+    </button>
+@else
+    <a
+        href="#"
+        wire:click="resetFilter('{{ $filterKey }}')"
+        @class([
+            'text-white ml-2' => ($isBootstrap),
+        ])
+    >
+        <span @class([
+            'sr-only' => $isBootstrap4,
+            'visually-hidden' => $isBootstrap5,
+        ])>
+            @lang('livewire-tables::Remove filter option')
+        </span>
+        <x-heroicon-m-x-mark class="laravel-livewire-tables-btn-tiny"  />
+    </a>
+@endif

--- a/resources/views/components/tools/filter-pills/item.blade.php
+++ b/resources/views/components/tools/filter-pills/item.blade.php
@@ -1,0 +1,23 @@
+@aware(['tableName','isTailwind','isBootstrap','isBootstrap4','isBootstrap5'])
+@props(['filterPillTitle', 'filterPillValue', 'filterSelectName', 'separator'])
+<span
+    wire:key="{{ $tableName }}-filter-pill-{{ $filterSelectName }}"
+    @class([
+        'inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-indigo-100 text-indigo-800 capitalize dark:bg-indigo-200 dark:text-indigo-900' => $isTailwind,
+        'badge badge-pill badge-info d-inline-flex align-items-center' => $isBootstrap4,
+        'badge rounded-pill bg-info d-inline-flex align-items-center' => $isBootstrap5,
+    ])
+>
+    {{ $filterPillTitle }}: 
+
+    @if(is_array($filterPillValue))
+        @foreach($filterPillValue as $filterPillArrayValue)
+            {{ $filterPillArrayValue }}{!! !$loop->last ? $separator : '' !!}
+        @endforeach
+    @else
+        {{ $filterPillValue }}
+    @endif
+
+    <x-livewire-tables::tools.filter-pills.buttons.reset-filter :filterKey="$filterSelectName" />
+
+</span>

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -226,10 +226,23 @@ trait FilterHelpers
     /**
      * @return array<mixed>
      */
-    public function getAppliedFiltersWithValues(): array
+    /*public function getAppliedFiltersWithValuesOld(): array
     {
         return $this->appliedFilters = array_filter($this->getAppliedFilters(), function ($item, $key) {
             return ! $this->getFilterByKey($key)->isEmpty($item) && (is_array($item) ? count($item) : $item !== null);
+        }, ARRAY_FILTER_USE_BOTH);
+    }*/
+
+    /**
+     * @return array<mixed>
+     */
+    public function getAppliedFiltersWithValues(): array
+    {
+        return $this->appliedFilters = array_filter($this->getAppliedFilters(), function ($item, $key) {
+            $filter = $this->getFilterByKey($key);
+            $item = (!is_null($item) && !$filter->isEmpty($item)) ? $filter->validate($item) : $item;
+            
+            return ! $filter->isEmpty($item) && (is_array($item) ? count($item) : $item !== null);
         }, ARRAY_FILTER_USE_BOTH);
     }
 

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -240,8 +240,8 @@ trait FilterHelpers
     {
         return $this->appliedFilters = array_filter($this->getAppliedFilters(), function ($item, $key) {
             $filter = $this->getFilterByKey($key);
-            $item = (!is_null($item) && !$filter->isEmpty($item)) ? $filter->validate($item) : $item;
-            
+            $item = (! is_null($item) && ! $filter->isEmpty($item)) ? $filter->validate($item) : $item;
+
             return ! $filter->isEmpty($item) && (is_array($item) ? count($item) : $item !== null);
         }, ARRAY_FILTER_USE_BOTH);
     }

--- a/tests/Traits/Helpers/FilterHelpersTest.php
+++ b/tests/Traits/Helpers/FilterHelpersTest.php
@@ -104,7 +104,7 @@ final class FilterHelpersTest extends TestCase
 
         $this->assertSame(['1'], $this->basicTable->getAppliedFilterWithValue('breed'));
 
-        $this->basicTable->setFilter('breed_id_filter', '2');
+        $this->basicTable->setFilter('breed_id_filter', 2);
 
         $this->assertSame('2', $this->basicTable->getAppliedFilterWithValue('breed_id_filter'));
 

--- a/tests/Traits/Helpers/SessionStorageHelpersTest.php
+++ b/tests/Traits/Helpers/SessionStorageHelpersTest.php
@@ -36,26 +36,26 @@ final class SessionStorageHelpersTest extends TestCase
         $this->assertSame(['breed' => ['1']], $this->basicTable->appliedFilters);
         $this->assertSame(['breed' => ['1']], $this->basicTable->getStoredFilterValues());
 
-        $this->basicTable->setFilter('breed', ['22']);
-        $this->assertSame(['breed' => ['22']], $this->basicTable->appliedFilters);
-        $this->assertSame(['22'], $this->basicTable->getAppliedFilterWithValue('breed'));
-        $this->assertSame(['breed' => ['22']], $this->basicTable->getStoredFilterValues());
+        $this->basicTable->setFilter('breed', ['2']);
+        $this->assertSame(['breed' => ['2']], $this->basicTable->appliedFilters);
+        $this->assertSame(['2'], $this->basicTable->getAppliedFilterWithValue('breed'));
+        $this->assertSame(['breed' => ['2']], $this->basicTable->getStoredFilterValues());
 
         $this->basicTable->restoreFilterValues();
-        $this->assertSame(['22'], $this->basicTable->getAppliedFilterWithValue('breed'));
-        $this->assertSame(['breed' => ['22']], $this->basicTable->getStoredFilterValues());
+        $this->assertSame(['2'], $this->basicTable->getAppliedFilterWithValue('breed'));
+        $this->assertSame(['breed' => ['2']], $this->basicTable->getStoredFilterValues());
 
         $this->basicTable->clearStoredFilterValues();
         $this->assertSame([], $this->basicTable->getStoredFilterValues());
-        $this->assertSame(['22'], $this->basicTable->getAppliedFilterWithValue('breed'));
+        $this->assertSame(['2'], $this->basicTable->getAppliedFilterWithValue('breed'));
 
-        $this->basicTable->setFilter('breed', ['33']);
-        $this->assertSame(['breed' => ['33']], $this->basicTable->getStoredFilterValues());
-        $this->assertSame(['33'], $this->basicTable->getAppliedFilterWithValue('breed'));
+        $this->basicTable->setFilter('breed', ['3']);
+        $this->assertSame(['breed' => ['3']], $this->basicTable->getStoredFilterValues());
+        $this->assertSame(['3'], $this->basicTable->getAppliedFilterWithValue('breed'));
 
-        $this->basicTable->appliedFilters = $this->basicTable->filterComponents = ['breed' => ['44']];
+        $this->basicTable->appliedFilters = $this->basicTable->filterComponents = ['breed' => ['4']];
         $this->basicTable->storeFilterValues();
-        $this->assertSame(['44'], $this->basicTable->getAppliedFilterWithValue('breed'));
+        $this->assertSame(['4'], $this->basicTable->getAppliedFilterWithValue('breed'));
 
         $this->basicTable->appliedFilters = $this->basicTable->filterComponents = [];
         $this->assertNull($this->basicTable->getAppliedFilterWithValue('breed'));
@@ -63,9 +63,9 @@ final class SessionStorageHelpersTest extends TestCase
         $this->assertSame([], $this->basicTable->filterComponents);
 
         $this->basicTable->restoreFilterValues();
-        $this->assertSame(['breed' => ['44']], $this->basicTable->appliedFilters);
-        $this->assertSame(['44'], $this->basicTable->getAppliedFilterWithValue('breed'));
-        $this->assertSame(['breed' => ['44']], $this->basicTable->getStoredFilterValues());
+        $this->assertSame(['breed' => ['4']], $this->basicTable->appliedFilters);
+        $this->assertSame(['4'], $this->basicTable->getAppliedFilterWithValue('breed'));
+        $this->assertSame(['breed' => ['4']], $this->basicTable->getStoredFilterValues());
 
     }
 

--- a/tests/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Traits/Visuals/FilterVisualsTest.php
@@ -152,7 +152,6 @@ final class FilterVisualsTest extends TestCase
                 'Cat',
                 '<br />',
                 'Dog',
-                '<br />',
             ])
             ->set('filterComponents.breed', [1, 2])
             ->assertSeeHtmlInOrder([


### PR DESCRIPTION
This change:
- Ensure that the getAppliedFilters only returns filters that have valid values
- Splits up the existing filter-pills blade to have three new child blades
  - "Item" (per applied filter)
    - Reset Filter Button (per applied filter)
  - Reset All Button

This also adjusts the class application for key elements in the above blades, in preparation for further improvement.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests and did you add any new tests needed for your feature?
2. [X] Did you update all templates (if applicable)?
3. [X] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [X] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?
