### PR TITLE
Set bulk action row button attributes

### DIFF
--- a/resources/views/components/table/tr/bulk-actions.blade.php
+++ b/resources/views/components/table/tr/bulk-actions.blade.php
@@ -28,7 +28,7 @@
                         wire:loading.attr="disabled"
                         type="button"
                         {{ 
-                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                            $this->getBulkActionsRowButtonAttributesBag->class([
                                 'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
                                 'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
                                 'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
@@ -54,7 +54,7 @@
                         wire:loading.attr="disabled"
                         type="button"
                         {{ 
-                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                            $this->getBulkActionsRowButtonAttributesBag->class([
                                 'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
                                 'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
                                 'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
@@ -69,7 +69,7 @@
                         wire:loading.attr="disabled"
                         type="button"
                         {{ 
-                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                            $this->getBulkActionsRowButtonAttributesBag->class([
                                 'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
                                 'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
                                 'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
@@ -84,7 +84,7 @@
                         wire:loading.attr="disabled"
                         type="button"
                         {{ 
-                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                            $this->getBulkActionsRowButtonAttributesBag->class([
                                 'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
                                 'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
                                 'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)

--- a/resources/views/components/table/tr/bulk-actions.blade.php
+++ b/resources/views/components/table/tr/bulk-actions.blade.php
@@ -1,4 +1,4 @@
-@aware([ 'tableName','isTailwind','isBootstrap'])
+@aware([ 'tableName'])
 
 @if ($this->bulkActionsAreEnabled() && $this->hasBulkActions())
     @php
@@ -7,134 +7,94 @@
         $simplePagination = $this->isPaginationMethod('simple');
     @endphp
 
-    @if ($isTailwind)
-        <x-livewire-tables::table.tr.plain
-            x-cloak x-show="selectedItems.length > 0 && !currentlyReorderingStatus"
-            wire:key="{{ $tableName }}-bulk-select-message"
-            class="bg-indigo-50 dark:bg-gray-900 dark:text-white"
-        >
-            <x-livewire-tables::table.td.plain :colspan="$colspan">
-                <template x-if="selectedItems.length == paginationTotalItemCount || selectAllStatus">
-                    <div wire:key="{{ $tableName }}-all-selected">
-                        <span>
-                            {{ __($this->getLocalisationPath.'You are currently selecting all') }}
-                            @if(!$simplePagination) <strong><span x-text="paginationTotalItemCount"></span></strong> @endif
-                            {{ __($this->getLocalisationPath.'rows') }}.
-                        </span>
-
-                        <button
-                            x-on:click="clearSelected"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="ml-1 text-blue-600 underline text-gray-700 text-sm leading-5 font-medium focus:outline-none focus:text-gray-800 focus:underline transition duration-150 ease-in-out dark:text-white dark:hover:text-gray-400"
-                        >
-                            {{ __($this->getLocalisationPath.'Deselect All') }}
-                        </button>
-                    </div>
-                </template>
-
-                <template x-if="selectedItems.length !== paginationTotalItemCount && !selectAllStatus">
-                    <div wire:key="{{ $tableName }}-some-selected">
-                        <span>
-                            {{ __($this->getLocalisationPath.'You have selected') }}
-                            <strong><span x-text="selectedItems.length"></span></strong>
-                            {{ __($this->getLocalisationPath.'rows, do you want to select all') }}
-                            @if(!$simplePagination) <strong><span x-text="paginationTotalItemCount"></span></strong> @endif
-                        </span>
-
-                        <button
-                            x-on:click="selectAllOnPage()"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="ml-1 text-blue-600 underline text-gray-700 text-sm leading-5 font-medium focus:outline-none focus:text-gray-800 focus:underline transition duration-150 ease-in-out dark:text-white dark:hover:text-gray-400"
-                        >{{ __($this->getLocalisationPath.'Select All On Page') }}
-                        </button>&nbsp;
-
-                        <button
-                            x-on:click="setAllSelected()"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="ml-1 text-blue-600 underline text-gray-700 text-sm leading-5 font-medium focus:outline-none focus:text-gray-800 focus:underline transition duration-150 ease-in-out dark:text-white dark:hover:text-gray-400"
-                        >
-                            {{ __($this->getLocalisationPath.'Select All') }}
-                        </button>
-
-                        <button
-                            x-on:click="clearSelected"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="ml-1 text-blue-600 underline text-gray-700 text-sm leading-5 font-medium focus:outline-none focus:text-gray-800 focus:underline transition duration-150 ease-in-out dark:text-white dark:hover:text-gray-400"
-                        >
-                            {{ __($this->getLocalisationPath.'Deselect All') }}
-                        </button>
-                    </div>
-                </template>
-            </x-livewire-tables::table.td.plain>
-        </x-livewire-tables::table.tr.plain>
-    @elseif ($isBootstrap)
-        <x-livewire-tables::table.tr.plain
-            x-cloak x-show="selectedItems.length > 0 && !currentlyReorderingStatus"
-            wire:key="{{ $tableName }}-bulk-select-message"
-        >
-            <x-livewire-tables::table.td.plain :colspan="$colspan">
-                <template x-if="selectedItems.length == paginationTotalItemCount || selectAllStatus">
-                    <div wire:key="{{ $tableName }}-all-selected">
-                        <span>
+    <x-livewire-tables::table.tr.plain
+        x-cloak x-show="selectedItems.length > 0 && !currentlyReorderingStatus"
+        wire:key="{{ $tableName }}-bulk-select-message"
+        @class([
+            'bg-indigo-50 dark:bg-gray-900 dark:text-white' => $this->isTailwind,
+        ])
+    >
+        <x-livewire-tables::table.td.plain :colspan="$colspan">
+            <template x-if="selectedItems.length == paginationTotalItemCount || selectAllStatus">
+                <div wire:key="{{ $tableName }}-all-selected">
+                    <span>
                         {{ __($this->getLocalisationPath.'You are currently selecting all') }}
                         @if(!$simplePagination) <strong><span x-text="paginationTotalItemCount"></span></strong> @endif
-                            {{ __($this->getLocalisationPath.'rows') }}.
+                        {{ __($this->getLocalisationPath.'rows') }}.
+                    </span>
 
-                        </span>
-
-                        <button
-                            x-on:click="clearSelected"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="btn btn-primary btn-sm"
-                        >
+                    <button
+                        x-on:click="clearSelected"
+                        wire:loading.attr="disabled"
+                        type="button"
+                        {{ 
+                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                                'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
+                                'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
+                                'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
+                            ])
+                        }}
+                    >
                         {{ __($this->getLocalisationPath.'Deselect All') }}
-                        </button>
-                    </div>
-                </template>
+                    </button>
+                </div>
+            </template>
 
-                <template x-if="selectedItems.length !== paginationTotalItemCount && !selectAllStatus">
-                    <div wire:key="{{ $tableName }}-some-selected">
-                        <span>
-                            {{ __($this->getLocalisationPath.'You have selected') }}
-                            <strong><span x-text="selectedItems.length"></span></strong>
-                            {{ __($this->getLocalisationPath.'rows, do you want to select all') }}
-                            @if(!$simplePagination) <strong><span x-text="paginationTotalItemCount"></span></strong> @endif
-                        </span>
+            <template x-if="selectedItems.length !== paginationTotalItemCount && !selectAllStatus">
+                <div wire:key="{{ $tableName }}-some-selected">
+                    <span>
+                        {{ __($this->getLocalisationPath.'You have selected') }}
+                        <strong><span x-text="selectedItems.length"></span></strong>
+                        {{ __($this->getLocalisationPath.'rows, do you want to select all') }}
+                        @if(!$simplePagination) <strong><span x-text="paginationTotalItemCount"></span></strong> @endif
+                    </span>
 
-                        <button
-                            x-on:click="selectAllOnPage"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="btn btn-primary btn-sm"
-                        >
-                            {{ __($this->getLocalisationPath.'Select All On Page') }}
-                        </button>&nbsp;
+                    <button
+                        x-on:click="selectAllOnPage()"
+                        wire:loading.attr="disabled"
+                        type="button"
+                        {{ 
+                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                                'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
+                                'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
+                                'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
+                            ])
+                        }}
 
-                        <button
-                            x-on:click="setAllSelected()"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="btn btn-primary btn-sm"
-                        >
-                            {{ __($this->getLocalisationPath.'Select All') }}
-                        </button>
+                    >{{ __($this->getLocalisationPath.'Select All On Page') }}
+                    </button>&nbsp;
 
-                        <button
-                            x-on:click="clearSelected"
-                            wire:loading.attr="disabled"
-                            type="button"
-                            class="btn btn-primary btn-sm"
-                        >
-                            {{ __($this->getLocalisationPath.'Deselect All') }}
-                        </button>
-                    </div>
-                </template>
-            </x-livewire-tables::table.td.plain>
-        </x-livewire-tables::table.tr.plain>
-    @endif
+                    <button
+                        x-on:click="setAllSelected()"
+                        wire:loading.attr="disabled"
+                        type="button"
+                        {{ 
+                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                                'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
+                                'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
+                                'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
+                            ])
+                        }}
+                    >
+                        {{ __($this->getLocalisationPath.'Select All') }}
+                    </button>
+
+                    <button
+                        x-on:click="clearSelected"
+                        wire:loading.attr="disabled"
+                        type="button"
+                        {{ 
+                            $attributes->merge($this->getBulkActionsRowButtonAttributes)->class([
+                                'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
+                                'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
+                                'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
+                            ])
+                        }}
+                    >
+                        {{ __($this->getLocalisationPath.'Deselect All') }}
+                    </button>
+                </div>
+            </template>
+        </x-livewire-tables::table.td.plain>
+    </x-livewire-tables::table.tr.plain>
 @endif

--- a/src/Traits/Styling/Configuration/BulkActionStylingConfiguration.php
+++ b/src/Traits/Styling/Configuration/BulkActionStylingConfiguration.php
@@ -76,7 +76,6 @@ trait BulkActionStylingConfiguration
 
     /**
      * Used to set attributes for the Bulk Actions Row Buttons
-     *
      */
     #[Computed]
     public function setBulkActionsRowButtonAttributes(array $bulkActionsRowButtonAttributes): self
@@ -85,5 +84,4 @@ trait BulkActionStylingConfiguration
 
         return $this;
     }
-
 }

--- a/src/Traits/Styling/Configuration/BulkActionStylingConfiguration.php
+++ b/src/Traits/Styling/Configuration/BulkActionStylingConfiguration.php
@@ -77,7 +77,6 @@ trait BulkActionStylingConfiguration
     /**
      * Used to set attributes for the Bulk Actions Row Buttons
      */
-    #[Computed]
     public function setBulkActionsRowButtonAttributes(array $bulkActionsRowButtonAttributes): self
     {
         $this->setCustomAttributes('bulkActionsRowButtonAttributes', $bulkActionsRowButtonAttributes);

--- a/src/Traits/Styling/Configuration/BulkActionStylingConfiguration.php
+++ b/src/Traits/Styling/Configuration/BulkActionStylingConfiguration.php
@@ -73,4 +73,17 @@ trait BulkActionStylingConfiguration
 
         return $this;
     }
+
+    /**
+     * Used to set attributes for the Bulk Actions Row Buttons
+     *
+     */
+    #[Computed]
+    public function setBulkActionsRowButtonAttributes(array $bulkActionsRowButtonAttributes): self
+    {
+        $this->setCustomAttributes('bulkActionsRowButtonAttributes', $bulkActionsRowButtonAttributes);
+
+        return $this;
+    }
+
 }

--- a/src/Traits/Styling/HasBulkActionsStyling.php
+++ b/src/Traits/Styling/HasBulkActionsStyling.php
@@ -25,4 +25,7 @@ trait HasBulkActionsStyling
     protected array $bulkActionsMenuAttributes = ['default-colors' => true, 'default-styling' => true];
 
     protected array $bulkActionsMenuItemAttributes = ['default-colors' => true, 'default-styling' => true];
+
+    protected array $bulkActionsRowButtonAttributes = ['default-colors' => true, 'default-styling' => true];
+
 }

--- a/src/Traits/Styling/HasBulkActionsStyling.php
+++ b/src/Traits/Styling/HasBulkActionsStyling.php
@@ -27,5 +27,4 @@ trait HasBulkActionsStyling
     protected array $bulkActionsMenuItemAttributes = ['default-colors' => true, 'default-styling' => true];
 
     protected array $bulkActionsRowButtonAttributes = ['default-colors' => true, 'default-styling' => true];
-
 }

--- a/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
 
-use Illuminate\View\ComponentAttributeBag;
 use Livewire\Attributes\Computed;
+use Illuminate\View\ComponentAttributeBag;
 
 trait BulkActionStylingHelpers
 {
@@ -106,4 +106,12 @@ trait BulkActionStylingHelpers
         return $this->getCustomAttributes('bulkActionsRowButtonAttributes', true);
 
     }
+
+    #[Computed]
+    public function getBulkActionsRowButtonAttributesBag(): ComponentAttributeBag
+    {
+        return $this->getCustomAttributesBagFromArray($this->getBulkActionsRowButtonAttributes());
+    }
+
+
 }

--- a/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
 
-use Livewire\Attributes\Computed;
 use Illuminate\View\ComponentAttributeBag;
+use Livewire\Attributes\Computed;
 
 trait BulkActionStylingHelpers
 {
@@ -106,6 +106,4 @@ trait BulkActionStylingHelpers
         return $this->getCustomAttributes('bulkActionsRowButtonAttributes', true);
 
     }
-
-
 }

--- a/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
 
-use Livewire\Attributes\Computed;
 use Illuminate\View\ComponentAttributeBag;
+use Livewire\Attributes\Computed;
 
 trait BulkActionStylingHelpers
 {
@@ -112,6 +112,4 @@ trait BulkActionStylingHelpers
     {
         return $this->getCustomAttributesBagFromArray($this->getBulkActionsRowButtonAttributes());
     }
-
-
 }

--- a/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
@@ -3,6 +3,7 @@
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
 
 use Livewire\Attributes\Computed;
+use Illuminate\View\ComponentAttributeBag;
 
 trait BulkActionStylingHelpers
 {
@@ -93,4 +94,18 @@ trait BulkActionStylingHelpers
         return $this->getCustomAttributes('bulkActionsTdCheckboxAttributes');
 
     }
+
+    /**
+     * Used to get attributes for the Bulk Actions Row Buttons
+     *
+     * @return array<mixed>
+     */
+    #[Computed]
+    public function getBulkActionsRowButtonAttributes(): array
+    {
+        return $this->getCustomAttributes('bulkActionsRowButtonAttributes', true);
+
+    }
+
+
 }

--- a/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
@@ -32,6 +32,7 @@ final class BulkActionsStylingConfigurationTest extends TestCase
             'BulkActionsThCheckboxAttributes',
             'BulkActionsTdAttributes',
             'BulkActionsTdCheckboxAttributes',
+            'BulkActionsRowButtonAttributes',
         ];
     }
 


### PR DESCRIPTION
PR:

- Simplifies the resources/views/components/table/tr/bulk-actions.blade.php to minimise code duplication
- Swaps elements in resources/views/components/table/tr/bulk-actions.blade.php to use Computed Property for isTailwind/isBootstrap rather than "aware" properties.
- Adds capability to add attributes to the buttons present in the top-most TR when utilising Bulk Actions
- Adds relevant tests for those attributes

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
