### PR TITLE
Fix checkbox in dark mode

### DIFF
--- a/resources/views/components/table/td/bulk-actions.blade.php
+++ b/resources/views/components/table/td/bulk-actions.blade.php
@@ -22,7 +22,7 @@
                 type="checkbox"
                 {{
                     $attributes->merge($bulkActionsTdCheckboxAttributes)->class([
-                        'rounded border-gray-300 text-indigo-600 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => ($theme === 'tailwind') && ($bulkActionsTdCheckboxAttributes['default'] ?? true),
+                        'text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:checked:bg-indigo-500 dark:border-gray-600' => ($theme === 'tailwind') && ($bulkActionsTdCheckboxAttributes['default'] ?? true),
                         'form-check-input' => ($theme === 'bootstrap-5') && ($bulkActionsTdCheckboxAttributes['default'] ?? true),
                     ])->except(['default','default-styling','default-colors'])
                 }}

--- a/resources/views/components/table/th/bulk-actions.blade.php
+++ b/resources/views/components/table/th/bulk-actions.blade.php
@@ -24,7 +24,7 @@
                 :checked="selectedItems.length == paginationTotalItemCount"
                 {{
                     $attributes->merge($bulkActionsThCheckboxAttributes)->class([
-                        'rounded border-gray-300 text-indigo-600 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => ($theme === 'tailwind') && ($bulkActionsThCheckboxAttributes['default'] ?? true),
+                        'text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:checked:bg-indigo-500 dark:border-gray-600' => ($theme === 'tailwind') && ($bulkActionsThCheckboxAttributes['default'] ?? true),
                         'form-check-input' => ($theme === 'bootstrap-5') && ($bulkActionsThCheckboxAttributes['default'] ?? true),
                     ])->except(['default','default-styling','default-colors'])
                 }}

--- a/resources/views/components/tools/filters/multi-select.blade.php
+++ b/resources/views/components/tools/filters/multi-select.blade.php
@@ -9,7 +9,7 @@
                     type="checkbox"
                     id="{{ $tableName }}-filter-{{ $filter->getKey() }}-select-all-@if($filter->hasCustomPosition()){{ $filter->getCustomPosition() }}@endif"
                     wire:input="selectAllFilterOptions('{{ $filter->getKey() }}')"
-                    class="text-indigo-600 rounded border-gray-300 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                    class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:checked:bg-indigo-500 dark:border-gray-600 disabled:opacity-50 disabled:cursor-wait"
                 >
                 <label for="{{ $tableName }}-filter-{{ $filter->getKey() }}-select-all-@if($filter->hasCustomPosition()){{ $filter->getCustomPosition() }}@endif" class="dark:text-white">
                 @if ($filter->getFirstOption() != "")
@@ -28,7 +28,7 @@
                         value="{{ $key }}"
                         wire:key="{{ $tableName }}-filter-{{ $filter->getKey() }}-{{ $loop->index }}-@if($filter->hasCustomPosition()){{ $filter->getCustomPosition() }}@endif"
                         {{ $filter->getWireMethod("filterComponents.".$filter->getKey()) }}
-                        class="text-indigo-600 rounded border-gray-300 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                        class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:checked:bg-indigo-500 dark:border-gray-600 disabled:opacity-50 disabled:cursor-wait"
                     >
                     <label for="{{ $tableName }}-filter-{{ $filter->getKey() }}-{{ $loop->index }}-@if($filter->hasCustomPosition()){{ $filter->getCustomPosition() }}@endif" class="dark:text-white">{{ $value }}</label>
                 </div>

--- a/resources/views/components/tools/toolbar/items/column-select.blade.php
+++ b/resources/views/components/tools/toolbar/items/column-select.blade.php
@@ -45,7 +45,7 @@
                             class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
                         >
                             <input
-                                class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                                class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:checked:bg-indigo-500 dark:border-gray-600 disabled:opacity-50 disabled:cursor-wait"
                                 wire:loading.attr="disabled" 
                                 type="checkbox"
                                 @checked($component->getSelectableSelectedColumns()->count() == $component->getSelectableColumns()->count())
@@ -65,7 +65,7 @@
                                 class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
                             >
                                 <input
-                                    class="text-indigo-600 rounded border-gray-300 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                                    class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:checked:bg-indigo-500 dark:border-gray-600 disabled:opacity-50 disabled:cursor-wait"
                                     wire:model.live="selectedColumns" wire:target="selectedColumns"
                                     wire:loading.attr="disabled" type="checkbox"
                                     value="{{ $columnSlug }}" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

The checkboxes do not work properly in dark mode with Tailwind. Resolves #1199 

Style testet with Chromium Version 129 and tailwindcss@3.4.14:

|  | Dark | Light |
|--------|--------|--------|
| Unchecked | ![Bildschirmfoto vom 2024-11-11 22-38-33](https://github.com/user-attachments/assets/e8114c2a-6cd8-4587-b947-0cdd0937cc90) | ![Bildschirmfoto vom 2024-11-11 22-39-30](https://github.com/user-attachments/assets/56e2a3b5-6272-4efe-99d8-6cf62660bc76) |
| Checked | ![Bildschirmfoto vom 2024-11-11 22-36-31](https://github.com/user-attachments/assets/e664cb1c-cdd1-4491-8bed-5e3711395b39) | ![Bildschirmfoto vom 2024-11-11 22-39-10](https://github.com/user-attachments/assets/8688ba00-f36e-4e2a-a325-4dc863e23945) |
| Unchecked focus | ![Bildschirmfoto vom 2024-11-11 22-38-51](https://github.com/user-attachments/assets/e820c22f-9a15-49bf-bde4-2612dfb5411e) | ![Bildschirmfoto vom 2024-11-11 22-39-43](https://github.com/user-attachments/assets/ca0835fc-27a7-46ec-b14d-084070da8d61) |
| Checked focus | ![Bildschirmfoto vom 2024-11-11 22-37-53](https://github.com/user-attachments/assets/51294284-5241-4341-8774-287702819165) | ![Bildschirmfoto vom 2024-11-11 22-39-24](https://github.com/user-attachments/assets/37477d62-d4e9-459c-9c67-922ad93e634d) |








