### PR TITLE
Add Missing Test for getCustomSortingPillDirectionsLabel with invalid direction

### DIFF
--- a/tests/Unit/Views/ColumnTest.php
+++ b/tests/Unit/Views/ColumnTest.php
@@ -114,4 +114,10 @@ final class ColumnTest extends TestCase
 
         $contents = $column->renderContents($rows->first());
     }
+
+    public function test_custom_sorting_pills_label_defaults_correctly(): void
+    {
+        $column = Column::make('Name', 'name');
+        $this->assertSame('Name', $column->getTitle());
+    }
 }

--- a/tests/Unit/Views/ColumnTest.php
+++ b/tests/Unit/Views/ColumnTest.php
@@ -115,6 +115,18 @@ final class ColumnTest extends TestCase
         $contents = $column->renderContents($rows->first());
     }
 
+    public function test_custom_sorting_pills_defaults_correctly(): void
+    {
+        $column = Column::make('Name', 'name');
+        $defaultString = __($this->basicTable->getLocalisationPath().'not_applicable');
+
+        $this->assertSame('A-Z', $column->getCustomSortingPillDirections('asc'));
+        $this->assertSame('Z-A', $column->getCustomSortingPillDirections('desc'));
+        $this->assertSame($defaultString, $column->getCustomSortingPillDirections('faulty_string'));
+
+    }
+
+    
     public function test_custom_sorting_pills_label_defaults_correctly(): void
     {
         $column = Column::make('Name', 'name');

--- a/tests/Unit/Views/ColumnTest.php
+++ b/tests/Unit/Views/ColumnTest.php
@@ -126,7 +126,6 @@ final class ColumnTest extends TestCase
 
     }
 
-    
     public function test_custom_sorting_pills_label_defaults_correctly(): void
     {
         $column = Column::make('Name', 'name');

--- a/tests/Unit/Views/ColumnTest.php
+++ b/tests/Unit/Views/ColumnTest.php
@@ -118,6 +118,11 @@ final class ColumnTest extends TestCase
     public function test_custom_sorting_pills_label_defaults_correctly(): void
     {
         $column = Column::make('Name', 'name');
-        $this->assertSame('Name', $column->getTitle());
+        $defaultString = __($this->basicTable->getLocalisationPath().'not_applicable');
+
+        $this->assertSame('A-Z', $column->getCustomSortingPillDirectionsLabel('asc'));
+        $this->assertSame('Z-A', $column->getCustomSortingPillDirectionsLabel('desc'));
+        $this->assertSame($defaultString, $column->getCustomSortingPillDirectionsLabel('faulty_string'));
+
     }
 }


### PR DESCRIPTION
Add Missing Test for getCustomSortingPillDirectionsLabel with invalid direction

```
        $column = Column::make('Name', 'name');
        $defaultString = __($this->basicTable->getLocalisationPath().'not_applicable');

        $this->assertSame('A-Z', $column->getCustomSortingPillDirectionsLabel('asc'));
        $this->assertSame('Z-A', $column->getCustomSortingPillDirectionsLabel('desc'));
        $this->assertSame($defaultString, $column->getCustomSortingPillDirectionsLabel('faulty_string'));

```


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
