### PR TITLE
FixSetDefaultPerPage

### DIFF
--- a/src/Traits/Configuration/PaginationConfiguration.php
+++ b/src/Traits/Configuration/PaginationConfiguration.php
@@ -107,6 +107,13 @@ trait PaginationConfiguration
         return $this;
     }
 
+    public function unsetPerPage(): self
+    {
+        $this->perPage = null;
+
+        return $this;
+    }
+
     public function setPaginationMethod(string $paginationMethod): self
     {
         $this->paginationMethod = $paginationMethod;

--- a/src/Traits/Configuration/PaginationConfiguration.php
+++ b/src/Traits/Configuration/PaginationConfiguration.php
@@ -138,12 +138,10 @@ trait PaginationConfiguration
     /**
      * Set a default per-page value (if not set already by session or querystring)
      */
-    public function setDefaultPerPage(int $perPage): self
+    public function setDefaultPerPage(int $defaultPerPage): self
     {
-        $defaultPerPage = $perPage;
-
-        if ($this->perPage == 10) {
-            $this->setPerPage($perPage);
+        if (in_array((int) $defaultPerPage, $this->getPerPageAccepted())) {
+            $this->defaultPerPage = $defaultPerPage;
         }
 
         return $this;

--- a/src/Traits/Helpers/PaginationHelpers.php
+++ b/src/Traits/Helpers/PaginationHelpers.php
@@ -74,7 +74,7 @@ trait PaginationHelpers
 
     public function getDefaultPerPage(): int
     {
-        return $this->defaultPerPage ?? ($this->getPerPageAccepted()[0] ?? 10);
+        return (in_array((int) $this->defaultPerPage, $this->getPerPageAccepted()) ? $this->defaultPerPage : ($this->getPerPageAccepted()[0] ?? 10);
     }
 
     /**

--- a/src/Traits/Helpers/PaginationHelpers.php
+++ b/src/Traits/Helpers/PaginationHelpers.php
@@ -69,7 +69,12 @@ trait PaginationHelpers
 
     public function getPerPage(): int
     {
-        return $this->perPage;
+        return $this->perPage ?? $this->getDefaultPerPage();
+    }
+
+    public function getDefaultPerPage(): int
+    {
+        return $this->defaultPerPage ?? ($this->getPerPageAccepted()[0] ?? 10);
     }
 
     /**
@@ -128,7 +133,7 @@ trait PaginationHelpers
         if (in_array(session($this->getPerPagePaginationSessionKey(), $this->getPerPage()), $this->getPerPageAccepted(), true)) {
             $this->setPerPage(session($this->getPerPagePaginationSessionKey(), $this->getPerPage()));
         } else {
-            $this->setPerPage($this->getPerPageAccepted()[0] ?? 10);
+            $this->setPerPage($this->getDefaultPerPage());
         }
     }
 

--- a/src/Traits/Helpers/PaginationHelpers.php
+++ b/src/Traits/Helpers/PaginationHelpers.php
@@ -74,7 +74,7 @@ trait PaginationHelpers
 
     public function getDefaultPerPage(): int
     {
-        return (in_array((int) $this->defaultPerPage, $this->getPerPageAccepted()) ? $this->defaultPerPage : ($this->getPerPageAccepted()[0] ?? 10);
+        return (in_array((int) $this->defaultPerPage, $this->getPerPageAccepted()) ? $this->defaultPerPage : ($this->getPerPageAccepted()[0] ?? 10));
     }
 
     /**

--- a/src/Traits/Helpers/PaginationHelpers.php
+++ b/src/Traits/Helpers/PaginationHelpers.php
@@ -74,7 +74,7 @@ trait PaginationHelpers
 
     public function getDefaultPerPage(): int
     {
-        return (in_array((int) $this->defaultPerPage, $this->getPerPageAccepted()) ? $this->defaultPerPage : ($this->getPerPageAccepted()[0] ?? 10));
+        return in_array((int) $this->defaultPerPage, $this->getPerPageAccepted()) ? $this->defaultPerPage : ($this->getPerPageAccepted()[0] ?? 10);
     }
 
     /**

--- a/src/Traits/WithPagination.php
+++ b/src/Traits/WithPagination.php
@@ -15,7 +15,10 @@ trait WithPagination
 
     public ?string $pageName = null;
 
-    public int $perPage = 10;
+    public ?int $perPage;
+
+    #[Locked]
+    public int $defaultPerPage = 10;
 
     #[Locked]
     public array $perPageAccepted = [10, 25, 50];
@@ -57,9 +60,9 @@ trait WithPagination
 
     public function mountWithPagination(): void
     {
-        $sessionPerPage = session()->get($this->getPerPagePaginationSessionKey(), $this->getPerPageAccepted()[0] ?? 10);
+        $sessionPerPage = session()->get($this->getPerPagePaginationSessionKey(), $this->getPerPage());
         if (! in_array((int) $sessionPerPage, $this->getPerPageAccepted(), false)) {
-            $sessionPerPage = $this->getPerPageAccepted()[0] ?? 10;
+            $sessionPerPage = $this->getDefaultPerPage();
         }
         $this->setPerPage($sessionPerPage);
     }
@@ -68,7 +71,7 @@ trait WithPagination
     public function updatedPerPage(int|string $value): void
     {
         if (! in_array((int) $value, $this->getPerPageAccepted(), false)) {
-            $value = $this->getPerPageAccepted()[0] ?? 10;
+            $value = $this->getDefaultPerPage();
         }
 
         if (in_array(session($this->getPerPagePaginationSessionKey(), (int) $value), $this->getPerPageAccepted(), true)) {

--- a/tests/Unit/Traits/Configuration/PaginationConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/PaginationConfigurationTest.php
@@ -113,10 +113,12 @@ final class PaginationConfigurationTest extends TestCase
 
     public function test_can_set_default_per_page(): void
     {
-        $this->assertSame(10, $this->unpaginatedTable->getPerPage());
-        $this->unpaginatedTable->setDefaultPerPage(50);
-        $this->assertSame(50, $this->unpaginatedTable->getPerPage());
-        $this->unpaginatedTable->perPage = 25;
-        $this->assertSame(25, $this->unpaginatedTable->getPerPage());
+        $this->assertSame(10, $this->basicTable->getPerPage());
+        $this->basicTable->unsetPerPage();
+        $this->basicTable->setDefaultPerPage(50);
+        $this->assertSame(50, $this->basicTable->getDefaultPerPage());
+        $this->assertSame(50, $this->basicTable->getPerPage());
+        $this->basicTable->perPage = 25;
+        $this->assertSame(25, $this->basicTable->getPerPage());
     }
 }

--- a/tests/Unit/Traits/Configuration/PaginationConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/PaginationConfigurationTest.php
@@ -120,5 +120,11 @@ final class PaginationConfigurationTest extends TestCase
         $this->assertSame(50, $this->basicTable->getPerPage());
         $this->basicTable->perPage = 25;
         $this->assertSame(25, $this->basicTable->getPerPage());
+        $this->basicTable->setPerPage(10);
+        $this->assertSame(10, $this->basicTable->getPerPage());
+        $this->assertSame(50, $this->basicTable->getDefaultPerPage());
+        $this->basicTable->unsetPerPage();
+        $this->assertSame(50, $this->basicTable->getPerPage());
+
     }
 }


### PR DESCRIPTION
This tweak ensures that the setDefaultPerPage(x) is respected, if perPage has not already been set.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
