### PR TITLE
TH Fixes - Clean-up, efficiency, and Sort Icons fixes

### DIFF
--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -7,66 +7,52 @@
     $customLabelAttributes = $allThAttributes['labelAttributes'];
     $customIconAttributes = $this->getThSortIconAttributes($column);
     $direction = $column->hasField() ? $this->getSort($column->getColumnSelectName()) : $this->getSort($column->getSlug()) ?? null;
-
 @endphp
 
-@if ($this->isTailwind)
-    <th scope="col" {{
-        $attributes->merge($customThAttributes)
-            ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
-            ->class(['px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true))])
-            ->class(['hidden' => $column->shouldCollapseAlways()])
-            ->class(['hidden md:table-cell' => $column->shouldCollapseOnMobile()])
-            ->class(['hidden lg:table-cell' => $column->shouldCollapseOnTablet()])
-            ->except(['default', 'default-colors', 'default-styling'])
-        }}
-    >
-        @if($column->getColumnLabelStatus())
-            @unless ($this->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
-                <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-            @else
-                <button wire:click="sortBy('{{ $column->getColumnSortKey() }}')"
-                    {{
+<th {{
+    $attributes->merge($customThAttributes)
+        ->class([
+            'text-gray-500 dark:bg-gray-800 dark:text-gray-400' => $this->isTailwind && (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true)),
+            'px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => $this->isTailwind && (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true)),
+            'hidden' => $this->isTailwind && $column->shouldCollapseAlways(),
+            'hidden md:table-cell' => $this->isTailwind && $column->shouldCollapseOnMobile(),
+            'hidden lg:table-cell' => $this->isTailwind && $column->shouldCollapseOnTablet(),
+            '' => $this->isBootstrap && ($customThAttributes['default'] ?? true),
+            'd-none' => $this->isBootstrap && $column->shouldCollapseAlways(),
+            'd-none d-md-table-cell' => $this->isBootstrap && $column->shouldCollapseOnMobile(),
+            'd-none d-lg-table-cell' => $this->isBootstrap && $column->shouldCollapseOnTablet(),
+        ])
+        ->except(['default', 'default-colors', 'default-styling'])
+}}>
+    @if($column->getColumnLabelStatus())
+        @unless ($this->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
+            <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
+        @else
+            @if ($this->isTailwind)
+
+                <button wire:click="sortBy('{{ $column->getColumnSortKey() }}')" {{
                         $attributes->merge($customSortButtonAttributes)
-                            ->class(['text-gray-500 dark:text-gray-400' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
-                            ->class(['flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
+                            ->class([
+                                'text-gray-500 dark:text-gray-400' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true)),
+                                'flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true)),
+                            ])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                >
+                }}>
                     <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
                     <x-livewire-tables::table.th.sort-icons :$direction :$customIconAttributes />
                 </button>
-            @endunless
-        @endif
-    </th>
-@elseif ($this->isBootstrap)
-    <th scope="col" {{
-        $attributes->merge($customThAttributes)
-            ->class(['' => $customThAttributes['default'] ?? true])
-            ->class(['d-none' => $column->shouldCollapseAlways()])
-            ->class(['d-none d-md-table-cell' => $column->shouldCollapseOnMobile()])
-            ->class(['d-none d-lg-table-cell' => $column->shouldCollapseOnTablet()])
-            ->except(['default','default-styling','default-colors'])
-        }}
-    >
-        @if($column->getColumnLabelStatus())
-            @unless ($this->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
-                <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-            @else
-                <div
-                    class="d-flex align-items-center laravel-livewire-tables-cursor"
-                    wire:click="sortBy('{{ $column->getColumnSortKey() }}')"
-                    {{
+            @elseif ($this->isBootstrap)
+                <div wire:click="sortBy('{{ $column->getColumnSortKey() }}')" {{
                         $attributes->merge($customSortButtonAttributes)
-                            ->class(['' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
+                            ->class(['d-flex align-items-center laravel-livewire-tables-cursor' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                >
+                }}>
                     <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
                     <x-livewire-tables::table.th.sort-icons :$direction :$customIconAttributes />
 
                 </div>
-            @endunless
-        @endif
-    </th>
-@endif
+            @endif
+
+        @endunless
+    @endif
+</th>

--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -26,7 +26,7 @@
 }}>
     @if($column->getColumnLabelStatus())
         @unless ($this->sortingIsEnabled() && ($column->isSortable() || $column->getSortCallback()))
-            <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
+            <x-livewire-tables::table.th.label :$customLabelAttributes :columnTitle="$column->getTitle()" />
         @else
             @if ($this->isTailwind)
 
@@ -38,7 +38,7 @@
                             ])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
                 }}>
-                    <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
+                    <x-livewire-tables::table.th.label :$customLabelAttributes :columnTitle="$column->getTitle()" />
                     <x-livewire-tables::table.th.sort-icons :$direction :$customIconAttributes />
                 </button>
             @elseif ($this->isBootstrap)
@@ -47,7 +47,7 @@
                             ->class(['d-flex align-items-center laravel-livewire-tables-cursor' => (($customSortButtonAttributes['default-styling'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
                             ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
                 }}>
-                    <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
+                    <x-livewire-tables::table.th.label :$customLabelAttributes :columnTitle="$column->getTitle()" />
                     <x-livewire-tables::table.th.sort-icons :$direction :$customIconAttributes />
 
                 </div>

--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -1,23 +1,15 @@
-@aware([ 'tableName','isTailwind','isBootstrap'])
 @props(['column', 'index'])
 
 @php
-    $attributes = $attributes->merge(['wire:key' => $tableName . '-header-col-'.$column->getSlug()]);
     $allThAttributes = $this->getAllThAttributes($column);
-
     $customThAttributes = $allThAttributes['customAttributes'];
     $customSortButtonAttributes = $allThAttributes['sortButtonAttributes'];
-    $customSortIconAttributes = $allThAttributes['sortIconAttributes'];
     $customLabelAttributes = $allThAttributes['labelAttributes'];
+    $direction = $column->hasField() ? $this->getSort($column->getColumnSelectName()) : $this->getSort($column->getSlug()) ?? null;
 
-    //$customThAttributes = $this->getThAttributes($column);
-    //$customSortButtonAttributes = $this->getThSortButtonAttributes($column);
-    //$customSortIconAttributes = $this->getThSortIconAttributes($column);
-
-    $direction = $column->hasField() ? $this->getSort($column->getColumnSelectName()) : $this->getSort($column->getSlug()) ?? null ;
 @endphp
 
-@if ($isTailwind)
+@if ($this->isTailwind)
     <th scope="col" {{
         $attributes->merge($customThAttributes)
             ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
@@ -41,18 +33,12 @@
                     }}
                 >
                     <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-                    <x-livewire-tables::table.th.sort-icons :$direction
-                    {{
-                        $attributes->merge($customSortIconAttributes)
-                            ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                    />
-
+                    <x-livewire-tables::table.th.sort-icons :$direction  />
                 </button>
             @endunless
         @endif
     </th>
-@elseif ($isBootstrap)
+@elseif ($this->isBootstrap)
     <th scope="col" {{
         $attributes->merge($customThAttributes)
             ->class(['' => $customThAttributes['default'] ?? true])
@@ -76,13 +62,8 @@
                     }}
                 >
                     <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
+                    <x-livewire-tables::table.th.sort-icons :$direction  />
 
-                    <x-livewire-tables::table.th.sort-icons :$direction                     {{
-                        $attributes->merge($customSortButtonAttributes)
-                            ->class(['' => (($customSortButtonAttributes['default-colors'] ?? true) || ($customSortButtonAttributes['default'] ?? true))])
-                            ->except(['default', 'default-colors', 'default-styling', 'wire:key'])
-                    }}
-                />
                 </div>
             @endunless
         @endif

--- a/resources/views/components/table/th.blade.php
+++ b/resources/views/components/table/th.blade.php
@@ -5,6 +5,7 @@
     $customThAttributes = $allThAttributes['customAttributes'];
     $customSortButtonAttributes = $allThAttributes['sortButtonAttributes'];
     $customLabelAttributes = $allThAttributes['labelAttributes'];
+    $customIconAttributes = $this->getThSortIconAttributes($column);
     $direction = $column->hasField() ? $this->getSort($column->getColumnSelectName()) : $this->getSort($column->getSlug()) ?? null;
 
 @endphp
@@ -33,7 +34,7 @@
                     }}
                 >
                     <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-                    <x-livewire-tables::table.th.sort-icons :$direction  />
+                    <x-livewire-tables::table.th.sort-icons :$direction :$customIconAttributes />
                 </button>
             @endunless
         @endif
@@ -62,7 +63,7 @@
                     }}
                 >
                     <span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>{{ $column->getTitle() }}</span>
-                    <x-livewire-tables::table.th.sort-icons :$direction  />
+                    <x-livewire-tables::table.th.sort-icons :$direction :$customIconAttributes />
 
                 </div>
             @endunless

--- a/resources/views/components/table/th/bulk-actions.blade.php
+++ b/resources/views/components/table/th/bulk-actions.blade.php
@@ -1,20 +1,17 @@
-@aware([ 'tableName'])
 @php
     $customAttributes = $this->hasBulkActionsThAttributes ? $this->getBulkActionsThAttributes : $this->getAllThAttributes($this->getBulkActionsColumn())['customAttributes'];
-
     $bulkActionsThCheckboxAttributes = $this->getBulkActionsThCheckboxAttributes();
-    $theme = $this->getTheme();
 @endphp
 
 @if ($this->bulkActionsAreEnabled() && $this->hasBulkActions())
-    <x-livewire-tables::table.th.plain wire:key="{{ $tableName }}-thead-bulk-actions" :displayMinimisedOnReorder="true" :$customAttributes>
+    <x-livewire-tables::table.th.plain  :displayMinimisedOnReorder="true" wire:key="{{ $this->getTableName }}-thead-bulk-actions" :$customAttributes>
         <div
             x-data="{newSelectCount: 0, indeterminateCheckbox: false, bulkActionHeaderChecked: false}"
             x-init="$watch('selectedItems', value => indeterminateCheckbox = (value.length > 0 && value.length < paginationTotalItemCount))"
             x-cloak x-show="currentlyReorderingStatus !== true"
             @class([
-                'inline-flex rounded-md shadow-sm' => $theme === 'tailwind',
-                'form-check' => $theme === 'bootstrap-5',
+                'inline-flex rounded-md shadow-sm' => $this->isTailwind,
+                'form-check' => $this->isBootstrap,
             ])
         >
             <input
@@ -24,8 +21,9 @@
                 :checked="selectedItems.length == paginationTotalItemCount"
                 {{
                     $attributes->merge($bulkActionsThCheckboxAttributes)->class([
-                        'rounded border-gray-300 text-indigo-600 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => ($theme === 'tailwind') && ($bulkActionsThCheckboxAttributes['default'] ?? true),
-                        'form-check-input' => ($theme === 'bootstrap-5') && ($bulkActionsThCheckboxAttributes['default'] ?? true),
+                        'border-gray-300 text-indigo-600 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => $this->isTailwind && (($bulkActionsThCheckboxAttributes['default'] ?? true) || ($bulkActionsThCheckboxAttributes['default-colors'] ?? true)),
+                        'rounded shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 ' => $this->isTailwind && (($bulkActionsThCheckboxAttributes['default'] ?? true) || ($bulkActionsThCheckboxAttributes['default-styling'] ?? true)),
+                        'form-check-input' => $this->isBootstrap && ($bulkActionsThCheckboxAttributes['default'] ?? true),
                     ])->except(['default','default-styling','default-colors'])
                 }}
             />

--- a/resources/views/components/table/th/collapsed-columns.blade.php
+++ b/resources/views/components/table/th/collapsed-columns.blade.php
@@ -1,29 +1,15 @@
-@aware([ 'tableName','isTailwind','isBootstrap'])
-
-@if ($this->collapsingColumnsAreEnabled() && $this->hasCollapsedColumns())
-    @if ($isTailwind)
-        <th
-            scope="col"
-            {{
-                $attributes
-                    ->merge(['class' => 'table-cell dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised'])
-                    ->class(['sm:hidden' => !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['md:hidden' => !$this->shouldCollapseOnMobile() && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['lg:hidden' => !$this->shouldCollapseAlways()])
-            }}
-            :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }"
-        ></th>
-    @elseif ($isBootstrap)
-        <th
-            scope="col"
-            {{
-                $attributes
-                    ->merge(['class' => 'd-table-cell laravel-livewire-tables-reorderingMinimised'])
-                    ->class(['d-sm-none' => !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['d-md-none' => !$this->shouldCollapseOnMobile() && !$this->shouldCollapseOnTablet() && !$this->shouldCollapseAlways()])
-                    ->class(['d-lg-none' => !$this->shouldCollapseAlways()])
-            }}                    
-            :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }"
-        ></th>
-    @endif
+@if ($this->collapsingColumnsAreEnabled && $this->hasCollapsedColumns)
+    <th scope="col" :class="{ 'laravel-livewire-tables-reorderingMinimised': ! currentlyReorderingStatus }" {{
+        $attributes->merge()
+            ->class([
+                'table-cell dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised' => $this->isTailwind,
+                'sm:hidden' => $this->isTailwind && !$this->shouldCollapseOnTablet && !$this->shouldCollapseAlways,
+                'md:hidden' => $this->isTailwind && !$this->shouldCollapseOnMobile && !$this->shouldCollapseOnTablet && !$this->shouldCollapseAlways,
+                'lg:hidden' => $this->isTailwind && !$this->shouldCollapseAlways,
+                'd-table-cell laravel-livewire-tables-reorderingMinimised' => $this->isBootstrap,
+                'd-sm-none' => $this->isBootstrap && !$this->shouldCollapseOnTablet && !$this->shouldCollapseAlways,
+                'd-md-none' => $this->isBootstrap && !$this->shouldCollapseOnMobile && !$this->shouldCollapseOnTablet && !$this->shouldCollapseAlways,
+                'd-lg-none' => $this->isBootstrap && !$this->shouldCollapseAlways,
+            ])
+        }}></th>
 @endif

--- a/resources/views/components/table/th/label.blade.php
+++ b/resources/views/components/table/th/label.blade.php
@@ -1,0 +1,4 @@
+@props(['columnTitle' => '', 'customLabelAttributes' => ['default' => true]])
+<span {{ $customLabelAttributes->except(['default', 'default-colors', 'default-styling']) }}>
+    {{ $columnTitle }}
+</span>

--- a/resources/views/components/table/th/plain.blade.php
+++ b/resources/views/components/table/th/plain.blade.php
@@ -1,14 +1,11 @@
-@aware(['isTailwind','isBootstrap'])
 @props(['displayMinimisedOnReorder' => false, 'hideUntilReorder' => false, 'customAttributes' => ['default' => true]])
 
-<th x-cloak {{ $attributes }} scope="col"
-    {{ 
+<th x-cloak scope="col" @if($hideUntilReorder) :class="!reorderDisplayColumn && 'w-0 p-0 hidden'" @endif {{ 
         $attributes->merge($customAttributes)->class([
-            'table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left bg-gray-50 dark:bg-gray-800 laravel-livewire-tables-reorderingMinimised' => ($isTailwind) && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
-            'laravel-livewire-tables-reorderingMinimised' => ($isBootstrap) && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
-        ])
-    }}
-    @if($hideUntilReorder) :class="!reorderDisplayColumn && 'w-0 p-0 hidden'" @endif
->
+            'table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left laravel-livewire-tables-reorderingMinimised' => $this->isTailwind && (($customAttributes['default-styling'] ?? true) || ($customAttributes['default'] ?? true)),
+            'bg-gray-50 dark:bg-gray-800' => $this->isTailwind && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
+            'laravel-livewire-tables-reorderingMinimised' => $this->isBootstrap && (($customAttributes['default-colors'] ?? true) || ($customAttributes['default'] ?? true)),
+        ])->except(['default','default-styling','default-colors'])
+}}>
     {{ $slot }}
 </th>

--- a/resources/views/components/table/th/reorder.blade.php
+++ b/resources/views/components/table/th/reorder.blade.php
@@ -1,14 +1,16 @@
-@aware(['tableName','isTailwind','isBootstrap'])
 @php
     $customThAttributes = $this->hasReorderThAttributes() ? $this->getReorderThAttributes() : $this->getAllThAttributes($this->getReorderColumn())['customAttributes'];
 @endphp
 
-<x-livewire-tables::table.th.plain x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $tableName }}-thead-reorder" :displayMinimisedOnReorder="false" 
+<x-livewire-tables::table.th.plain x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $this->getTableName }}-thead-reorder" :displayMinimisedOnReorder="false" 
     {{ 
         $attributes->merge($customThAttributes)
-            ->class(['text-gray-500 dark:bg-gray-800 dark:text-gray-400' => (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true))])
-            ->class(['table-cell px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true))])
-            ->class(['laravel-livewire-tables-reorderingMinimised' => ($isBootstrap) && ($customThAttributes['default'] ?? true)])
+            ->class([
+                'table-cell px-6 py-3 text-left text-xs font-medium whitespace-nowrap uppercase tracking-wider' => $this->isTailwind && (($customThAttributes['default-styling'] ?? true) || ($customThAttributes['default'] ?? true)),
+                'text-gray-500 dark:bg-gray-800 dark:text-gray-400' => $this->isTailwind && (($customThAttributes['default-colors'] ?? true) || ($customThAttributes['default'] ?? true)),
+                'laravel-livewire-tables-reorderingMinimised' => $this->isBootstrap && ($customThAttributes['default'] ?? true),
+            ])
+            ->except(['default','default-styling','default-colors'])
     }}
 >
     <div x-cloak x-show="currentlyReorderingStatus"></div>

--- a/resources/views/components/table/th/sort-icons.blade.php
+++ b/resources/views/components/table/th/sort-icons.blade.php
@@ -1,32 +1,83 @@
-@props(['direction'])
-<span {{ $attributes->class([
+@props(['direction' => 'none'])
+@aware(['column'])
+<span @class([
         'relative flex items-center' => $this->isTailwind,
         'relative d-flex align-items-center' => $this->isBootstrap
-    ]) }}
+    ])
 >
+@php
+$customIconAttributes = $this->getThSortIconAttributes($column)
+@endphp
+
     @if($this->isTailwind)
         @switch($direction)
             @case('asc')
-                <x-heroicon-o-chevron-up class="w-3 h-3 group-hover:opacity-0" />
-                <x-heroicon-o-chevron-down class="w-3 h-3 opacity-0 group-hover:opacity-100 absolute"/>
-                @break
+                <x-heroicon-o-chevron-up {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'w-3 h-3' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                        'absolute opacity-100 group-hover:opacity-0',
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }} />
+                <x-heroicon-o-chevron-down {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'w-3 h-3' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                        'absolute opacity-0 group-hover:opacity-100',
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }}  />
+            @break
             @case('desc')
-                <x-heroicon-o-chevron-down class="w-3 h-3 group-hover:opacity-0" />
-                <x-heroicon-o-x-circle class="w-3 h-3 opacity-0 group-hover:opacity-100 absolute"/>
-                @break
+                <x-heroicon-o-chevron-down {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'w-3 h-3' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                        'absolute opacity-100 group-hover:opacity-0',
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }}   />
+                <x-heroicon-o-x-circle  {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'w-3 h-3' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                        'absolute opacity-0 group-hover:opacity-100',
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }}  />
+
+            @break
             @default
-                <x-heroicon-o-chevron-up class="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-        @endswitch
+                <x-heroicon-o-chevron-up-down {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'w-3 h-3' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                        'absolute opacity-100 group-hover:opacity-0',
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key'])  }}  />
+                <x-heroicon-o-chevron-up {{ $attributes->merge($this->getThSortIconAttributes($column))
+                    ->class([
+                        'w-3 h-3' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                        'absolute opacity-0 group-hover:opacity-100',
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }} />
+            @endswitch
+
+
     @else
         @switch($direction)
             @case('asc')
-                <x-heroicon-o-chevron-up class="laravel-livewire-tables-btn-smaller ms-1 "  />
+                <x-heroicon-o-chevron-up {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'laravel-livewire-tables-btn-smaller ms-1 ' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }} />
                 @break
             @case('desc')
-                <x-heroicon-o-chevron-down class="laravel-livewire-tables-btn-smaller ms-1"  />
+                <x-heroicon-o-chevron-down {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'laravel-livewire-tables-btn-smaller ms-1' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }}  />
             @break
             @default
-                <x-heroicon-o-chevron-up-down class="laravel-livewire-tables-btn-smaller ms-1" />
+                <x-heroicon-o-chevron-up-down {{ $attributes->merge($customIconAttributes)
+                    ->class([
+                        'laravel-livewire-tables-btn-smaller ms-1' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                    ])
+                    ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }}  />
         @endswitch
     @endif
 </span>

--- a/resources/views/components/table/th/sort-icons.blade.php
+++ b/resources/views/components/table/th/sort-icons.blade.php
@@ -1,5 +1,4 @@
 @props(['direction' => 'none', 'customIconAttributes'])
-@aware(['column'])
 <span @class([
         'relative flex items-center' => $this->isTailwind,
         'relative d-flex align-items-center' => $this->isBootstrap
@@ -44,7 +43,7 @@
                         'absolute opacity-100 group-hover:opacity-0',
                     ])
                     ->except(['default', 'default-colors', 'default-styling', 'wire:key'])  }}  />
