### PR TITLE
Columns() Setup Improvements

### DIFF
--- a/src/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Traits/Configuration/ColumnConfiguration.php
@@ -8,7 +8,10 @@ trait ColumnConfiguration
 {
     public function setPrependedColumns(array $prependedColumns): void
     {
-        $this->prependedColumns = collect($prependedColumns)
+        $this->prependedColumns = collect($prependedColumns);
+        $this->hasRunColumnSetup = false;
+        /*
+        
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
                 $column->setTheme($this->getTheme());
@@ -24,12 +27,15 @@ trait ColumnConfiguration
                 }
 
                 return $column;
-            });
+            });*/
     }
 
     public function setAppendedColumns(array $appendedColumns): void
     {
-        $this->appendedColumns = collect($appendedColumns)
+        $this->appendedColumns = collect($appendedColumns);
+        $this->hasRunColumnSetup = false;
+        /*
+        
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
                 $column->setTheme($this->getTheme());
@@ -45,7 +51,7 @@ trait ColumnConfiguration
                 }
 
                 return $column;
-            });
+            });*/
     }
 
     public function unsetCollapsedStatuses(): void

--- a/src/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Traits/Configuration/ColumnConfiguration.php
@@ -10,48 +10,12 @@ trait ColumnConfiguration
     {
         $this->prependedColumns = collect($prependedColumns);
         $this->hasRunColumnSetup = false;
-        /*
-
-            ->filter(fn ($column) => $column instanceof Column)
-            ->map(function (Column $column) {
-                $column->setTheme($this->getTheme());
-                $column->setHasTableRowUrl($this->hasTableRowUrl());
-                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
-
-                if ($column->hasField()) {
-                    if ($column->isBaseColumn()) {
-                        $column->setTable($this->getBuilder()->getModel()->getTable());
-                    } else {
-                        $column->setTable($this->getTableForColumn($column));
-                    }
-                }
-
-                return $column;
-            });*/
     }
 
     public function setAppendedColumns(array $appendedColumns): void
     {
         $this->appendedColumns = collect($appendedColumns);
         $this->hasRunColumnSetup = false;
-        /*
-
-            ->filter(fn ($column) => $column instanceof Column)
-            ->map(function (Column $column) {
-                $column->setTheme($this->getTheme());
-                $column->setHasTableRowUrl($this->hasTableRowUrl());
-                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
-
-                if ($column->hasField()) {
-                    if ($column->isBaseColumn()) {
-                        $column->setTable($this->getBuilder()->getModel()->getTable());
-                    } else {
-                        $column->setTable($this->getTableForColumn($column));
-                    }
-                }
-
-                return $column;
-            });*/
     }
 
     public function unsetCollapsedStatuses(): void

--- a/src/Traits/Configuration/ColumnConfiguration.php
+++ b/src/Traits/Configuration/ColumnConfiguration.php
@@ -11,7 +11,7 @@ trait ColumnConfiguration
         $this->prependedColumns = collect($prependedColumns);
         $this->hasRunColumnSetup = false;
         /*
-        
+
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
                 $column->setTheme($this->getTheme());
@@ -35,7 +35,7 @@ trait ColumnConfiguration
         $this->appendedColumns = collect($appendedColumns);
         $this->hasRunColumnSetup = false;
         /*
-        
+
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
                 $column->setTheme($this->getTheme());

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -16,38 +16,37 @@ trait ColumnHelpers
         $this->columns = collect($this->getPrependedColumns())->concat($this->columns())->concat(collect($this->getAppendedColumns()));
 
     }
-    
+
     protected function setupColumns(): void
     {
-        if(!$this->hasRunColumnSetup)
-        {
+        if (! $this->hasRunColumnSetup) {
             $this->columns = $this->columns
-            ->filter(fn ($column) => $column instanceof Column)
-            ->map(function (Column $column) {
-                $column->setTheme($this->getTheme())
-                ->setHasTableRowUrl($this->hasTableRowUrl())
-                ->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
+                ->filter(fn ($column) => $column instanceof Column)
+                ->map(function (Column $column) {
+                    $column->setTheme($this->getTheme())
+                        ->setHasTableRowUrl($this->hasTableRowUrl())
+                        ->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
 
-                if ($column instanceof AggregateColumn) {
-                    if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
-                        $this->addExtraWithCount($column->getDataSource());
-                    } elseif ($column->getAggregateMethod() == 'sum' && $column->hasDataSource() && $column->hasForeignColumn()) {
-                        $this->addExtraWithSum($column->getDataSource(), $column->getForeignColumn());
-                    } elseif ($column->getAggregateMethod() == 'avg' && $column->hasDataSource() && $column->hasForeignColumn()) {
-                        $this->addExtraWithAvg($column->getDataSource(), $column->getForeignColumn());
+                    if ($column instanceof AggregateColumn) {
+                        if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
+                            $this->addExtraWithCount($column->getDataSource());
+                        } elseif ($column->getAggregateMethod() == 'sum' && $column->hasDataSource() && $column->hasForeignColumn()) {
+                            $this->addExtraWithSum($column->getDataSource(), $column->getForeignColumn());
+                        } elseif ($column->getAggregateMethod() == 'avg' && $column->hasDataSource() && $column->hasForeignColumn()) {
+                            $this->addExtraWithAvg($column->getDataSource(), $column->getForeignColumn());
+                        }
                     }
-                }
 
-                if ($column->hasField()) {
-                    if ($column->isBaseColumn()) {
-                        $column->setTable($this->getBuilder()->getModel()->getTable());
-                    } else {
-                        $column->setTable($this->getTableForColumn($column));
+                    if ($column->hasField()) {
+                        if ($column->isBaseColumn()) {
+                            $column->setTable($this->getBuilder()->getModel()->getTable());
+                        } else {
+                            $column->setTable($this->getTableForColumn($column));
+                        }
                     }
-                }
 
-                return $column;
-            });
+                    return $column;
+                });
 
             $this->hasRunColumnSetup = true;
         }
@@ -55,10 +54,10 @@ trait ColumnHelpers
 
     public function getColumns(): Collection
     {
-        if(!$this->hasRunColumnSetup)
-        {
+        if (! $this->hasRunColumnSetup) {
             $this->setupColumns();
         }
+
         return $this->columns;
     }
 
@@ -248,31 +247,31 @@ trait ColumnHelpers
     public function getAppendedColumns(): Collection
     {
         return collect($this->appendedColumns ?? $this->appendColumns());
-            /*->filter(fn ($column) => $column instanceof Column)
-            ->map(function (Column $column) {
-                $column->setTheme($this->getTheme());
-                $column->setHasTableRowUrl($this->hasTableRowUrl());
-                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
-                if ($column instanceof AggregateColumn) {
-                    if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
-                        $this->addExtraWithCount($column->getDataSource());
-                    } elseif ($column->getAggregateMethod() == 'sum' && $column->hasDataSource() && $column->hasForeignColumn()) {
-                        $this->addExtraWithSum($column->getDataSource(), $column->getForeignColumn());
-                    } elseif ($column->getAggregateMethod() == 'avg' && $column->hasDataSource() && $column->hasForeignColumn()) {
-                        $this->addExtraWithAvg($column->getDataSource(), $column->getForeignColumn());
-                    }
+        /*->filter(fn ($column) => $column instanceof Column)
+        ->map(function (Column $column) {
+            $column->setTheme($this->getTheme());
+            $column->setHasTableRowUrl($this->hasTableRowUrl());
+            $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
+            if ($column instanceof AggregateColumn) {
+                if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
+                    $this->addExtraWithCount($column->getDataSource());
+                } elseif ($column->getAggregateMethod() == 'sum' && $column->hasDataSource() && $column->hasForeignColumn()) {
+                    $this->addExtraWithSum($column->getDataSource(), $column->getForeignColumn());
+                } elseif ($column->getAggregateMethod() == 'avg' && $column->hasDataSource() && $column->hasForeignColumn()) {
+                    $this->addExtraWithAvg($column->getDataSource(), $column->getForeignColumn());
                 }
+            }
 
-                if ($column->hasField()) {
-                    if ($column->isBaseColumn()) {
-                        $column->setTable($this->getBuilder()->getModel()->getTable());
-                    } else {
-                        $column->setTable($this->getTableForColumn($column));
-                    }
+            if ($column->hasField()) {
+                if ($column->isBaseColumn()) {
+                    $column->setTable($this->getBuilder()->getModel()->getTable());
+                } else {
+                    $column->setTable($this->getTableForColumn($column));
                 }
+            }
 
-                return $column;
-            });*/
+            return $column;
+        });*/
 
     }
 

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -244,7 +244,6 @@ trait ColumnHelpers
         return $this->shouldAlwaysCollapse;
     }
 
