### PR TITLE
Ensure filters available in builder

### DIFF
--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -126,7 +126,7 @@ class MakeCommand extends Command implements PromptsForMissingInput
         if (isset($this->modelPath)) {
             $filename = rtrim($this->modelPath, '/').'/'.$this->model.'.php';
             if (File::exists($filename)) {
-                //In case the file has more than one class which is highly unlikely but still possible
+                // In case the file has more than one class which is highly unlikely but still possible
                 $classes = array_filter($this->getClassesList($filename), function ($class) {
                     return substr($class, strrpos($class, '\\') + 1) == $this->model;
                 });

--- a/src/Traits/HasAllTraits.php
+++ b/src/Traits/HasAllTraits.php
@@ -12,7 +12,8 @@ trait HasAllTraits
     use HasLocalisations;
     use WithLoadingPlaceholder;
     use HasTheme;
-    use WithQuery,
+    use WithFilters,
+        WithQuery,
         ComponentUtilities,
         WithActions,
         WithData,
@@ -29,7 +30,6 @@ trait HasAllTraits
         WithCustomisations,
         WithDebugging,
         WithEvents,
-        WithFilters,
         WithFooter,
         WithRefresh,
         WithReordering,

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -21,7 +21,7 @@ trait WithData
      */
     public function bootedWithData(): void
     {
-        //Sets up the Builder Instance
+        // Sets up the Builder Instance
         $this->setBuilder($this->builder());
     }
 

--- a/src/Traits/WithReordering.php
+++ b/src/Traits/WithReordering.php
@@ -51,7 +51,7 @@ trait WithReordering
 
     public function enableReordering(): void
     {
-        //$this->enablePaginatedReordering();
+        // $this->enablePaginatedReordering();
 
         $this->setReorderingSession();
         $this->setReorderingBackup();

--- a/src/Views/Traits/Filters/HasCustomPosition.php
+++ b/src/Views/Traits/Filters/HasCustomPosition.php
@@ -67,7 +67,7 @@ trait HasCustomPosition
 
     public function setFilterSlidedownRow(string $filterSlidedownRow): self
     {
-        //$this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
+        // $this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
         $this->filterSlidedownRow = intval($filterSlidedownRow);
 
         return $this;
@@ -75,7 +75,7 @@ trait HasCustomPosition
 
     public function setFilterSlidedownColspan(string $filterSlidedownColspan): self
     {
-        //$this->filterSlidedownColspan = (is_int($filterSlidedownColspan) ? $filterSlidedownColspan : intval($filterSlidedownColspan));
+        // $this->filterSlidedownColspan = (is_int($filterSlidedownColspan) ? $filterSlidedownColspan : intval($filterSlidedownColspan));
         $this->filterSlidedownColspan = intval($filterSlidedownColspan);
 
         return $this;

--- a/tests/Localisations/BaseLocalisationCase.php
+++ b/tests/Localisations/BaseLocalisationCase.php
@@ -57,10 +57,10 @@ class BaseLocalisationCase extends TestCase
             'tw',
             'uk',
         ];
-        //return $availableLocales;
+        // return $availableLocales;
 
         foreach ($availableLocales as $availableLocale) {
-            //$array = require($baseDir.$availableLocale.'/core.php');
+            // $array = require($baseDir.$availableLocale.'/core.php');
             $localisations[] = [
                 'locale' => $availableLocale,
                 //      'localisationStrings' => $array,

--- a/tests/Unit/Traits/Helpers/ColumnHelpersTest.php
+++ b/tests/Unit/Traits/Helpers/ColumnHelpersTest.php
@@ -205,7 +205,7 @@ final class ColumnHelpersTest extends TestCase
         $this->assertSame(7, $this->basicTable->getVisibleTabletColumnsCount());
     }
 
-    /// *** ** //
+    // / *** ** //
 
     public function test_can_tell_if_columns_should_collapse_always(): void
     {
@@ -299,7 +299,7 @@ final class ColumnHelpersTest extends TestCase
         $this->assertTrue($column->hasSecondaryHeaderCallback());
 
         $contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey($column->getSecondaryHeaderCallback()), $this->basicTable->getFilterGenericData());
-        //$contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey('breed'));
+        // $contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey('breed'));
         $this->assertStringContainsString('id="table-filter-breed-8-header"', $contents);
     }
 

--- a/tests/Unit/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Unit/Traits/Helpers/ComponentHelpersTest.php
@@ -244,7 +244,7 @@ final class ComponentHelpersTest extends TestCase
 
     // Exists in DataTableComponentTest
     // public function test_can_get_dataTable_fingerprint(): void
-    //{
+    // {
     //     $this->assertSame($this->defaultFingerPrintingAlgo($this->basicTable::class), $this->basicTable->getDataTableFingerprint());
     // }
 

--- a/tests/Unit/Views/Columns/DateColumnTest.php
+++ b/tests/Unit/Views/Columns/DateColumnTest.php
@@ -2,7 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Views\Columns;
 
-//use Illuminate\Support\Facades\Exceptions;
+// use Illuminate\Support\Facades\Exceptions;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;

--- a/tests/Unit/Views/Columns/IconColumnTest.php
+++ b/tests/Unit/Views/Columns/IconColumnTest.php
@@ -2,7 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Views\Columns;
 
-//use Illuminate\Support\Facades\Exceptions;
+// use Illuminate\Support\Facades\Exceptions;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 use Rappasoft\LaravelLivewireTables\Views\Columns\IconColumn;


### PR DESCRIPTION
This fix ensures that the "filters" and values are available in builder() on initial boot.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
