### PR TITLE
Move default attributes out of blades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ phpunit.xml.bak
 phpstan.txt
 coverage.xml
 ./tmp/**
+tests.txt

--- a/resources/views/components/table/empty.blade.php
+++ b/resources/views/components/table/empty.blade.php
@@ -2,18 +2,15 @@
 
 @php($attributes = $attributes->merge(['wire:key' => 'empty-message-'.$this->getId()]))
 
-@if ($isTailwind)
-    <tr {{ $attributes }}>
-        <td colspan="{{ $this->getColspanCount() }}">
+<tr {{ $attributes }}>
+    <td colspan="{{ $this->getColspanCount() }}">
+        @if ($isTailwind)
             <div class="flex justify-center items-center space-x-2 dark:bg-gray-800">
                 <span class="font-medium py-8 text-gray-400 text-lg dark:text-white">{{ $this->getEmptyMessage() }}</span>
             </div>
-        </td>
-    </tr>
-@elseif ($isBootstrap)
-     <tr {{ $attributes }}>
-        <td colspan="{{ $this->getColspanCount() }}">
+        @else
             {{ $this->getEmptyMessage() }}
-        </td>
-    </tr>
-@endif
+
+        @endif
+    </td>
+</tr>

--- a/resources/views/components/table/td.blade.php
+++ b/resources/views/components/table/td.blade.php
@@ -2,18 +2,13 @@
 @props(['column', 'colIndex'])
 
 @php
-    $customAttributes = $this->getTdAttributes($column, $row, $colIndex, $rowIndex)
+    $customAttributes = $this->getTdAttributesBag($column, $row, $colIndex, $rowIndex)
 @endphp
 
-<td wire:key="{{ $tableName . '-table-td-'.$row->{$primaryKey}.'-'.$column->getSlug() }}"
-    @if ($column->isClickable())
-        @if($this->getTableRowUrlTarget($row) === 'navigate') wire:navigate href="{{ $this->getTableRowUrl($row) }}"
-        @else onclick="window.open('{{ $this->getTableRowUrl($row) }}', '{{ $this->getTableRowUrlTarget($row) ?? '_self' }}')"
-        @endif
-    @endif
-        {{
-            $attributes->merge($customAttributes)
-                ->class(['px-6 py-4 whitespace-nowrap text-sm font-medium dark:text-white' => $isTailwind && ($customAttributes['default'] ?? true)])
+<td {{
+            $customAttributes->merge()
+                ->class(['px-6 py-4 whitespace-nowrap text-sm font-medium' => $isTailwind && ($customAttributes['default-styling'] ?? ($customAttributes['default'] ?? true))])
+                ->class(['dark:text-white' => $isTailwind && ($customAttributes['default-colors'] ?? ($customAttributes['default'] ?? true))])
                 ->class(['hidden' =>  $isTailwind && $column && $column->shouldCollapseAlways()])
                 ->class(['hidden md:table-cell' => $isTailwind && $column && $column->shouldCollapseOnMobile()])
                 ->class(['hidden lg:table-cell' => $isTailwind && $column && $column->shouldCollapseOnTablet()])
@@ -23,7 +18,6 @@
                 ->class(['d-none d-lg-table-cell' => $isBootstrap && $column && $column->shouldCollapseOnTablet()])
                 ->class(['laravel-livewire-tables-cursor' => $isBootstrap && $column && $column->isClickable()])
                 ->except(['default','default-styling','default-colors'])
-        }}
-    >
-        {{ $slot }}
+        }}>
+    {{ $slot }}
 </td>

--- a/resources/views/components/table/td/bulk-actions.blade.php
+++ b/resources/views/components/table/td/bulk-actions.blade.php
@@ -2,31 +2,23 @@
 @props(['row', 'rowIndex'])
 
 @php
-    $customAttributes = $this->getBulkActionsTdAttributes();
-    $bulkActionsTdCheckboxAttributes = $this->getBulkActionsTdCheckboxAttributes();
-    $theme = $this->getTheme();
+    $customAttributes = $this->getBulkActionsTdAttributesNew($row->{$primaryKey});
+    $bulkActionsTdCheckboxAttributes = $this->getBulkActionsTdCheckboxAttributesNew($row->{$primaryKey});
 @endphp
 
 @if ($this->bulkActionsAreEnabled() && $this->hasBulkActions())
-    <x-livewire-tables::table.td.plain wire:key="{{ $tableName }}-tbody-td-bulk-actions-td-{{ $row->{$primaryKey} }}" :displayMinimisedOnReorder="true"  :$customAttributes>
+    <x-livewire-tables::table.td.plain  :$customAttributes>
         <div @class([
-            'inline-flex rounded-md shadow-sm' => $theme === 'tailwind',
-            'form-check' => $theme === 'bootstrap-5',
+            'inline-flex rounded-md shadow-sm' => $this->isTailwind,
+            'form-check' => $this->isBootstrap,
         ])>
-            <input
-                x-cloak x-show="!currentlyReorderingStatus"
-                x-model="selectedItems"
-                wire:key="{{ $tableName . 'selectedItems-'.$row->{$primaryKey} }}"
-                wire:loading.attr.delay="disabled"
-                value="{{ $row->{$primaryKey} }}"
-                type="checkbox"
-                {{
+            <input {{
                     $attributes->merge($bulkActionsTdCheckboxAttributes)->class([
-                        'rounded border-gray-300 text-indigo-600 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => ($theme === 'tailwind') && ($bulkActionsTdCheckboxAttributes['default'] ?? true),
-                        'form-check-input' => ($theme === 'bootstrap-5') && ($bulkActionsTdCheckboxAttributes['default'] ?? true),
+                        'rounded shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50' => $this->isTailwind && (($bulkActionsTdCheckboxAttributes['default'] ?? true) || ($bulkActionsTdCheckboxAttributes['default-styling'] ?? true)),
+                        'border-gray-300 text-indigo-600 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => $this->isTailwind && (($bulkActionsTdCheckboxAttributes['default'] ?? true) || ($bulkActionsTdCheckboxAttributes['default-colors'] ?? true)),
+                        'form-check-input' => $this->isBootstrap && ($bulkActionsTdCheckboxAttributes['default'] ?? true),
                     ])->except(['default','default-styling','default-colors'])
-                }}
-            />
+                }} />
         </div>
     </x-livewire-tables::table.td.plain>
 @endif

--- a/resources/views/components/table/td/collapsed-columns.blade.php
+++ b/resources/views/components/table/td/collapsed-columns.blade.php
@@ -5,11 +5,15 @@
     @if ($isTailwind)
         <td x-data="{open:false}" wire:key="{{ $tableName }}-collapsingIcon-{{ $rowIndex }}-{{ md5(now()) }}"
             {{
-                $attributes
-                    ->merge(['class' => 'p-3 table-cell text-center '])
-                    ->class(['sm:hidden' => !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
-                    ->class(['md:hidden' => !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
-                    ->class(['lg:hidden' => !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
+                $attributes->merge()
+                    ->class(['p-3 table-cell text-center' => $this->isTailwind])
+                    ->class(['sm:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
+                    ->class(['md:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
+                    ->class(['lg:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
+                    ->class(['d-sm-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
+                    ->class(['d-md-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
+                    ->class(['d-lg-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
+
             }}
             :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
         >
@@ -43,12 +47,7 @@
         </td>
     @elseif ($isBootstrap)
         <td x-data="{open:false}" wire:key="{{ $tableName }}-collapsingIcon-{{ $rowIndex }}-{{ md5(now()) }}" 
-            {{
-                $attributes
-                    ->class(['d-sm-none' => !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
-                    ->class(['d-md-none' => !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
-                    ->class(['d-lg-none' => !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
-            }}
+
             :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
         >
             @if (! $hidden)

--- a/resources/views/components/table/td/collapsed-columns.blade.php
+++ b/resources/views/components/table/td/collapsed-columns.blade.php
@@ -2,80 +2,44 @@
 @props(['rowIndex', 'hidden' => false])
 
 @if ($this->collapsingColumnsAreEnabled() && $this->hasCollapsedColumns())
-    @if ($isTailwind)
-        <td x-data="{open:false}" wire:key="{{ $tableName }}-collapsingIcon-{{ $rowIndex }}-{{ md5(now()) }}"
-            {{
-                $attributes->merge()
-                    ->class(['p-3 table-cell text-center' => $this->isTailwind])
-                    ->class(['sm:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
-                    ->class(['md:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
-                    ->class(['lg:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
-                    ->class(['d-sm-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
-                    ->class(['d-md-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
-                    ->class(['d-lg-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
+    <td x-data="{open:false}" wire:key="{{ $tableName }}-collapsingIcon-{{ $rowIndex }}-{{ md5(now()) }}"
+        {{
+            $attributes->merge()
+                ->class(['p-3 table-cell text-center' => $this->isTailwind])
+                ->class(['sm:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
+                ->class(['md:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
+                ->class(['lg:hidden' => $this->isTailwind && !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
+                ->class(['d-sm-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet()])
+                ->class(['d-md-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && !$this->shouldCollapseOnTablet() && $this->shouldCollapseOnMobile()])
+                ->class(['d-lg-none' => $this->isBootstrap && !$this->shouldCollapseAlways() && ($this->shouldCollapseOnTablet() || $this->shouldCollapseOnMobile())])
 
-            }}
-            :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
-        >
-            @if (! $hidden)
-                <button
-                    x-cloak x-show="!currentlyReorderingStatus"
-                    x-on:click.prevent="$dispatch('toggle-row-content', {'tableName': '{{ $tableName }}', 'row': {{ $rowIndex }}}); open = !open"
-                >
-                    <x-heroicon-o-plus-circle x-cloak x-show="!open" 
-                        {{ 
-                            $attributes->merge($this->getCollapsingColumnButtonExpandAttributes)
-                            ->class([
-                                'h-6 w-6' => $this->getCollapsingColumnButtonExpandAttributes['default-styling'] ?? true,
-                                'text-green-600' => $this->getCollapsingColumnButtonExpandAttributes['default-colors'] ?? true,
-                            ])
-                            ->except(['default','default-styling','default-colors']) 
-                        }}
-                     />
-                    <x-heroicon-o-minus-circle x-cloak x-show="open" 
-                        {{ 
-                            $attributes->merge($this->getCollapsingColumnButtonCollapseAttributes)
-                            ->class([
-                                'h-6 w-6' => $this->getCollapsingColumnButtonCollapseAttributes['default-styling'] ?? true,
-                                'text-yellow-600' => $this->getCollapsingColumnButtonCollapseAttributes['default-colors'] ?? true,
-                            ])
-                            ->except(['default','default-styling','default-colors']) 
-                        }}
-                    />
-                </button>
-            @endif
-        </td>
-    @elseif ($isBootstrap)
-        <td x-data="{open:false}" wire:key="{{ $tableName }}-collapsingIcon-{{ $rowIndex }}-{{ md5(now()) }}" 
+        }}
+        :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
+    >
+        @if (! $hidden)
+            <button x-cloak x-show="!currentlyReorderingStatus" x-on:click.prevent="$dispatch('toggle-row-content', {'tableName': '{{ $tableName }}', 'row': {{ $rowIndex }}}); open = !open" @class([
+                    "border-0 bg-transparent p-0" => $this->isBootstrap
+                ])>
+                <x-heroicon-o-plus-circle x-cloak x-show="!open"  {{ 
+                        $attributes->merge($this->getCollapsingColumnButtonExpandAttributes)
+                        ->class([
+                            'h-6 w-6' => $this->isTailwind && ($this->getCollapsingColumnButtonExpandAttributes['default-styling'] ?? true),
+                            'text-green-600' => $this->isTailwind && ($this->getCollapsingColumnButtonExpandAttributes['default-colors'] ?? true),
+                            'laravel-livewire-tables-btn-lg text-success' => $this->isBootstrap && ($this->getCollapsingColumnButtonExpandAttributes['default-colors'] ?? true),
+                        ])
+                        ->except(['default','default-styling','default-colors']) 
+                    }} />
+                <x-heroicon-o-minus-circle x-cloak x-show="open"  {{ 
+                        $attributes->merge($this->getCollapsingColumnButtonCollapseAttributes)
+                        ->class([
+                            'h-6 w-6' => $this->isTailwind && ($this->getCollapsingColumnButtonCollapseAttributes['default-styling'] ?? true),
+                            'text-yellow-600' => $this->isTailwind && ($this->getCollapsingColumnButtonCollapseAttributes['default-colors'] ?? true),
+                            'laravel-livewire-tables-btn-lg text-warning' => $this->isBootstrap && ($this->getCollapsingColumnButtonExpandAttributes['default-colors'] ?? true),
 
-            :class="currentlyReorderingStatus ? 'laravel-livewire-tables-reorderingMinimised' : ''"
-        >
-            @if (! $hidden)
-                <button
-                    x-cloak x-show="!currentlyReorderingStatus"
-                    x-on:click.prevent="$dispatch('toggle-row-content', {'tableName': '{{ $tableName }}', 'row': {{ $rowIndex }}});open = !open"
-                    class="border-0 bg-transparent p-0"
-                >
-                    <x-heroicon-o-plus-circle x-cloak x-show="!open"  
-                        {{ 
-                            $attributes->merge($this->getCollapsingColumnButtonExpandAttributes)
-                            ->class([
-                                'laravel-livewire-tables-btn-lg text-success' => $this->getCollapsingColumnButtonExpandAttributes['default-colors'] ?? true,
-                            ])
-                            ->except(['default','default-styling','default-colors']) 
-                        }}
-                    />
-                    <x-heroicon-o-minus-circle x-cloak x-show="open" 
-                        {{ 
-                            $attributes->merge($this->getCollapsingColumnButtonExpandAttributes)
-                            ->class([
-                                'laravel-livewire-tables-btn-lg text-warning' => $this->getCollapsingColumnButtonExpandAttributes['default-colors'] ?? true,
-                            ])
-                            ->except(['default','default-styling','default-colors']) 
-                        }}
-                    />
-                </button>
-            @endif
-        </td>
-    @endif
+                        ])
+                        ->except(['default','default-styling','default-colors']) 
+                    }} />
+            </button>
+        @endif
+    </td>
 @endif

--- a/resources/views/components/table/td/plain.blade.php
+++ b/resources/views/components/table/td/plain.blade.php
@@ -2,26 +2,16 @@
 @props(['column' => null, 'customAttributes' => [], 'displayMinimisedOnReorder' => false, 'hideUntilReorder' => false])
 
 
-@if ($isTailwind)
-    <td x-cloak {{ $attributes
-        ->merge($customAttributes)
-        ->class(['px-6 py-4 whitespace-nowrap text-sm font-medium dark:text-white' => $customAttributes['default'] ?? true])
-        ->class(['hidden' => $column && $column->shouldCollapseAlways()])
-        ->class(['hidden md:table-cell' => $column && $column->shouldCollapseOnMobile()])
-        ->class(['hidden lg:table-cell' => $column && $column->shouldCollapseOnTablet()])
-        ->except(['default','default-styling','default-colors'])
-    }} @if($hideUntilReorder) x-show="reorderDisplayColumn" @endif >
-        {{ $slot }}
-    </td>
-@elseif ($isBootstrap)
-    <td {{ $attributes
-        ->merge($customAttributes)
-        ->class(['' => $customAttributes['default'] ?? true])
-        ->class(['d-none' => $column && $column->shouldCollapseAlways()])
-        ->class(['d-none d-md-table-cell' => $column && $column->shouldCollapseOnMobile()])
-        ->class(['d-none d-lg-table-cell' => $column && $column->shouldCollapseOnTablet()])
-        ->except(['default','default-styling','default-colors'])
-    }}>
-        {{ $slot }}
-    </td>
-@endif
+<td x-cloak {{ $attributes
+    ->merge($customAttributes)
+    ->class(['px-6 py-4 whitespace-nowrap text-sm font-medium dark:text-white' => $isTailwind && ($customAttributes['default'] ?? true)])
+    ->class(['hidden' => $isTailwind && $column && $column->shouldCollapseAlways()])
+    ->class(['hidden md:table-cell' => $isTailwind && $column && $column->shouldCollapseOnMobile()])
+    ->class(['hidden lg:table-cell' => $isTailwind && $column && $column->shouldCollapseOnTablet()])
+    ->class(['d-none' => $isBootstrap && $column && $column->shouldCollapseAlways()])
+    ->class(['d-none d-md-table-cell' => $isBootstrap && $column && $column->shouldCollapseOnMobile()])
+    ->class(['d-none d-lg-table-cell' => $isBootstrap && $column && $column->shouldCollapseOnTablet()])
+    ->except(['default','default-styling','default-colors'])
+}} @if($hideUntilReorder) x-show="reorderDisplayColumn" @endif >
+    {{ $slot }}
+</td>

--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -10,81 +10,50 @@
     $customSortIconAttributes = $allThAttributes['sortIconAttributes'];
     $customLabelAttributes = $allThAttributes['labelAttributes'];
 
-    //$customThAttributes = $this->getThAttributes($column);
-    //$customSortButtonAttributes = $this->getThSortButtonAttributes($column);
-    //$customSortIconAttributes = $this->getThSortIconAttributes($column);
-
     $direction = $column->hasField() ? $this->getSort($column->getColumnSelectName()) : $this->getSort($column->getSlug()) ?? null ;
 @endphp
 
-@if ($isTailwind)
-    <th scope="col" {{
-        $attributes->merge($customThAttributes)
-            ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
-            ->class(['px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true))])
-            ->class(['hidden' => $column->shouldCollapseAlways()])
-            ->class(['hidden md:table-cell' => $column->shouldCollapseOnMobile()])
-            ->class(['hidden lg:table-cell' => $column->shouldCollapseOnTablet()])
-            ->except(['default', 'default-colors', 'default-styling'])
-        }}
-    >
-        @if($column->getColumnLabelStatus())
-            @unless ($this->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
-                <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-            @else
-                <button wire:click="sortBy('{{ $column->getColumnSortKey() }}')"
-                    {{
-                        $attributes->merge($customSortButtonAttributes)
-                            ->class(['text-gray-500 dark:text-gray-400' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
-                            ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
-                            ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                >
-                    <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-                    <x-livewire-tables::table.th.sort-icons :$direction
-                    {{
-                        $attributes->merge($customSortIconAttributes)
-                            ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                    />
+<th scope="col" {{ $attributes->merge($customThAttributes)
+        ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => $isTailwind && (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
+        ->class(['px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => $isTailwind && (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true))])
+        ->class(['hidden' => $isTailwind && $column->shouldCollapseAlways()])
+        ->class(['hidden md:table-cell' => $isTailwind && $column->shouldCollapseOnMobile()])
+        ->class(['hidden lg:table-cell' => $isTailwind && $column->shouldCollapseOnTablet()])
+        ->class(['d-none' => $isBootstrap && $column->shouldCollapseAlways()])
+        ->class(['d-none d-md-table-cell' => $isBootstrap && $column->shouldCollapseOnMobile()])
+        ->class(['d-none d-lg-table-cell' => $isBootstrap && $column->shouldCollapseOnTablet()])
+        ->except(['default', 'default-colors', 'default-styling'])
+}}>
+    @if($column->getColumnLabelStatus())
+        @unless ($this->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
+            <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
+        @else
 
-                </button>
-            @endunless
-        @endif
-    </th>
-@elseif ($isBootstrap)
-    <th scope="col" {{
-        $attributes->merge($customThAttributes)
-            ->class(['' => $customThAttributes['default'] ?? true])
-            ->class(['d-none' => $column->shouldCollapseAlways()])
-            ->class(['d-none d-md-table-cell' => $column->shouldCollapseOnMobile()])
-            ->class(['d-none d-lg-table-cell' => $column->shouldCollapseOnTablet()])
-            ->except(['default','default-styling','default-colors'])
-        }}
-    >
-        @if($column->getColumnLabelStatus())
-            @unless ($this->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
-                <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-            @else
-                <div
-                    class="d-flex align-items-center laravel-livewire-tables-cursor"
-                    wire:click="sortBy('{{ $column->getColumnSortKey() }}')"
-                    {{
-                        $attributes->merge($customSortButtonAttributes)
+            @if ($isTailwind)
+                    <button wire:click="sortBy('{{ $column->getColumnSortKey() }}')" {{
+                            $attributes->merge($customSortButtonAttributes)
+                                ->class(['text-gray-500 dark:text-gray-400' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
+                                ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
+                                ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
+                    }}>
+                        <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
+                        <x-livewire-tables::table.th.sort-icons :$direction {{  $attributes->merge($customSortIconAttributes)
+                                ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
+                        }} />
+                    </button>
+            @elseif ($isBootstrap)
+                <div class="d-flex align-items-center laravel-livewire-tables-cursor" wire:click="sortBy('{{ $column->getColumnSortKey() }}')" {{ $attributes->merge($customSortButtonAttributes)
                             ->class(['' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                >
+                }}>
                     <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
 
-                    <x-livewire-tables::table.th.sort-icons :$direction                     {{
-                        $attributes->merge($customSortButtonAttributes)
+                    <x-livewire-tables::table.th.sort-icons :$direction {{  $attributes->merge($customSortButtonAttributes)
                             ->class(['' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                />
+                         }} />
                 </div>
-            @endunless
-        @endif
-    </th>
-@endif
+            @endif
+        @endunless
+    @endif
+</th>

--- a/resources/views/components/table/th/collapsed-columns.blade.php
+++ b/resources/views/components/table/th/collapsed-columns.blade.php
@@ -1,29 +1,18 @@
 @aware([ 'tableName','isTailwind','isBootstrap'])
 
 @if ($this->collapsingColumnsAreEnabled() && $this->hasCollapsedColumns())
-    @if ($isTailwind)
-        <th
-            scope="col"
-            {{
-                $attributes
-                    ->merge(['class' => 'table-cell dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised'])
-                    ->class(['sm:hidden' => !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['md:hidden' => !$this->shouldCollapseOnMobile() && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['lg:hidden' => !$this->shouldCollapseAlways()])
-            }}
-            :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }"
-        ></th>
-    @elseif ($isBootstrap)
-        <th
-            scope="col"
-            {{
-                $attributes
-                    ->merge(['class' => 'd-table-cell laravel-livewire-tables-reorderingMinimised'])
-                    ->class(['d-sm-none' => !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['d-md-none' => !$this->shouldCollapseOnMobile() && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['d-lg-none' => !$this->shouldCollapseAlways()])
-            }}                    
-            :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }"
-        ></th>
-    @endif
+    <th scope="col" {{
+            $attributes->merge()
+                ->class(['table-cell dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised' => $isTailwind])
+                ->class(['sm:hidden' => $isTailwind && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
+                ->class(['md:hidden' => $isTailwind && !$this->shouldCollapseOnMobile() && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
+                ->class(['lg:hidden' => $isTailwind &&  !$this->shouldCollapseAlways()])
+                ->class(['d-table-cell laravel-livewire-tables-reorderingMinimised' => $isBootstrap])
+                ->class(['d-sm-none' => $isBootstrap && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
+                ->class(['d-md-none' => $isBootstrap && !$this->shouldCollapseOnMobile() && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
+                ->class(['d-lg-none' => $isBootstrap && !$this->shouldCollapseAlways()])
+
+        }}
+        :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }"
+    ></th>
 @endif

--- a/resources/views/components/table/th/plain.blade.php
+++ b/resources/views/components/table/th/plain.blade.php
@@ -1,14 +1,12 @@
 @aware(['isTailwind','isBootstrap'])
 @props(['displayMinimisedOnReorder' => false, 'hideUntilReorder' => false, 'customAttributes' => ['default' => true]])
 
-<th x-cloak {{ $attributes }} scope="col"
-    {{ 
+<th x-cloak scope="col" {{ 
         $attributes->merge($customAttributes)->class([
             'table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left bg-gray-50 dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised' => ($isTailwind) && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
             'laravel-livewire-tables-reorderingMinimised' => ($isBootstrap) && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
-        ])
-    }}
-    @if($hideUntilReorder) :class="!reorderDisplayColumn && 'w-0 p-0 hidden'" @endif
+        ])->except(['default','default-styling','default-colors'])
+    }} @if($hideUntilReorder) :class="!reorderDisplayColumn && 'w-0 p-0 hidden'" @endif
 >
     {{ $slot }}
 </th>

--- a/resources/views/components/table/th/reorder.blade.php
+++ b/resources/views/components/table/th/reorder.blade.php
@@ -9,6 +9,7 @@
             ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
             ->class(['table-cell px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true))])
             ->class(['laravel-livewire-tables-reorderingMinimised' => ($isBootstrap) && ($customThAttributes['default'] ?? true)])
+            ->except(['default','default-styling','default-colors'])
     }}
 >
     <div x-cloak x-show="currentlyReorderingStatus"></div>

--- a/resources/views/components/table/tr.blade.php
+++ b/resources/views/components/table/tr.blade.php
@@ -2,34 +2,17 @@
 @props(['row', 'rowIndex'])
 
 @php
-    $customAttributes = $this->getTrAttributes($row, $rowIndex);
+    $customAttributes = $this->getTrAttributesBag($row, $rowIndex);
 @endphp
 
-<tr
-    rowpk='{{ $row->{$primaryKey} }}'
-    x-on:dragstart.self="currentlyReorderingStatus && dragStart(event)"
-    x-on:drop.prevent="currentlyReorderingStatus && dropEvent(event)"
-    x-on:dragover.prevent.throttle.500ms="currentlyReorderingStatus && dragOverEvent(event)"
-    x-on:dragleave.prevent.throttle.500ms="currentlyReorderingStatus && dragLeaveEvent(event)"
-    @if($this->hasDisplayLoadingPlaceholder()) 
-        wire:loading.class.add="hidden d-none"
-    @else
-        wire:loading.class.delay="opacity-50 dark:bg-gray-900 dark:opacity-60"
-    @endif
-    id="{{ $tableName }}-row-{{ $row->{$primaryKey} }}"
-    :draggable="currentlyReorderingStatus"
-    wire:key="{{ $tableName }}-tablerow-tr-{{ $row->{$primaryKey} }}"
-    loopType="{{ ($rowIndex % 2 === 0) ? 'even' : 'odd' }}"
-    {{
-        $attributes->merge($customAttributes)
+<tr {{
+        $customAttributes->merge()
                 ->class(['bg-white dark:bg-gray-700 dark:text-white rappasoft-striped-row' => ($isTailwind && ($customAttributes['default'] ?? true) && $rowIndex % 2 === 0)])
                 ->class(['bg-gray-50 dark:bg-gray-800 dark:text-white rappasoft-striped-row' => ($isTailwind && ($customAttributes['default'] ?? true) && $rowIndex % 2 !== 0)])
                 ->class(['cursor-pointer' => ($isTailwind && $this->hasTableRowUrl() && ($customAttributes['default'] ?? true))])
                 ->class(['bg-light rappasoft-striped-row' => ($isBootstrap && $rowIndex % 2 === 0 && ($customAttributes['default'] ?? true))])
                 ->class(['bg-white rappasoft-striped-row' => ($isBootstrap && $rowIndex % 2 !== 0 && ($customAttributes['default'] ?? true))])
                 ->except(['default','default-styling','default-colors'])
-    }}
-
->
+    }}>
     {{ $slot }}
 </tr>

--- a/resources/views/components/table/tr/bulk-actions.blade.php
+++ b/resources/views/components/table/tr/bulk-actions.blade.php
@@ -32,7 +32,7 @@
                                 'ml-1 underline text-sm leading-5 font-medium focus:outline-none focus:underline transition duration-150 ease-in-out' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true),
                                 'text-blue-600 text-gray-700 focus:text-gray-800 dark:text-white dark:hover:text-gray-400' => $this->isTailwind && ($this->getBulkActionsRowButtonAttributes['default-colors'] ?? true),
                                 'btn btn-primary btn-sm' => $this->isBootstrap && ($this->getBulkActionsRowButtonAttributes['default-styling'] ?? true)
-                            ])
+                            ])->except(['default','default-styling','default-colors'])
                         }}
                     >
                         {{ __($this->getLocalisationPath.'Deselect All') }}

--- a/resources/views/components/table/tr/plain.blade.php
+++ b/resources/views/components/table/tr/plain.blade.php
@@ -1,24 +1,12 @@
 @aware(['isTailwind','isBootstrap'])
 @props(['customAttributes' => [], 'displayMinimisedOnReorder' => true])
 
-@if ($isTailwind)
-    <tr {{ $attributes
-            ->merge($customAttributes)
-            ->class(['bg-white dark:bg-gray-700 dark:text-white' => $customAttributes['default'] ?? true])
-            ->class(['laravel-livewire-tables-reorderingMinimised'])
-            ->except(['default','default-styling','default-colors'])
-        }}
-    >
-        {{ $slot }}
-    </tr>
-@elseif ($isBootstrap)
-    <tr {{ $attributes
-            ->merge($customAttributes)
-            ->class(['' => $customAttributes['default'] ?? true])
-            ->class(['laravel-livewire-tables-reorderingMinimised'])
-            ->except(['default','default-styling','default-colors'])
-        }}
-    >
-        {{ $slot }}
-    </tr>
-@endif
+<tr {{ $attributes
+        ->merge($customAttributes)
+        ->class(['bg-white dark:bg-gray-700 dark:text-white' => $isTailwind && ($customAttributes['default'] ?? true)])
+        ->class(['laravel-livewire-tables-reorderingMinimised'])
+        ->except(['default','default-styling','default-colors'])
+    }}
+>
+    {{ $slot }}
+</tr>

--- a/src/Traits/Helpers/TableAttributeHelpers.php
+++ b/src/Traits/Helpers/TableAttributeHelpers.php
@@ -103,24 +103,21 @@ trait TableAttributeHelpers
     public function getTrAttributesBag(Model $row, int $index): ComponentAttributeBag
     {
         $default = [
-            'id' => $this->getTableName()."-row-".$row->{$this->getPrimaryKey()},
+            'id' => $this->getTableName().'-row-'.$row->{$this->getPrimaryKey()},
             'loopType' => $index % 2 === 0 ? 'even' : 'odd',
             'rowpk' => $row->{$this->getPrimaryKey()},
-            'x-on:dragstart.self' => "currentlyReorderingStatus && dragStart(event)",
-            'x-on:drop.prevent' => "currentlyReorderingStatus && dropEvent(event)",
-            'x-on:dragover.prevent.throttle.500ms' => "currentlyReorderingStatus && dragOverEvent(event)",
-            'x-on:dragleave.prevent.throttle.500ms' => "currentlyReorderingStatus && dragLeaveEvent(event)",
-            ':draggable' => "currentlyReorderingStatus",
-            'wire:key' => $this->getTableName()."-tablerow-tr-".$row->{$this->getPrimaryKey()},
+            'x-on:dragstart.self' => 'currentlyReorderingStatus && dragStart(event)',
+            'x-on:drop.prevent' => 'currentlyReorderingStatus && dropEvent(event)',
+            'x-on:dragover.prevent.throttle.500ms' => 'currentlyReorderingStatus && dragOverEvent(event)',
+            'x-on:dragleave.prevent.throttle.500ms' => 'currentlyReorderingStatus && dragLeaveEvent(event)',
+            ':draggable' => 'currentlyReorderingStatus',
+            'wire:key' => $this->getTableName().'-tablerow-tr-'.$row->{$this->getPrimaryKey()},
         ];
 
-        if($this->hasDisplayLoadingPlaceholder())
-        {
-            $default['wire:loading.class.add'] = "hidden d-none";
-        }
-        else
-        {
-            $default['wire:loading.class.delay'] = "opacity-50 dark:bg-gray-900 dark:opacity-60";
+        if ($this->hasDisplayLoadingPlaceholder()) {
+            $default['wire:loading.class.add'] = 'hidden d-none';
+        } else {
+            $default['wire:loading.class.delay'] = 'opacity-50 dark:bg-gray-900 dark:opacity-60';
         }
 
         return new ComponentAttributeBag(array_merge($default, $this->getTrAttributes($row, $index)));
@@ -135,27 +132,24 @@ trait TableAttributeHelpers
     #[Computed]
     public function getTdAttributesBag(Column $column, Model $row, int $colIndex, int $rowIndex): ComponentAttributeBag
     {
-        $default = [ 
-            'wire:key' => $this->getTableName() . '-table-td-'.$row->{$this->getPrimaryKey()}.'-'.$column->getSlug(),
+        $default = [
+            'wire:key' => $this->getTableName().'-table-td-'.$row->{$this->getPrimaryKey()}.'-'.$column->getSlug(),
             'default' => true,
             'default-colors' => true,
             'default-styling' => true,
         ];
-        if($column->isClickable())
-        {
-            if($this->getTableRowUrlTarget($row) === 'navigate') {
+        if ($column->isClickable()) {
+            if ($this->getTableRowUrlTarget($row) === 'navigate') {
                 $default['wire:navigate'] = '';
                 $default['href'] = $this->getTableRowUrl($row);
-            } 
-            else
-            {
+            } else {
                 $target = $this->getTableRowUrlTarget($row) ?? '_self';
                 $default['onclick'] = "window.open('".$this->getTableRowUrl($row)."', '".$target."')";
-            }    
+            }
         }
+
         return new ComponentAttributeBag(array_merge($default, $this->getTdAttributes($column, $row, $colIndex, $rowIndex)));
     }
-
 
     public function hasTableRowUrl(): bool
     {

--- a/src/Traits/Helpers/TableAttributeHelpers.php
+++ b/src/Traits/Helpers/TableAttributeHelpers.php
@@ -100,10 +100,62 @@ trait TableAttributeHelpers
     }
 
     #[Computed]
+    public function getTrAttributesBag(Model $row, int $index): ComponentAttributeBag
+    {
+        $default = [
+            'id' => $this->getTableName()."-row-".$row->{$this->getPrimaryKey()},
+            'loopType' => $index % 2 === 0 ? 'even' : 'odd',
+            'rowpk' => $row->{$this->getPrimaryKey()},
+            'x-on:dragstart.self' => "currentlyReorderingStatus && dragStart(event)",
+            'x-on:drop.prevent' => "currentlyReorderingStatus && dropEvent(event)",
+            'x-on:dragover.prevent.throttle.500ms' => "currentlyReorderingStatus && dragOverEvent(event)",
+            'x-on:dragleave.prevent.throttle.500ms' => "currentlyReorderingStatus && dragLeaveEvent(event)",
+            ':draggable' => "currentlyReorderingStatus",
+            'wire:key' => $this->getTableName()."-tablerow-tr-".$row->{$this->getPrimaryKey()},
+        ];
+
+        if($this->hasDisplayLoadingPlaceholder())
+        {
+            $default['wire:loading.class.add'] = "hidden d-none";
+        }
+        else
+        {
+            $default['wire:loading.class.delay'] = "opacity-50 dark:bg-gray-900 dark:opacity-60";
+        }
+
+        return new ComponentAttributeBag(array_merge($default, $this->getTrAttributes($row, $index)));
+    }
+
+    #[Computed]
     public function getTdAttributes(Column $column, Model $row, int $colIndex, int $rowIndex): array
     {
         return isset($this->tdAttributesCallback) ? call_user_func($this->tdAttributesCallback, $column, $row, $colIndex, $rowIndex) : ['default' => true];
     }
+
+    #[Computed]
+    public function getTdAttributesBag(Column $column, Model $row, int $colIndex, int $rowIndex): ComponentAttributeBag
+    {
+        $default = [ 
+            'wire:key' => $this->getTableName() . '-table-td-'.$row->{$this->getPrimaryKey()}.'-'.$column->getSlug(),
+            'default' => true,
+            'default-colors' => true,
+            'default-styling' => true,
+        ];
+        if($column->isClickable())
+        {
+            if($this->getTableRowUrlTarget($row) === 'navigate') {
+                $default['wire:navigate'] = '';
+                $default['href'] = $this->getTableRowUrl($row);
+            } 
+            else
+            {
+                $target = $this->getTableRowUrlTarget($row) ?? '_self';
+                $default['onclick'] = "window.open('".$this->getTableRowUrl($row)."', '".$target."')";
+            }    
+        }
+        return new ComponentAttributeBag(array_merge($default, $this->getTdAttributes($column, $row, $colIndex, $rowIndex)));
+    }
+
 
     public function hasTableRowUrl(): bool
     {

--- a/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
@@ -2,8 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
 
-use Illuminate\View\ComponentAttributeBag;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\View\ComponentAttributeBag;
 use Livewire\Attributes\Computed;
 
 trait BulkActionStylingHelpers
@@ -83,13 +83,14 @@ trait BulkActionStylingHelpers
     public function getBulkActionsTdAttributesNew(string $rowPrimaryKey): array
     {
         $default = [
-            'wire:key' => $this->getTableName() ."-tbody-td-bulk-actions-".$rowPrimaryKey,
-            ':displayMinimisedOnReorder' => "true",
+            'wire:key' => $this->getTableName().'-tbody-td-bulk-actions-'.$rowPrimaryKey,
+            ':displayMinimisedOnReorder' => 'true',
         ];
+
         return array_merge($default, $this->getBulkActionsTdAttributes());
     }
 
-        /**
+    /**
      * Used to get attributes for the Bulk Actions TD
      *
      * @return array<mixed>
@@ -99,7 +100,6 @@ trait BulkActionStylingHelpers
         return $this->getCustomAttributes('bulkActionsTdAttributes');
     }
 
-
     /**
      * Used to get attributes for the Bulk Actions TD
      *
@@ -107,7 +107,6 @@ trait BulkActionStylingHelpers
      */
     public function getBulkActionsTdCheckboxAttributes(): array
     {
-
 
         return $this->getCustomAttributes('bulkActionsTdCheckboxAttributes');
 
@@ -117,19 +116,18 @@ trait BulkActionStylingHelpers
     {
         $default = [
             'x-cloak' => '',
-            'x-show' => "!currentlyReorderingStatus",
-            'x-model' => "selectedItems",
-            'wire:key' => $this->getTableName()."-selectedItems-".$rowPrimaryKey,
-            'id' => $this->getTableName()."-row-bac-".$rowPrimaryKey,
+            'x-show' => '!currentlyReorderingStatus',
+            'x-model' => 'selectedItems',
+            'wire:key' => $this->getTableName().'-selectedItems-'.$rowPrimaryKey,
+            'id' => $this->getTableName().'-row-bac-'.$rowPrimaryKey,
             'value' => $rowPrimaryKey,
-            'wire:loading.attr.delay' => "disabled",
-            'type' => "checkbox",
+            'wire:loading.attr.delay' => 'disabled',
+            'type' => 'checkbox',
         ];
 
         return array_merge($default, $this->getBulkActionsTdCheckboxAttributes());
 
     }
-
 
     /**
      * Used to get attributes for the Bulk Actions Row Buttons

--- a/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/BulkActionStylingHelpers.php
@@ -3,6 +3,7 @@
 namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
 
 use Illuminate\View\ComponentAttributeBag;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Computed;
 
 trait BulkActionStylingHelpers
@@ -79,10 +80,25 @@ trait BulkActionStylingHelpers
      *
      * @return array<mixed>
      */
+    public function getBulkActionsTdAttributesNew(string $rowPrimaryKey): array
+    {
+        $default = [
+            'wire:key' => $this->getTableName() ."-tbody-td-bulk-actions-".$rowPrimaryKey,
+            ':displayMinimisedOnReorder' => "true",
+        ];
+        return array_merge($default, $this->getBulkActionsTdAttributes());
+    }
+
+        /**
+     * Used to get attributes for the Bulk Actions TD
+     *
+     * @return array<mixed>
+     */
     public function getBulkActionsTdAttributes(): array
     {
         return $this->getCustomAttributes('bulkActionsTdAttributes');
     }
+
 
     /**
      * Used to get attributes for the Bulk Actions TD
@@ -91,9 +107,29 @@ trait BulkActionStylingHelpers
      */
     public function getBulkActionsTdCheckboxAttributes(): array
     {
+
+
         return $this->getCustomAttributes('bulkActionsTdCheckboxAttributes');
 
     }
+
+    public function getBulkActionsTdCheckboxAttributesNew(string $rowPrimaryKey): array
+    {
+        $default = [
+            'x-cloak' => '',
+            'x-show' => "!currentlyReorderingStatus",
+            'x-model' => "selectedItems",
+            'wire:key' => $this->getTableName()."-selectedItems-".$rowPrimaryKey,
+            'id' => $this->getTableName()."-row-bac-".$rowPrimaryKey,
+            'value' => $rowPrimaryKey,
+            'wire:loading.attr.delay' => "disabled",
+            'type' => "checkbox",
+        ];
+
+        return array_merge($default, $this->getBulkActionsTdCheckboxAttributes());
+
+    }
+
 
     /**
      * Used to get attributes for the Bulk Actions Row Buttons

--- a/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
@@ -145,11 +145,11 @@ final class BulkActionsStylingConfigurationTest extends TestCase
             'value' => '5',
             'wire:loading.attr.delay' => 'disabled',
             'type' => 'checkbox',
-            'default' => true, 
-            'default-colors' => false, 
-            'default-styling' => false
-        ], 
-        $this->basicTable->getBulkActionsTdCheckboxAttributesNew(5));
+            'default' => true,
+            'default-colors' => false,
+            'default-styling' => false,
+        ],
+            $this->basicTable->getBulkActionsTdCheckboxAttributesNew(5));
 
         $this->assertSame([
             'x-cloak' => '',
@@ -160,36 +160,33 @@ final class BulkActionsStylingConfigurationTest extends TestCase
             'value' => '14',
             'wire:loading.attr.delay' => 'disabled',
             'type' => 'checkbox',
-            'default' => true, 
-            'default-colors' => false, 
-            'default-styling' => false
-        ], 
-        $this->basicTable->getBulkActionsTdCheckboxAttributesNew(14));
+            'default' => true,
+            'default-colors' => false,
+            'default-styling' => false,
+        ],
+            $this->basicTable->getBulkActionsTdCheckboxAttributesNew(14));
 
     }
-
 
     public function test_can_set_bulk_actions_td_attributes(): void
     {
         $this->assertSame([
             'wire:key' => 'table-tbody-td-bulk-actions-5',
             ':displayMinimisedOnReorder' => 'true',
-            'default' => true, 
-            'default-colors' => false, 
-            'default-styling' => false
-        ], 
-        $this->basicTable->getBulkActionsTdAttributesNew(5));
+            'default' => true,
+            'default-colors' => false,
+            'default-styling' => false,
+        ],
+            $this->basicTable->getBulkActionsTdAttributesNew(5));
 
         $this->assertSame([
             'wire:key' => 'table-tbody-td-bulk-actions-14',
             ':displayMinimisedOnReorder' => 'true',
-            'default' => true, 
-            'default-colors' => false, 
-            'default-styling' => false
-        ], 
-        $this->basicTable->getBulkActionsTdAttributesNew(14));
+            'default' => true,
+            'default-colors' => false,
+            'default-styling' => false,
+        ],
+            $this->basicTable->getBulkActionsTdAttributesNew(14));
 
     }
-
-
 }

--- a/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
@@ -133,4 +133,63 @@ final class BulkActionsStylingConfigurationTest extends TestCase
     {
         $this->assertSame(['default' => true, 'default-colors' => false, 'default-styling' => false], $this->basicTable->getBulkActionsThCheckboxAttributes());
     }
+
+    public function test_can_set_bulk_actions_checkbox_attributes(): void
+    {
+        $this->assertSame([
+            'x-cloak' => '',
+            'x-show' => '!currentlyReorderingStatus',
+            'x-model' => 'selectedItems',
+            'wire:key' => 'table-selectedItems-5',
+            'id' => 'table-row-bac-5',
+            'value' => '5',
+            'wire:loading.attr.delay' => 'disabled',
+            'type' => 'checkbox',
+            'default' => true, 
+            'default-colors' => false, 
+            'default-styling' => false
+        ], 
+        $this->basicTable->getBulkActionsTdCheckboxAttributesNew(5));
+
+        $this->assertSame([
+            'x-cloak' => '',
+            'x-show' => '!currentlyReorderingStatus',
+            'x-model' => 'selectedItems',
+            'wire:key' => 'table-selectedItems-14',
+            'id' => 'table-row-bac-14',
+            'value' => '14',
+            'wire:loading.attr.delay' => 'disabled',
+            'type' => 'checkbox',
+            'default' => true, 
+            'default-colors' => false, 
+            'default-styling' => false
+        ], 
+        $this->basicTable->getBulkActionsTdCheckboxAttributesNew(14));
+
+    }
+
+
+    public function test_can_set_bulk_actions_td_attributes(): void
+    {
+        $this->assertSame([
+            'wire:key' => 'table-tbody-td-bulk-actions-5',
+            ':displayMinimisedOnReorder' => 'true',
+            'default' => true, 
+            'default-colors' => false, 
+            'default-styling' => false
+        ], 
+        $this->basicTable->getBulkActionsTdAttributesNew(5));
+
+        $this->assertSame([
+            'wire:key' => 'table-tbody-td-bulk-actions-14',
+            ':displayMinimisedOnReorder' => 'true',
+            'default' => true, 
+            'default-colors' => false, 
+            'default-styling' => false
+        ], 
+        $this->basicTable->getBulkActionsTdAttributesNew(14));
+
+    }
+
+
 }


### PR DESCRIPTION
This PR:
- Starts to remove non-class attributes from the views/blades, and migrates them to the core-code.
- Merges where there's superfluous bootstrap/tailwind duplication of view code

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