-    
     /**
      * Prepend columns.
      */

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -13,14 +13,21 @@ trait ColumnHelpers
      */
     public function setColumns(): void
     {
-        $this->prependedColumns = $this->getPrependedColumns();
+        $this->columns = collect($this->getPrependedColumns())->concat($this->columns())->concat(collect($this->getAppendedColumns()));
 
-        $columns = collect($this->columns())
+    }
+    
+    protected function setupColumns(): void
+    {
+        if(!$this->hasRunColumnSetup)
+        {
+            $this->columns = $this->columns
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
-                $column->setTheme($this->getTheme());
-                $column->setHasTableRowUrl($this->hasTableRowUrl());
-                $column->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
+                $column->setTheme($this->getTheme())
+                ->setHasTableRowUrl($this->hasTableRowUrl())
+                ->setIsReorderColumn($this->getDefaultReorderColumn() == $column->getField());
+
                 if ($column instanceof AggregateColumn) {
                     if ($column->getAggregateMethod() == 'count' && $column->hasDataSource()) {
                         $this->addExtraWithCount($column->getDataSource());
@@ -42,13 +49,16 @@ trait ColumnHelpers
                 return $column;
             });
 
-        $this->appendedColumns = $this->getAppendedColumns();
-
-        $this->columns = collect([...$this->prependedColumns, ...$columns, ...$this->appendedColumns]);
+            $this->hasRunColumnSetup = true;
+        }
     }
 
     public function getColumns(): Collection
     {
+        if(!$this->hasRunColumnSetup)
+        {
+            $this->setupColumns();
+        }
         return $this->columns;
     }
 