-                <x-heroicon-o-chevron-up {{ $attributes->merge($this->getThSortIconAttributes($column))
+                <x-heroicon-o-chevron-up {{ $attributes->merge($customIconAttributes)
                     ->class([
                         'w-3 h-3' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
                         'absolute opacity-0 group-hover:opacity-100',

--- a/resources/views/components/table/th/sort-icons.blade.php
+++ b/resources/views/components/table/th/sort-icons.blade.php
@@ -1,13 +1,10 @@
-@props(['direction' => 'none'])
+@props(['direction' => 'none', 'customIconAttributes'])
 @aware(['column'])
 <span @class([
         'relative flex items-center' => $this->isTailwind,
         'relative d-flex align-items-center' => $this->isBootstrap
     ])
 >
-@php
-$customIconAttributes = $this->getThSortIconAttributes($column)
-@endphp
 
     @if($this->isTailwind)
         @switch($direction)

--- a/resources/views/components/table/th/sort-icons.blade.php
+++ b/resources/views/components/table/th/sort-icons.blade.php
@@ -58,7 +58,7 @@
             @case('asc')
                 <x-heroicon-o-chevron-up {{ $attributes->merge($customIconAttributes)
                     ->class([
-                        'laravel-livewire-tables-btn-smaller ms-1 ' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
+                        'laravel-livewire-tables-btn-smaller ms-1' => $customIconAttributes['default-styling'] ?? ($customIconAttributes['default'] ?? true),
                     ])
                     ->except(['default', 'default-colors', 'default-styling', 'wire:key']) }} />
                 @break

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -68,7 +68,7 @@
                     @endif
 
                     @foreach($this->selectedVisibleColumns as $index => $column)
-                        <x-livewire-tables::table.th wire:key="{{ $tableName.'-table-head-'.$index }}" :column="$column" :index="$index" />
+                        <x-livewire-tables::table.th wire:key="{{ $tableName.'-table-head-'.$index }}" :$column :$index />
                     @endforeach
                 </x-slot>
 
@@ -84,19 +84,19 @@
                 @endif
 
                 @forelse ($this->getRows as $rowIndex => $row)
-                    <x-livewire-tables::table.tr wire:key="{{ $tableName }}-row-wrap-{{ $row->{$primaryKey} }}" :row="$row" :rowIndex="$rowIndex">
+                    <x-livewire-tables::table.tr wire:key="{{ $tableName }}-row-wrap-{{ $row->{$primaryKey} }}" :$row :$rowIndex>
                         @if($this->getCurrentlyReorderingStatus)
-                            <x-livewire-tables::table.td.reorder x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $tableName }}-row-reorder-{{ $row->{$primaryKey} }}" :rowID="$tableName.'-'.$row->{$this->getPrimaryKey()}" :rowIndex="$rowIndex" />
+                            <x-livewire-tables::table.td.reorder x-cloak x-show="currentlyReorderingStatus" wire:key="{{ $tableName }}-row-reorder-{{ $row->{$primaryKey} }}" :rowID="$tableName.'-'.$row->{$this->getPrimaryKey()}" :$rowIndex />
                         @endif
                         @if($this->showBulkActionsSections)
-                            <x-livewire-tables::table.td.bulk-actions wire:key="{{ $tableName }}-row-bulk-act-{{ $row->{$primaryKey} }}" :row="$row" :rowIndex="$rowIndex"/>
+                            <x-livewire-tables::table.td.bulk-actions wire:key="{{ $tableName }}-row-bulk-act-{{ $row->{$primaryKey} }}" :$row :$rowIndex />
                         @endif
                         @if ($this->showCollapsingColumnSections)
-                            <x-livewire-tables::table.td.collapsed-columns wire:key="{{ $tableName }}-row-collapsed-{{ $row->{$primaryKey} }}" :rowIndex="$rowIndex" />
+                            <x-livewire-tables::table.td.collapsed-columns wire:key="{{ $tableName }}-row-collapsed-{{ $row->{$primaryKey} }}" :$rowIndex />
                         @endif
 
                         @foreach($this->selectedVisibleColumns as $colIndex => $column)
-                            <x-livewire-tables::table.td wire:key="{{ $tableName . '-' . $row->{$primaryKey} . '-datatable-td-' . $column->getSlug() }}"  :column="$column" :colIndex="$colIndex">
+                            <x-livewire-tables::table.td wire:key="{{ $tableName . '-' . $row->{$primaryKey} . '-datatable-td-' . $column->getSlug() }}"  :$column :$colIndex>
                                 @if($column->isHtml())
                                     {!! $column->setIndexes($rowIndex, $colIndex)->renderContents($row) !!}
                                 @else
@@ -107,7 +107,7 @@
                     </x-livewire-tables::table.tr>
 
                     @if ($this->showCollapsingColumnSections)
-                        <x-livewire-tables::table.collapsed-columns :row="$row" :rowIndex="$rowIndex" />
+                        <x-livewire-tables::table.collapsed-columns :$row :$rowIndex />
                     @endif
                 @empty
                     <x-livewire-tables::table.empty />

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -126,7 +126,7 @@ class MakeCommand extends Command implements PromptsForMissingInput
         if (isset($this->modelPath)) {
             $filename = rtrim($this->modelPath, '/').'/'.$this->model.'.php';
             if (File::exists($filename)) {
-                //In case the file has more than one class which is highly unlikely but still possible
+                // In case the file has more than one class which is highly unlikely but still possible
                 $classes = array_filter($this->getClassesList($filename), function ($class) {
                     return substr($class, strrpos($class, '\\') + 1) == $this->model;
                 });

--- a/src/Traits/Helpers/CollapsingColumnHelpers.php
+++ b/src/Traits/Helpers/CollapsingColumnHelpers.php
@@ -11,11 +11,13 @@ trait CollapsingColumnHelpers
         return $this->collapsingColumnsStatus;
     }
 
+    #[Computed]
     public function hasCollapsingColumns(): bool
     {
         return $this->getCollapsingColumnsStatus() === true;
     }
 
+    #[Computed]
     public function collapsingColumnsAreEnabled(): bool
     {
         return $this->getCollapsingColumnsStatus() === true;

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -5,6 +5,7 @@ namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
 use Illuminate\Support\Collection;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\AggregateColumn;
+use Livewire\Attributes\Computed;
 
 trait ColumnHelpers
 {
@@ -133,6 +134,7 @@ trait ColumnHelpers
         return false;
     }
 
+    #[Computed]
     public function shouldCollapseOnMobile(): bool
     {
 
@@ -170,6 +172,7 @@ trait ColumnHelpers
         return $this->getVisibleMobileColumns()->count();
     }
 
+    #[Computed]
     public function shouldCollapseOnTablet(): bool
     {
         if (! isset($this->shouldTabletCollapse)) {
@@ -235,6 +238,7 @@ trait ColumnHelpers
         return $this->getCollapsedAlwaysColumns()->count();
     }
 
+    #[Computed]
     public function shouldCollapseAlways(): bool
     {
         if (! isset($this->shouldAlwaysCollapse)) {

--- a/src/Traits/Helpers/ColumnHelpers.php
+++ b/src/Traits/Helpers/ColumnHelpers.php
@@ -3,9 +3,9 @@
 namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
 
 use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\AggregateColumn;
-use Livewire\Attributes\Computed;
 
 trait ColumnHelpers
 {

--- a/src/Traits/Helpers/TableAttributeHelpers.php
+++ b/src/Traits/Helpers/TableAttributeHelpers.php
@@ -47,7 +47,7 @@ trait TableAttributeHelpers
     {
 
         if (isset($this->thAttributesCallback)) {
-            return array_merge(['default' => false, 'default-colors' => false, 'default-styling' => false], call_user_func($this->thAttributesCallback, $column));
+            return array_merge(['scope' => 'col', 'default' => false, 'default-colors' => false, 'default-styling' => false], call_user_func($this->thAttributesCallback, $column));
         }
 
         return ['default' => true, 'default-colors' => true, 'default-styling' => true];

--- a/src/Traits/WithData.php
+++ b/src/Traits/WithData.php
@@ -21,7 +21,7 @@ trait WithData
      */
     public function bootedWithData(): void
     {
-        //Sets up the Builder Instance
+        // Sets up the Builder Instance
         $this->setBuilder($this->builder());
     }
 

--- a/src/Traits/WithReordering.php
+++ b/src/Traits/WithReordering.php
@@ -51,7 +51,7 @@ trait WithReordering
 
     public function enableReordering(): void
     {
-        //$this->enablePaginatedReordering();
+        // $this->enablePaginatedReordering();
 
         $this->setReorderingSession();
         $this->setReorderingBackup();

--- a/src/Traits/WithReordering.php
+++ b/src/Traits/WithReordering.php
@@ -51,13 +51,10 @@ trait WithReordering
 
     public function enableReordering(): void
     {
-        // $this->enablePaginatedReordering();
-
         $this->setReorderingSession();
         $this->setReorderingBackup();
         $this->resetReorderFields();
         $this->reorderStatus = $this->currentlyReorderingStatus = $this->reorderDisplayColumn = true;
-
     }
 
     public function disableReordering(): void

--- a/src/Views/Traits/Filters/HasCustomPosition.php
+++ b/src/Views/Traits/Filters/HasCustomPosition.php
@@ -67,7 +67,7 @@ trait HasCustomPosition
 
     public function setFilterSlidedownRow(string $filterSlidedownRow): self
     {
-        //$this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
+        // $this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
         $this->filterSlidedownRow = intval($filterSlidedownRow);
 
         return $this;
@@ -75,7 +75,7 @@ trait HasCustomPosition
 
     public function setFilterSlidedownColspan(string $filterSlidedownColspan): self
     {
-        //$this->filterSlidedownColspan = (is_int($filterSlidedownColspan) ? $filterSlidedownColspan : intval($filterSlidedownColspan));
+        // $this->filterSlidedownColspan = (is_int($filterSlidedownColspan) ? $filterSlidedownColspan : intval($filterSlidedownColspan));
         $this->filterSlidedownColspan = intval($filterSlidedownColspan);
 
         return $this;

--- a/src/Views/Traits/Filters/HasCustomPosition.php
+++ b/src/Views/Traits/Filters/HasCustomPosition.php
@@ -67,7 +67,6 @@ trait HasCustomPosition
 
     public function setFilterSlidedownRow(string $filterSlidedownRow): self
     {
-        // $this->filterSlidedownRow = (is_int($filterSlidedownRow) ? $filterSlidedownRow : intval($filterSlidedownRow));
         $this->filterSlidedownRow = intval($filterSlidedownRow);
 
         return $this;
@@ -75,7 +74,6 @@ trait HasCustomPosition
 
     public function setFilterSlidedownColspan(string $filterSlidedownColspan): self
     {
-        // $this->filterSlidedownColspan = (is_int($filterSlidedownColspan) ? $filterSlidedownColspan : intval($filterSlidedownColspan));
         $this->filterSlidedownColspan = intval($filterSlidedownColspan);
 
         return $this;

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -26,7 +26,6 @@ class DataTableComponentTest extends TestCase
         $this->assertFalse($this->basicTable->hasPrimaryKey());
     }
 
-
     public function test_default_fingerprint_will_always_be_the_same_for_same_datatable(): void
     {
         $this->assertSame(

--- a/tests/DataTableComponentTest.php
+++ b/tests/DataTableComponentTest.php
@@ -2,7 +2,6 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests;
 
-use Livewire\Livewire;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\NoColumnsTable;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\NoPrimaryKeyTable;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
@@ -27,12 +26,6 @@ class DataTableComponentTest extends TestCase
         $this->assertFalse($this->basicTable->hasPrimaryKey());
     }
 
-    public function test_primary_key_has_to_be_set(): void
-    {
-        $this->expectException(\Illuminate\View\ViewException::class);
-        Livewire::test(NoPrimaryKeyTable::class)
-            ->call('setSearch', 'abcd');
-    }
 
     public function test_default_fingerprint_will_always_be_the_same_for_same_datatable(): void
     {

--- a/tests/Localisations/BaseLocalisationCase.php
+++ b/tests/Localisations/BaseLocalisationCase.php
@@ -57,10 +57,10 @@ class BaseLocalisationCase extends TestCase
             'tw',
             'uk',
         ];
-        //return $availableLocales;
+        // return $availableLocales;
 
         foreach ($availableLocales as $availableLocale) {
-            //$array = require($baseDir.$availableLocale.'/core.php');
+            // $array = require($baseDir.$availableLocale.'/core.php');
             $localisations[] = [
                 'locale' => $availableLocale,
                 //      'localisationStrings' => $array,

--- a/tests/Unit/Traits/Configuration/ComponentConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/ComponentConfigurationTest.php
@@ -73,8 +73,8 @@ final class ComponentConfigurationTest extends TestCase
             return ['default' => true, 'here' => 'there'];
         });
 
-        $this->assertSame($this->basicTable->getThAttributes($this->basicTable->columns()[0]), ['default' => false, 'default-colors' => false, 'default-styling' => false, 'this' => 'that']);
-        $this->assertSame($this->basicTable->getThAttributes($this->basicTable->columns()[1]), ['default' => true, 'default-colors' => false, 'default-styling' => false, 'here' => 'there']);
+        $this->assertSame($this->basicTable->getThAttributes($this->basicTable->columns()[0]), ['scope' => 'col', 'default' => false, 'default-colors' => false, 'default-styling' => false, 'this' => 'that']);
+        $this->assertSame($this->basicTable->getThAttributes($this->basicTable->columns()[1]), ['scope' => 'col', 'default' => true, 'default-colors' => false, 'default-styling' => false, 'here' => 'there']);
     }
 
     public function test_can_set_th_sort_button_attributes(): void

--- a/tests/Unit/Traits/Helpers/ColumnHelpersTest.php
+++ b/tests/Unit/Traits/Helpers/ColumnHelpersTest.php
@@ -205,7 +205,7 @@ final class ColumnHelpersTest extends TestCase
         $this->assertSame(7, $this->basicTable->getVisibleTabletColumnsCount());
     }
 
-    /// *** ** //
+    // / *** ** //
 
     public function test_can_tell_if_columns_should_collapse_always(): void
     {
@@ -299,7 +299,7 @@ final class ColumnHelpersTest extends TestCase
         $this->assertTrue($column->hasSecondaryHeaderCallback());
 
         $contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey($column->getSecondaryHeaderCallback()), $this->basicTable->getFilterGenericData());
-        //$contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey('breed'));
+        // $contents = $column->getSecondaryHeaderFilter($this->basicTable->getFilterByKey('breed'));
         $this->assertStringContainsString('id="table-filter-breed-8-header"', $contents);
     }
 

--- a/tests/Unit/Traits/Helpers/ComponentHelpersTest.php
+++ b/tests/Unit/Traits/Helpers/ComponentHelpersTest.php
@@ -244,7 +244,7 @@ final class ComponentHelpersTest extends TestCase
 
     // Exists in DataTableComponentTest
     // public function test_can_get_dataTable_fingerprint(): void
-    //{
+    // {
     //     $this->assertSame($this->defaultFingerPrintingAlgo($this->basicTable::class), $this->basicTable->getDataTableFingerprint());
     // }
 

--- a/tests/Unit/Traits/WithCustomisationsTest.php
+++ b/tests/Unit/Traits/WithCustomisationsTest.php
@@ -8,7 +8,6 @@ use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 final class WithCustomisationsTest extends TestCase
 {
-
     public function test_can_use_as_full_page(): void
     {
         $temp = new class extends PetsTable

--- a/tests/Unit/Traits/WithCustomisationsTest.php
+++ b/tests/Unit/Traits/WithCustomisationsTest.php
@@ -2,42 +2,12 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Traits;
 
-use Livewire\Component;
 use Livewire\Features\SupportPageComponents\PageComponentConfig;
-use Livewire\Livewire;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 final class WithCustomisationsTest extends TestCase
 {
-    public function test_can_use_as_nested(): void
-    {
-        $test = Livewire::test([new class extends Component
-        {
-            public function render()
-            {
-                return <<<'HTML'
-                <div>
-                    <div>ParentComponentTest</div>
-                    <div> <livewire:child /></div>
-                </div>
-                HTML;
-            }
-        },
-            'child' => new class extends PetsTable
-            {
-                public function configure(): void
-                {
-                    parent::configure();
-                    $this->setLayout('livewire-tables::tests.layout1');
-
-                }
-            },
-        ])
-            ->assertSee('ParentComponentTest')
-            ->assertSee('Cartman');
-
-    }
 
     public function test_can_use_as_full_page(): void
     {

--- a/tests/Unit/Views/Columns/DateColumnTest.php
+++ b/tests/Unit/Views/Columns/DateColumnTest.php
@@ -2,7 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Views\Columns;
 
-//use Illuminate\Support\Facades\Exceptions;
+// use Illuminate\Support\Facades\Exceptions;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;

--- a/tests/Unit/Views/Columns/IconColumnTest.php
+++ b/tests/Unit/Views/Columns/IconColumnTest.php
@@ -2,7 +2,7 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Views\Columns;
 
-//use Illuminate\Support\Facades\Exceptions;
+// use Illuminate\Support\Facades\Exceptions;
 use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 use Rappasoft\LaravelLivewireTables\Views\Columns\IconColumn;

--- a/tests/Unit/Visuals/BulkActionsVisualsTest.php
+++ b/tests/Unit/Visuals/BulkActionsVisualsTest.php
@@ -258,7 +258,6 @@ final class BulkActionsVisualsTest extends TestCase
             ]);
     }
 
-
     public function test_bulk_dropdown_can_have_customised_classes_with_default_colors(): void
     {
         Livewire::test(new class extends PetsTable
@@ -324,6 +323,4 @@ final class BulkActionsVisualsTest extends TestCase
                 'wire:key="table-thead-bulk-actions"',
             ]);
     }
-
-
 }

--- a/tests/Unit/Visuals/BulkActionsVisualsTest.php
+++ b/tests/Unit/Visuals/BulkActionsVisualsTest.php
@@ -192,7 +192,40 @@ final class BulkActionsVisualsTest extends TestCase
         })->assertDontSee('Bulk Actions');
     }
 
-    public function test_bulk_dropdown_can_have_customised_classes(): void
+    public function test_bulk_dropdown_can_have_customised_classes_with_no_defaults(): void
+    {
+        Livewire::test(new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+                $this->setBulkActionsThAttributes([
+                    'class' => 'bg-yellow-500 dark:bg-yellow-800',
+                    'default' => false,
+                    'default-styling' => false,
+                    'default-colors' => false,
+                ]);
+
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        })->assertSee('Bulk Actions')
+            ->assertSeeHtmlInOrder([
+                'scope="col"',
+                'class="bg-yellow-500 dark:bg-yellow-800"',
+                'wire:key="table-thead-bulk-actions"',
+            ]);
+    }
+
+    public function test_bulk_dropdown_can_have_customised_classes_with_default_styling(): void
     {
         Livewire::test(new class extends PetsTable
         {
@@ -220,8 +253,77 @@ final class BulkActionsVisualsTest extends TestCase
         })->assertSee('Bulk Actions')
             ->assertSeeHtmlInOrder([
                 'scope="col"',
-                'class="bg-yellow-500 dark:bg-yellow-800"',
+                'class="table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left laravel-livewire-tables-reorderingMinimised bg-yellow-500 dark:bg-yellow-800"',
                 'wire:key="table-thead-bulk-actions"',
             ]);
     }
+
+
+    public function test_bulk_dropdown_can_have_customised_classes_with_default_colors(): void
+    {
+        Livewire::test(new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+                $this->setBulkActionsThAttributes([
+                    'class' => 'text-lg',
+                    'default' => false,
+                    'default-styling' => false,
+                    'default-colors' => true,
+                ]);
+
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        })->assertSee('Bulk Actions')
+            ->assertSeeHtmlInOrder([
+                'scope="col"',
+                'class="bg-gray-50 dark:bg-gray-800 text-lg"',
+                'wire:key="table-thead-bulk-actions"',
+            ]);
+    }
+
+    public function test_bulk_dropdown_can_have_customised_classes_with_defaults(): void
+    {
+        Livewire::test(new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                $this->setPrimaryKey('id');
+                $this->setBulkActionsThAttributes([
+                    'class' => 'text-lg',
+                    'default' => true,
+                    'default-styling' => true,
+                    'default-colors' => true,
+                ]);
+
+            }
+
+            public function bulkActions(): array
+            {
+                return ['exportBulk' => 'exportBulk'];
+            }
+
+            public function exportBulk($items)
+            {
+                return $items;
+            }
+        })->assertSee('Bulk Actions')
+            ->assertSeeHtmlInOrder([
+                'scope="col"',
+                'class="table-cell px-3 py-2 md:px-6 md:py-3 text-center md:text-left laravel-livewire-tables-reorderingMinimised bg-gray-50 dark:bg-gray-800 text-lg"',
+                'wire:key="table-thead-bulk-actions"',
+            ]);
+    }
+
+
 }

--- a/tests/Unit/Visuals/CustomisationsVisualsTest.php
+++ b/tests/Unit/Visuals/CustomisationsVisualsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Visuals;
+
+use Exception;
+use Illuminate\View\ViewException;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Group;
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\{BrokenSecondaryHeaderTable, NoBuildMethodTable, NoPrimaryKeyTable};
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\{PetsTable,PetsTableAttributes};
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+use Livewire\Component;
+
+#[Group('Visuals')]
+final class CustomisationsVisualsTest extends TestCase
+{
+    public function test_can_use_as_nested(): void
+    {
+        $test = Livewire::test([new class extends Component
+        {
+            public function render()
+            {
+                return <<<'HTML'
+                <div>
+                    <div>ParentComponentTest</div>
+                    <div> <livewire:child /></div>
+                </div>
+                HTML;
+            }
+        },
+            'child' => new class extends PetsTable
+            {
+                public function configure(): void
+                {
+                    parent::configure();
+                    $this->setLayout('livewire-tables::tests.layout1');
+
+                }
+            },
+        ])
+            ->assertSee('ParentComponentTest')
+            ->assertSee('Cartman');
+
+    }
+
+}

--- a/tests/Unit/Visuals/CustomisationsVisualsTest.php
+++ b/tests/Unit/Visuals/CustomisationsVisualsTest.php
@@ -4,13 +4,13 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Visuals;
 
 use Exception;
 use Illuminate\View\ViewException;
+use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Group;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\{BrokenSecondaryHeaderTable, NoBuildMethodTable, NoPrimaryKeyTable};
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\{PetsTable,PetsTableAttributes};
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
-use Livewire\Component;
 
 #[Group('Visuals')]
 final class CustomisationsVisualsTest extends TestCase
@@ -43,5 +43,4 @@ final class CustomisationsVisualsTest extends TestCase
             ->assertSee('Cartman');
 
     }
-
 }

--- a/tests/Unit/Visuals/DataTableComponentVisualsTest.php
+++ b/tests/Unit/Visuals/DataTableComponentVisualsTest.php
@@ -4,13 +4,13 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Visuals;
 
 use Exception;
 use Illuminate\View\ViewException;
+use Livewire\Component;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Group;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\{BrokenSecondaryHeaderTable, NoBuildMethodTable, NoPrimaryKeyTable};
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\{PetsTable,PetsTableAttributes};
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
-use Livewire\Component;
 
 #[Group('Visuals')]
 final class DataTableComponentVisualsTest extends TestCase
@@ -21,5 +21,4 @@ final class DataTableComponentVisualsTest extends TestCase
         Livewire::test(NoPrimaryKeyTable::class)
             ->call('setSearch', 'abcd');
     }
-
 }

