### PR TITLE
Add setFilterPopoverAttributes

### DIFF
--- a/docs/filters/available-methods.md
+++ b/docs/filters/available-methods.md
@@ -206,6 +206,30 @@ public function configure(): void
 }
 ```
 
+### setFilterPopoverAttributes
+
+Allows for the customisation of the appearance of the Filter Popover Menu.
+
+Note the addition of a "default-width" boolean, allowing you to customise the width more smoothly without impacting other applied classes.
+
+You may also replace default colors by setting "default-colors" to false, or default styling by setting "default-styling" to false, and specifying replacement classes in the "class" property.
+
+You can also replace the default transition behaviours (Tailwind) by specifying replacement attributes in the array.
+
+```php
+public function configure(): void
+{
+    $this->setFilterPopoverAttributes(
+        [
+        'class' => 'w-96',
+        'default-width' => false,
+        'default-colors' => true,
+        'default-styling' => true, 
+        'x-transition:enter' => 'transition ease-out duration-100',
+        ]
+    );
+}
+```
 
 ----
 

--- a/resources/views/components/tools/toolbar/items/filter-popover.blade.php
+++ b/resources/views/components/tools/toolbar/items/filter-popover.blade.php
@@ -1,66 +1,51 @@
-@aware([ 'tableName','isBootstrap','isBootstrap4','isBootstrap5'])
+@aware(['tableName'])
 @if($this->isBootstrap)
-    <ul
-        x-cloak
-        @class([
-            'dropdown-menu w-100 mt-md-5' => $this->isBootstrap4,
-            'dropdown-menu w-100' => $this->isBootstrap5,
-        ])
-        x-bind:class="{ 'show': filterPopoverOpen }"
-        role="menu"
-    >
+    <ul x-cloak {{ $attributes
+            ->merge($this->getFilterPopoverAttributes)
+            ->merge(['role' => 'menu'])
+            ->class([
+                'w-100' => $this->getFilterPopoverAttributes['default-width'] ?? true,
+                'dropdown-menu mt-md-5' => $this->isBootstrap4,
+                'dropdown-menu' => $this->isBootstrap5,
+            ]) }} x-bind:class="{ 'show': filterPopoverOpen }">
         @foreach ($this->getVisibleFilters() as $filter)
-            <div
-                wire:key="{{ $tableName }}-filter-{{ $filter->getKey() }}-toolbar"
-                @class([
-                    'p-2' => $this->isBootstrap,
-                ])
-                id="{{ $tableName }}-filter-{{ $filter->getKey() }}-wrapper"
-            >
+            <div id="{{ $tableName }}-filter-{{ $filter->getKey() }}-wrapper" wire:key="{{ $tableName }}-filter-{{ $filter->getKey() }}-toolbar" class="p-2">
                 {{ $filter->setGenericDisplayData($this->getFilterGenericData)->render() }}
             </div>
         @endforeach
 
         @if ($this->hasAppliedVisibleFiltersWithValuesThatCanBeCleared())
-            <div
-                @class([
-                    'dropdown-divider' => $this->isBootstrap,
-                ])
-            >
-            </div>
-
-            <button
-                wire:click.prevent="setFilterDefaults" x-on:click="filterPopoverOpen = false"
-                @class([
-                    'dropdown-item btn text-center' => $this->isBootstrap4,
-                    'dropdown-item text-center' => $this->isBootstrap5,
-                ])
-            >
-                {{ __($this->getLocalisationPath.'Clear') }}
-            </button>
+            <div class='dropdown-divider'></div>
+            <x-livewire-tables::tools.toolbar.items.filter-popover.clear-button />
         @endif
     </ul>
 @else
-    <div
-        x-cloak x-show="filterPopoverOpen"
-        x-transition:enter="transition ease-out duration-100"
-        x-transition:enter-start="transform opacity-0 scale-95"
-        x-transition:enter-end="transform opacity-100 scale-100"
-        x-transition:leave="transition ease-in duration-75"
-        x-transition:leave-start="transform opacity-100 scale-100"
-        x-transition:leave-end="transform opacity-0 scale-95"
-        class="origin-top-left absolute left-0 mt-2 w-full md:w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 focus:outline-none z-50 dark:bg-gray-700 dark:text-white dark:divide-gray-600"
-        role="menu"
-        aria-orientation="vertical"
-        aria-labelledby="filters-menu"
-    >
+    <div x-cloak x-show="filterPopoverOpen"
+        {{ 
+            $attributes
+            ->merge($this->getFilterPopoverAttributes)
+            ->merge([
+                'role' => 'menu',
+                'aria-orientation' => 'vertical',
+                'aria-labelledby' => 'filters-menu',
+                'x-transition:enter' => 'transition ease-out duration-100',
+                'x-transition:enter-start' => 'transform opacity-0 scale-95',
+                'x-transition:enter-end' => 'transform opacity-100 scale-100',
+                'x-transition:leave' => 'transition ease-in duration-75',
+                'x-transition:leave-start' => 'transform opacity-100 scale-100',
+                'x-transition:leave-end' => 'transform opacity-0 scale-95',
+            ])
+            ->class([
+                'w-full md:w-56' => $this->getFilterPopoverAttributes['default-width'] ?? true,
+                'origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50' => $this->getFilterPopoverAttributes['default-styling'] ?? true,
+                'bg-white divide-gray-100 ring-black dark:bg-gray-700 dark:text-white dark:divide-gray-600' => $this->getFilterPopoverAttributes['default-colors'] ?? true,
+            ])
+            ->except(['x-cloak', 'x-show', 'default','default-width', 'default-styling','default-colors']) 
+        }}>
+
         @foreach ($this->getVisibleFilters() as $filter)
             <div class="py-1" role="none">
-                <div
-                    class="block px-4 py-2 text-sm text-gray-700 space-y-1"
-                    role="menuitem"
-                    id="{{ $tableName }}-filter-{{ $filter->getKey() }}-wrapper"
-                >
+                <div id="{{ $tableName }}-filter-{{ $filter->getKey() }}-wrapper" wire:key="{{ $tableName }}-filter-{{ $filter->getKey() }}-toolbar" class="block px-4 py-2 text-sm text-gray-700 space-y-1" role="menuitem">
                     {{ $filter->setGenericDisplayData($this->getFilterGenericData)->render() }}
                 </div>
             </div>
@@ -68,14 +53,7 @@
 
         @if ($this->hasAppliedVisibleFiltersWithValuesThatCanBeCleared())
             <div class="block px-4 py-3 text-sm text-gray-700 dark:text-white" role="menuitem">
-                <button
-                    x-on:click="filterPopoverOpen = false"
-                    wire:click.prevent="setFilterDefaults"
-                    type="button"
-                    class="w-full inline-flex items-center justify-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-800 dark:border-gray-600 dark:text-white dark:hover:border-gray-500 dark:hover:bg-gray-600"
-                >
-                    {{ __($this->getLocalisationPath.'Clear') }}
-                </button>
+                <x-livewire-tables::tools.toolbar.items.filter-popover.clear-button />
             </div>
         @endif
     </div>

--- a/resources/views/components/tools/toolbar/items/filter-popover/clear-button.blade.php
+++ b/resources/views/components/tools/toolbar/items/filter-popover/clear-button.blade.php
@@ -1,0 +1,7 @@
+<button type="button" wire:click.prevent="setFilterDefaults" x-on:click="filterPopoverOpen = false" @class([
+        'w-full inline-flex items-center justify-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-800 dark:border-gray-600 dark:text-white dark:hover:border-gray-500 dark:hover:bg-gray-600' => $this->isTailwind,
+        'dropdown-item btn text-center' => $this->isBootstrap4,
+        'dropdown-item text-center' => $this->isBootstrap5,
+    ])>
+    {{ __($this->getLocalisationPath.'Clear') }}
+</button>

--- a/src/Traits/Configuration/FilterConfiguration.php
+++ b/src/Traits/Configuration/FilterConfiguration.php
@@ -69,7 +69,6 @@ trait FilterConfiguration
         return $this;
     }
 
-
     public function generateFilterGenericData(): array
     {
         return (new FilterGenericData($this->getTableName(), $this->getFilterLayout(), $this->isTailwind(), $this->isBootstrap4(), $this->isBootstrap5()))->toArray();

--- a/src/Traits/Configuration/FilterConfiguration.php
+++ b/src/Traits/Configuration/FilterConfiguration.php
@@ -3,7 +3,6 @@
 namespace Rappasoft\LaravelLivewireTables\Traits\Configuration;
 
 use Rappasoft\LaravelLivewireTables\DataTransferObjects\FilterGenericData;
-use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 
 trait FilterConfiguration
 {
@@ -70,51 +69,6 @@ trait FilterConfiguration
         return $this;
     }
 
-    public function setFilterLayout(string $type): self
-    {
-        if (! in_array($type, ['popover', 'slide-down'], true)) {
-            throw new DataTableConfigurationException('Invalid filter layout type');
-        }
-
-        $this->filterLayout = $type;
-
-        return $this;
-    }
-
-    public function setFilterLayoutPopover(): self
-    {
-        $this->setFilterLayout('popover');
-
-        return $this;
-    }
-
-    public function setFilterLayoutSlideDown(): self
-    {
-        $this->setFilterLayout('slide-down');
-
-        return $this;
-    }
-
-    public function setFilterSlideDownDefaultStatus(bool $status): self
-    {
-        $this->filterSlideDownDefaultVisible = $status;
-
-        return $this;
-    }
-
-    public function setFilterSlideDownDefaultStatusDisabled(): self
-    {
-        $this->setFilterSlideDownDefaultStatus(false);
-
-        return $this;
-    }
-
-    public function setFilterSlideDownDefaultStatusEnabled(): self
-    {
-        $this->setFilterSlideDownDefaultStatus(true);
-
-        return $this;
-    }
 
     public function generateFilterGenericData(): array
     {

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -63,21 +63,6 @@ trait FilterHelpers
         return $this->getFiltersVisibilityStatus() === false;
     }
 
-    public function getFilterSlideDownDefaultStatus(): bool
-    {
-        return $this->filterSlideDownDefaultVisible;
-    }
-
-    public function filtersSlideDownIsDefaultVisible(): bool
-    {
-        return $this->getFilterSlideDownDefaultStatus() === true;
-    }
-
-    public function filtersSlideDownIsDefaultHidden(): bool
-    {
-        return $this->getFilterSlideDownDefaultStatus() === false;
-    }
-
     public function getFilterPillsStatus(): bool
     {
         return $this->filterPillsStatus;
@@ -273,31 +258,6 @@ trait FilterHelpers
 
     }
 
-    public function getFilterLayout(): string
-    {
-        return $this->filterLayout;
-    }
-
-    public function isFilterLayoutPopover(): bool
-    {
-        return $this->getFilterLayout() === 'popover';
-    }
-
-    public function isFilterLayoutSlideDown(): bool
-    {
-        return $this->getFilterLayout() === 'slide-down';
-    }
-
-    /**
-     * Get whether any filter has a configured slide down row.
-     */
-    public function hasFiltersWithSlidedownRows(): bool
-    {
-        return $this->getFilters()
-            ->reject(fn (Filter $filter) => ! $filter->hasFilterSlidedownRow())
-            ->count() > 0;
-    }
-
     /**
      * Get whether filter has a configured slide down row.
      */
@@ -306,37 +266,6 @@ trait FilterHelpers
         return $this->getFilters()->reject(fn (Filter $filter) => $filter->isHiddenFromMenus());
     }
 
-    /**
-     * Get filters sorted by row
-     *
-     * @return array<mixed>
-     */
-    public function getFiltersByRow(): array
-    {
-        $orderedFilters = [];
-        $filterList = ($this->hasFiltersWithSlidedownRows()) ? $this->getVisibleFilters()->sortBy('filterSlidedownRow') : $this->getVisibleFilters();
-        if ($this->hasFiltersWithSlidedownRows()) {
-            foreach ($filterList as $filter) {
-                $orderedFilters[(string) $filter->getFilterSlidedownRow()][] = $filter;
-            }
-
-            if (empty($orderedFilters['1'])) {
-                $orderedFilters['1'] = (isset($orderedFilters['99']) ? $orderedFilters['99'] : []);
-                if (isset($orderedFilters['99'])) {
-                    unset($orderedFilters['99']);
-                }
-            }
-        } else {
-            $orderedFilters = Arr::wrap($filterList);
-            $orderedFilters['1'] = $orderedFilters['0'] ?? [];
-            if (isset($orderedFilters['0'])) {
-                unset($orderedFilters['0']);
-            }
-        }
-        ksort($orderedFilters);
-
-        return $orderedFilters;
-    }
 
     public function hasFilterGenericData(): bool
     {

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -266,7 +266,6 @@ trait FilterHelpers
         return $this->getFilters()->reject(fn (Filter $filter) => $filter->isHiddenFromMenus());
     }
 
-
     public function hasFilterGenericData(): bool
     {
         return ! empty($this->filterGenericData);

--- a/src/Traits/Styling/Configuration/FilterMenuStylingConfiguration.php
+++ b/src/Traits/Styling/Configuration/FilterMenuStylingConfiguration.php
@@ -61,5 +61,4 @@ trait FilterMenuStylingConfiguration
 
         return $this;
     }
-
 }

--- a/src/Traits/Styling/Configuration/FilterMenuStylingConfiguration.php
+++ b/src/Traits/Styling/Configuration/FilterMenuStylingConfiguration.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Configuration;
+
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
+
+trait FilterMenuStylingConfiguration
+{
+    /**
+     * Used to set attributes for the Filter Popover
+     */
+    public function setFilterPopoverAttributes(array $filterPopoverAttributes): self
+    {
+        $this->filterPopoverAttributes = array_merge($this->filterPopoverAttributes, $filterPopoverAttributes);
+
+        return $this;
+    }
+
+    public function setFilterLayout(string $type): self
+    {
+        if (! in_array($type, ['popover', 'slide-down'], true)) {
+            throw new DataTableConfigurationException('Invalid filter layout type');
+        }
+
+        $this->filterLayout = $type;
+
+        return $this;
+    }
+
+    public function setFilterLayoutPopover(): self
+    {
+        $this->setFilterLayout('popover');
+
+        return $this;
+    }
+
+    public function setFilterLayoutSlideDown(): self
+    {
+        $this->setFilterLayout('slide-down');
+
+        return $this;
+    }
+
+    public function setFilterSlideDownDefaultStatus(bool $status): self
+    {
+        $this->filterSlideDownDefaultVisible = $status;
+
+        return $this;
+    }
+
+    public function setFilterSlideDownDefaultStatusDisabled(): self
+    {
+        $this->setFilterSlideDownDefaultStatus(false);
+
+        return $this;
+    }
+
+    public function setFilterSlideDownDefaultStatusEnabled(): self
+    {
+        $this->setFilterSlideDownDefaultStatus(true);
+
+        return $this;
+    }
+
+}

--- a/src/Traits/Styling/HasFilterMenuStyling.php
+++ b/src/Traits/Styling/HasFilterMenuStyling.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Styling;
+
+use Livewire\Attributes\Locked;
+use Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers\FilterMenuStylingHelpers;
+use Rappasoft\LaravelLivewireTables\Traits\Styling\Configuration\FilterMenuStylingConfiguration;
+
+trait HasFilterMenuStyling
+{
+    use FilterMenuStylingConfiguration,
+    FilterMenuStylingHelpers;
+
+    #[Locked]
+    public string $filterLayout = 'popover';
+
+    // Entangled in JS
+    public bool $filterSlideDownDefaultVisible = false;
+
+    protected array $filterPopoverAttributes = ['class' => '', 'default-width' => true, 'default-colors' => true, 'default-styling' => true];
+
+
+
+
+}

--- a/src/Traits/Styling/HasFilterMenuStyling.php
+++ b/src/Traits/Styling/HasFilterMenuStyling.php
@@ -3,13 +3,13 @@
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling;
 
 use Livewire\Attributes\Locked;
-use Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers\FilterMenuStylingHelpers;
 use Rappasoft\LaravelLivewireTables\Traits\Styling\Configuration\FilterMenuStylingConfiguration;
+use Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers\FilterMenuStylingHelpers;
 
 trait HasFilterMenuStyling
 {
     use FilterMenuStylingConfiguration,
-    FilterMenuStylingHelpers;
+        FilterMenuStylingHelpers;
 
     #[Locked]
     public string $filterLayout = 'popover';
@@ -18,8 +18,4 @@ trait HasFilterMenuStyling
     public bool $filterSlideDownDefaultVisible = false;
 
     protected array $filterPopoverAttributes = ['class' => '', 'default-width' => true, 'default-colors' => true, 'default-styling' => true];
-
-
-
-
 }

--- a/src/Traits/Styling/Helpers/FilterMenuStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/FilterMenuStylingHelpers.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
+
+use Livewire\Attributes\Computed;
+
+trait FilterMenuStylingHelpers
+{
+    /**
+     * Used to get attributes for the Filter Popover
+     *
+     * @return array<mixed>
+     */
+    #[Computed]
+    public function getFilterPopoverAttributes(): array
+    {
+        return $this->filterPopoverAttributes;
+
+    }
+
+    public function getFilterSlideDownDefaultStatus(): bool
+    {
+        return $this->filterSlideDownDefaultVisible;
+    }
+
+    public function filtersSlideDownIsDefaultVisible(): bool
+    {
+        return $this->getFilterSlideDownDefaultStatus() === true;
+    }
+
+    public function filtersSlideDownIsDefaultHidden(): bool
+    {
+        return $this->getFilterSlideDownDefaultStatus() === false;
+    }
+
+    public function getFilterLayout(): string
+    {
+        return $this->filterLayout;
+    }
+
+    public function isFilterLayoutPopover(): bool
+    {
+        return $this->getFilterLayout() === 'popover';
+    }
+
+    public function isFilterLayoutSlideDown(): bool
+    {
+        return $this->getFilterLayout() === 'slide-down';
+    }
+
+    
+    /**
+     * Get whether any filter has a configured slide down row.
+     */
+    public function hasFiltersWithSlidedownRows(): bool
+    {
+        return $this->getFilters()
+            ->reject(fn (Filter $filter) => ! $filter->hasFilterSlidedownRow())
+            ->count() > 0;
+    }
+
+    /**
+     * Get filters sorted by row
+     *
+     * @return array<mixed>
+     */
+    public function getFiltersByRow(): array
+    {
+        $orderedFilters = [];
+        $filterList = ($this->hasFiltersWithSlidedownRows()) ? $this->getVisibleFilters()->sortBy('filterSlidedownRow') : $this->getVisibleFilters();
+        if ($this->hasFiltersWithSlidedownRows()) {
+            foreach ($filterList as $filter) {
+                $orderedFilters[(string) $filter->getFilterSlidedownRow()][] = $filter;
+            }
+
+            if (empty($orderedFilters['1'])) {
+                $orderedFilters['1'] = (isset($orderedFilters['99']) ? $orderedFilters['99'] : []);
+                if (isset($orderedFilters['99'])) {
+                    unset($orderedFilters['99']);
+                }
+            }
+        } else {
+            $orderedFilters = Arr::wrap($filterList);
+            $orderedFilters['1'] = $orderedFilters['0'] ?? [];
+            if (isset($orderedFilters['0'])) {
+                unset($orderedFilters['0']);
+            }
+        }
+        ksort($orderedFilters);
+
+        return $orderedFilters;
+    }
+
+}

--- a/src/Traits/Styling/Helpers/FilterMenuStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/FilterMenuStylingHelpers.php
@@ -48,7 +48,6 @@ trait FilterMenuStylingHelpers
         return $this->getFilterLayout() === 'slide-down';
     }
 
-    
     /**
      * Get whether any filter has a configured slide down row.
      */
@@ -90,5 +89,4 @@ trait FilterMenuStylingHelpers
 
         return $orderedFilters;
     }
-
 }

--- a/src/Traits/Styling/Helpers/FilterMenuStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/FilterMenuStylingHelpers.php
@@ -2,7 +2,9 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
 
+use Illuminate\Support\Arr;
 use Livewire\Attributes\Computed;
+use Rappasoft\LaravelLivewireTables\Views\Filter;
 
 trait FilterMenuStylingHelpers
 {

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -17,7 +17,7 @@ trait WithFilters
         FilterHelpers;
     use HasQueryStringForFilter;
     use HasFilterMenuStyling;
-    
+
     #[Locked]
     public bool $filtersStatus = true;
 

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -9,13 +9,15 @@ use Rappasoft\LaravelLivewireTables\Events\FilterApplied;
 use Rappasoft\LaravelLivewireTables\Traits\Configuration\FilterConfiguration;
 use Rappasoft\LaravelLivewireTables\Traits\Core\QueryStrings\HasQueryStringForFilter;
 use Rappasoft\LaravelLivewireTables\Traits\Helpers\FilterHelpers;
+use Rappasoft\LaravelLivewireTables\Traits\Styling\HasFilterMenuStyling;
 
 trait WithFilters
 {
     use FilterConfiguration,
         FilterHelpers;
     use HasQueryStringForFilter;
-
+    use HasFilterMenuStyling;
+    
     #[Locked]
     public bool $filtersStatus = true;
 
@@ -24,12 +26,6 @@ trait WithFilters
 
     #[Locked]
     public bool $filterPillsStatus = true;
-
-    // Entangled in JS
-    public bool $filterSlideDownDefaultVisible = false;
-
-    #[Locked]
-    public string $filterLayout = 'popover';
 
     #[Locked]
     public int $filterCount;

--- a/tests/Unit/Traits/Styling/FilterPopoverStylingTest.php
+++ b/tests/Unit/Traits/Styling/FilterPopoverStylingTest.php
@@ -6,7 +6,6 @@ use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 final class FilterPopoverStylingTest extends TestCase
 {
-
     public function test_filter_popover_attributes_returns_default_if_not_set(): void
     {
         $this->assertSame(['class' => '', 'default-width' => true, 'default-colors' => true, 'default-styling' => true], $this->basicTable->getFilterPopoverAttributes());
@@ -25,7 +24,4 @@ final class FilterPopoverStylingTest extends TestCase
         $this->assertSame(['class' => 'bg-red-500', 'default-width' => true, 'default-colors' => false, 'default-styling' => true], $this->basicTable->getFilterPopoverAttributes());
 
     }
-
-
-
 }

--- a/tests/Unit/Traits/Styling/FilterPopoverStylingTest.php
+++ b/tests/Unit/Traits/Styling/FilterPopoverStylingTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Traits\Styling;
+
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+final class FilterPopoverStylingTest extends TestCase
+{
+
+    public function test_filter_popover_attributes_returns_default_if_not_set(): void
+    {
+        $this->assertSame(['class' => '', 'default-width' => true, 'default-colors' => true, 'default-styling' => true], $this->basicTable->getFilterPopoverAttributes());
+    }
+
+    public function test_filter_popover_attributes_can_be_changed(): void
+    {
+        $this->assertSame(['class' => '', 'default-width' => true, 'default-colors' => true, 'default-styling' => true], $this->basicTable->getFilterPopoverAttributes());
+
+        $this->basicTable->setFilterPopoverAttributes(['class' => 'bg-blue-500']);
+
+        $this->assertSame(['class' => 'bg-blue-500', 'default-width' => true, 'default-colors' => true, 'default-styling' => true], $this->basicTable->getFilterPopoverAttributes());
+
+        $this->basicTable->setFilterPopoverAttributes(['class' => 'bg-red-500', 'default-colors' => false]);
+
+        $this->assertSame(['class' => 'bg-red-500', 'default-width' => true, 'default-colors' => false, 'default-styling' => true], $this->basicTable->getFilterPopoverAttributes());
+
+    }
+
+
+
+}

--- a/tests/Unit/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Unit/Traits/Visuals/FilterVisualsTest.php
@@ -161,6 +161,67 @@ final class FilterVisualsTest extends TestCase
             ]);
     }
 
+    public function test_filters_popover_menu_is_customisable(): void
+    {
+        Livewire::test(new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+
+        
+            }
+
+            public function filters(): array
+            {
+                return [
+                    \Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectFilter::make('Breed')
+                        ->options(
+                            \Rappasoft\LaravelLivewireTables\Tests\Models\Breed::query()
+                                ->orderBy('name')
+                                ->get()
+                                ->keyBy('id')
+                                ->map(fn ($breed) => $breed->name)
+                                ->toArray()
+                        )
+                        ->filter(function (\Illuminate\Database\Eloquent\Builder $builder, array $values) {
+                            return $builder->whereIn('pets.breed_id', $values);
+                        }),
+                    \Rappasoft\LaravelLivewireTables\Views\Filters\MultiSelectDropdownFilter::make('Species')
+                        ->options(
+                            \Rappasoft\LaravelLivewireTables\Tests\Models\Species::query()
+                                ->orderBy('name')
+                                ->get()
+                                ->keyBy('id')
+                                ->map(fn ($species) => $species->name)
+                                ->toArray()
+                        )
+                        ->filter(function (\Illuminate\Database\Eloquent\Builder $builder, array $values) {
+                            return $builder->whereIn('pets.species_id', $values);
+                        })
+                        ->setPillsSeparator('<br />'),
+
+                    \Rappasoft\LaravelLivewireTables\Views\Filters\TextFilter::make('Pet Name', 'pet_name_filter')
+                        ->filter(function (\Illuminate\Database\Eloquent\Builder $builder, string $value) {
+                            return $builder->where('pets.name', '=', $value);
+                        }),
+                ];
+            }
+        })
+        ->assertSeeHtmlInOrder([
+            'class="w-full md:w-56 origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 bg-white divide-gray-100 ring-black dark:bg-gray-700 dark:text-white dark:divide-gray-600"',
+        ])
+        ->call('setFilterPopoverAttributes', ['class' => 'w-96', 'default-width' => false])
+        ->assertSeeHtmlInOrder([
+            'class="origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 bg-white divide-gray-100 ring-black dark:bg-gray-700 dark:text-white dark:divide-gray-600 w-96"',
+        ])
+        ->call('setFilterPopoverAttributes', ['class' => 'w-96', 'default-width' => false, 'default-colors' => false])
+        ->assertSeeHtmlInOrder([
+            'class="origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 w-96"',
+        ]);
+
+    }
+
     /*public function test_filter_events_apply_correctly(): void
     {
         Livewire::test(PetsTable::class)

--- a/tests/Unit/Traits/Visuals/FilterVisualsTest.php
+++ b/tests/Unit/Traits/Visuals/FilterVisualsTest.php
@@ -169,7 +169,6 @@ final class FilterVisualsTest extends TestCase
             {
                 $this->setPrimaryKey('id');
 
-        
             }
 
             public function filters(): array
@@ -208,17 +207,17 @@ final class FilterVisualsTest extends TestCase
                 ];
             }
         })
-        ->assertSeeHtmlInOrder([
-            'class="w-full md:w-56 origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 bg-white divide-gray-100 ring-black dark:bg-gray-700 dark:text-white dark:divide-gray-600"',
-        ])
-        ->call('setFilterPopoverAttributes', ['class' => 'w-96', 'default-width' => false])
-        ->assertSeeHtmlInOrder([
-            'class="origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 bg-white divide-gray-100 ring-black dark:bg-gray-700 dark:text-white dark:divide-gray-600 w-96"',
-        ])
-        ->call('setFilterPopoverAttributes', ['class' => 'w-96', 'default-width' => false, 'default-colors' => false])
-        ->assertSeeHtmlInOrder([
-            'class="origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 w-96"',
-        ]);
+            ->assertSeeHtmlInOrder([
+                'class="w-full md:w-56 origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 bg-white divide-gray-100 ring-black dark:bg-gray-700 dark:text-white dark:divide-gray-600"',
+            ])
+            ->call('setFilterPopoverAttributes', ['class' => 'w-96', 'default-width' => false])
+            ->assertSeeHtmlInOrder([
+                'class="origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 bg-white divide-gray-100 ring-black dark:bg-gray-700 dark:text-white dark:divide-gray-600 w-96"',
+            ])
+            ->call('setFilterPopoverAttributes', ['class' => 'w-96', 'default-width' => false, 'default-colors' => false])
+            ->assertSeeHtmlInOrder([
+                'class="origin-top-left absolute left-0 mt-2 rounded-md shadow-lg ring-1 ring-opacity-5 divide-y focus:outline-none z-50 w-96"',
+            ]);
 
     }
 


### PR DESCRIPTION
This PR adds one new feature, creates one additional blade, and tidies up existing blade

### Blade Clean-Up - Filter Pop-Over
Created an additional component blade for the "clear filters" button used in the popover menu, to minimise code duplication

### Adds a new "setFilterPopoverAttributes" feature
Allows for the customisation of the appearance of the Filter Popover Menu.

Note the addition of a "default-width" boolean, allowing you to customise the width more smoothly without impacting other applied classes.

You may also replace default colors by setting "default-colors" to false, or default styling by setting "default-styling" to false, and specifying replacement classes in the "class" property.

You can also replace the default transition behaviours (Tailwind) by specifying replacement attributes in the array.

```php
public function configure(): void
{
    $this->setFilterPopoverAttributes(
        [
        'class' => 'w-96',
        'default-width' => false,
        'default-colors' => true,
        'default-styling' => true, 
        'x-transition:enter' => 'transition ease-out duration-100',
        ]
    );
}
```


### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
4. [ ] Did you update all templates (if applicable)?
5. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
6. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