@@ -206,7 +216,8 @@ trait ColumnHelpers
 
     public function getPrependedColumns(): Collection
     {
-        return collect($this->prependedColumns ?? $this->prependColumns())
+        return collect($this->prependedColumns ?? $this->prependColumns());
+        /*return collect($this->prependedColumns ?? $this->prependColumns())
             ->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
                 $column->setTheme($this->getTheme());
@@ -231,13 +242,13 @@ trait ColumnHelpers
                 }
 
                 return $column;
-            });
+            });*/
     }
 
     public function getAppendedColumns(): Collection
     {
-        return collect($this->appendedColumns ?? $this->appendColumns())
-            ->filter(fn ($column) => $column instanceof Column)
+        return collect($this->appendedColumns ?? $this->appendColumns());
+            /*->filter(fn ($column) => $column instanceof Column)
             ->map(function (Column $column) {
                 $column->setTheme($this->getTheme());
                 $column->setHasTableRowUrl($this->hasTableRowUrl());
@@ -261,7 +272,7 @@ trait ColumnHelpers
                 }
 
                 return $column;
-            });
+            });*/
 
     }
 

--- a/src/Traits/WithColumns.php
+++ b/src/Traits/WithColumns.php
@@ -15,9 +15,9 @@ trait WithColumns
 
     protected Collection $columns;
 
-    protected Collection $prependedColumns;
+    protected ?Collection $prependedColumns;
 
-    protected Collection $appendedColumns;
+    protected ?Collection $appendedColumns;
 
     protected ?bool $shouldAlwaysCollapse;
 
@@ -57,21 +57,6 @@ trait WithColumns
      */
     abstract public function columns(): array;
 
-    /**
-     * Prepend columns.
-     */
-    public function prependColumns(): array
-    {
-        return [];
-    }
-
-    /**
-     * Append columns.
-     */
-    public function appendColumns(): array
-    {
-        return [];
-    }
 
     /**
      * Add Columns to View

--- a/src/Traits/WithColumns.php
+++ b/src/Traits/WithColumns.php
@@ -57,7 +57,6 @@ trait WithColumns
      */
     abstract public function columns(): array;
 
-
     /**
      * Add Columns to View
      */

--- a/src/Traits/WithColumns.php
+++ b/src/Traits/WithColumns.php
@@ -25,6 +25,8 @@ trait WithColumns
 
     protected ?bool $shouldTabletCollapse;
 
+    protected bool $hasRunColumnSetup = false;
+
     /**
      * Sets up Columns
      */
@@ -39,7 +41,7 @@ trait WithColumns
 
         // Set Columns
         $this->setColumns();
-
+        
         // Fire Lifecycle Hooks for columnsSet
         $this->callHook('columnsSet');
         $this->callTraitHook('columnsSet');

--- a/src/Traits/WithColumns.php
+++ b/src/Traits/WithColumns.php
@@ -41,7 +41,7 @@ trait WithColumns
 
         // Set Columns
         $this->setColumns();
-        
+
         // Fire Lifecycle Hooks for columnsSet
         $this->callHook('columnsSet');
         $this->callTraitHook('columnsSet');


### PR DESCRIPTION
A basic improvement so that:

A new protected boolean:
- $hasRunColumnSetup = false

On boot:
- $columns Collection is created:
  - prependedColumns
  - columns()
  - appendedColumns

When attempting to getColumns(), validate whether $hasRunColumnSetup
If it has not run, validate/filter the Columns, and add the relevant fields/withs to the $builder

This change:
- reduces the number of times that the logic checking different Column sources has to run
- removes the requirement for builder to be instantiated before the WithColumns trait boots.
- simplifies some future changes to improve the data flow

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