--- a/tests/Unit/Visuals/DataTableComponentVisualsTest.php
+++ b/tests/Unit/Visuals/DataTableComponentVisualsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Visuals;
+
+use Exception;
+use Illuminate\View\ViewException;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Group;
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\{BrokenSecondaryHeaderTable, NoBuildMethodTable, NoPrimaryKeyTable};
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\{PetsTable,PetsTableAttributes};
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+use Livewire\Component;
+
+#[Group('Visuals')]
+final class DataTableComponentVisualsTest extends TestCase
+{
+    public function test_primary_key_has_to_be_set(): void
+    {
+        $this->expectException(\Illuminate\View\ViewException::class);
+        Livewire::test(NoPrimaryKeyTable::class)
+            ->call('setSearch', 'abcd');
+    }
+
+}

--- a/tests/Unit/Visuals/SortingVisualsTest.php
+++ b/tests/Unit/Visuals/SortingVisualsTest.php
@@ -37,7 +37,7 @@ final class SortingVisualsTest extends TestCase
         Livewire::test(PetsTable::class)
             ->assertSeeHtmlInOrder([
                 'wire:click="sortBy(\'id\')"',
-                'class="flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none text-gray-500 dark:text-gray-400"',
+                'class="text-gray-500 dark:text-gray-400 flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none"',
             ]);
     }
 
@@ -58,12 +58,12 @@ final class SortingVisualsTest extends TestCase
             ->call('setSortingDisabled')
             ->assertDontSeeHtml('<button
                 wire:click="sortBy(\'id\')"
-                class="flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none text-gray-500 dark:text-gray-400"
+                class="text-gray-500 dark:text-gray-400 flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none"
             >')
             ->call('setSortingEnabled')
             ->assertSeeHtmlInOrder([
                 'wire:click="sortBy(\'id\')"',
-                'class="flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none text-gray-500 dark:text-gray-400"',
+                'class="text-gray-500 dark:text-gray-400 flex items-center space-x-1 text-left text-xs leading-4 font-medium uppercase tracking-wider group focus:outline-none"',
             ]);
 
     }


### PR DESCRIPTION
Fixes to smooth the Sort Icon Styling approach

- Tidy up main "th" blade - clean up class merging, reduce duplicated code
- TH Bulk Actions - Clean up classes
- TH Collapsing Columns - use Computed Properties, clean up classes
- TH Label (new) - centralise the TH label
- TH Plain - clean up classes
- TH Reorder - clean up classes
- TH Sort Icons - clean up classes, improve performance

- Datatable - clean up attribute assignment

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
