### PR TITLE
Migrate Filter Status into Own Trait

### DIFF
--- a/src/Traits/Configuration/FilterConfiguration.php
+++ b/src/Traits/Configuration/FilterConfiguration.php
@@ -4,24 +4,4 @@ namespace Rappasoft\LaravelLivewireTables\Traits\Configuration;
 
 trait FilterConfiguration
 {
-    public function setFiltersStatus(bool $status): self
-    {
-        $this->filtersStatus = $status;
-
-        return $this;
-    }
-
-    public function setFiltersEnabled(): self
-    {
-        $this->setFiltersStatus(true);
-
-        return $this;
-    }
-
-    public function setFiltersDisabled(): self
-    {
-        $this->setFiltersStatus(false);
-
-        return $this;
-    }
 }

--- a/src/Traits/Configuration/FilterConfiguration.php
+++ b/src/Traits/Configuration/FilterConfiguration.php
@@ -2,6 +2,4 @@
 
 namespace Rappasoft\LaravelLivewireTables\Traits\Configuration;
 
-trait FilterConfiguration
-{
-}
+trait FilterConfiguration {}

--- a/src/Traits/Core/Filters/HandlesFilterTraits.php
+++ b/src/Traits/Core/Filters/HandlesFilterTraits.php
@@ -9,5 +9,6 @@ trait HandlesFilterTraits
         HasFilterMenuStyling,
         HasFilterPillsStyling,
         HasFilterQueryString,
+        HasFiltersStatus,
         HasFiltersVisibility;
 }

--- a/src/Traits/Core/Filters/HasFiltersStatus.php
+++ b/src/Traits/Core/Filters/HasFiltersStatus.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Core\Filters;
+
+use Livewire\Attributes\Locked;
+
+trait HasFiltersStatus
+{
+    #[Locked]
+    public bool $filtersStatus = true;
+
+    public function getFiltersStatus(): bool
+    {
+        return $this->filtersStatus;
+    }
+
+    public function filtersAreEnabled(): bool
+    {
+        return $this->getFiltersStatus() === true;
+    }
+
+    public function filtersAreDisabled(): bool
+    {
+        return $this->getFiltersStatus() === false;
+    }
+
+
+    public function setFiltersStatus(bool $status): self
+    {
+        $this->filtersStatus = $status;
+
+        return $this;
+    }
+
+    public function setFiltersEnabled(): self
+    {
+        $this->setFiltersStatus(true);
+
+        return $this;
+    }
+
+    public function setFiltersDisabled(): self
+    {
+        $this->setFiltersStatus(false);
+
+        return $this;
+    }
+}

--- a/src/Traits/Core/Filters/HasFiltersStatus.php
+++ b/src/Traits/Core/Filters/HasFiltersStatus.php
@@ -24,21 +24,21 @@ trait HasFiltersStatus
         return $this->getFiltersStatus() === false;
     }
 
-    public function setFiltersStatus(bool $status): self
+    protected function setFiltersStatus(bool $status): self
     {
         $this->filtersStatus = $status;
 
         return $this;
     }
 
-    public function setFiltersEnabled(): self
+    protected function setFiltersEnabled(): self
     {
         $this->setFiltersStatus(true);
 
         return $this;
     }
 
-    public function setFiltersDisabled(): self
+    protected function setFiltersDisabled(): self
     {
         $this->setFiltersStatus(false);
 

--- a/src/Traits/Core/Filters/HasFiltersStatus.php
+++ b/src/Traits/Core/Filters/HasFiltersStatus.php
@@ -24,7 +24,6 @@ trait HasFiltersStatus
         return $this->getFiltersStatus() === false;
     }
 
-
     public function setFiltersStatus(bool $status): self
     {
         $this->filtersStatus = $status;

--- a/src/Traits/Core/Filters/HasFiltersStatus.php
+++ b/src/Traits/Core/Filters/HasFiltersStatus.php
@@ -24,21 +24,21 @@ trait HasFiltersStatus
         return $this->getFiltersStatus() === false;
     }
 
-    protected function setFiltersStatus(bool $status): self
+    public function setFiltersStatus(bool $status): self
     {
         $this->filtersStatus = $status;
 
         return $this;
     }
 
-    protected function setFiltersEnabled(): self
+    public function setFiltersEnabled(): self
     {
         $this->setFiltersStatus(true);
 
         return $this;
     }
 
-    protected function setFiltersDisabled(): self
+    public function setFiltersDisabled(): self
     {
         $this->setFiltersStatus(false);
 

--- a/src/Traits/Helpers/FilterHelpers.php
+++ b/src/Traits/Helpers/FilterHelpers.php
@@ -11,21 +11,6 @@ use Rappasoft\LaravelLivewireTables\Views\Filters\{MultiSelectDropdownFilter, Mu
 
 trait FilterHelpers
 {
-    public function getFiltersStatus(): bool
-    {
-        return $this->filtersStatus;
-    }
-
-    public function filtersAreEnabled(): bool
-    {
-        return $this->getFiltersStatus() === true;
-    }
-
-    public function filtersAreDisabled(): bool
-    {
-        return $this->getFiltersStatus() === false;
-    }
-
     public function hasFilters(): bool
     {
         return $this->getFiltersCount() > 0;

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -15,9 +15,6 @@ trait WithFilters
     use HandlesFilterTraits;
 
     #[Locked]
-    public bool $filtersStatus = true;
-
-    #[Locked]
     public int $filterCount;
 
     protected ?Collection $filterCollection;

--- a/tests/Unit/Traits/Core/Filters/FilterStatusTest.php
+++ b/tests/Unit/Traits/Core/Filters/FilterStatusTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Traits\Core\Filters;
+
+use PHPUnit\Framework\Attributes\Group;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+#[Group('Filters')]
+final class FilterStatusTest extends TestCase
+{
+    public function test_can_check_if_filters_are_enabled(): void
+    {
+        $this->assertTrue($this->basicTable->filtersAreEnabled());
+    }
+
+    public function test_can_check_if_filters_can_be_disabled_when_enbled(): void
+    {
+
+        $mock = new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                parent::configure();
+                $this->setFiltersEnabled();
+            }
+
+            public function setFiltersToEnabled()
+            {
+                $this->setFiltersEnabled();
+            }
+
+            public function setFiltersToDisabled()
+            {
+                $this->setFiltersDisabled();
+            }
+
+        };
+
+        $mock->configure();
+        $mock->boot();
+
+        $this->assertTrue($mock->filtersAreEnabled());
+        $this->assertFalse($mock->filtersAreDisabled());
+        
+        $mock->setFiltersToDisabled();
+        
+        $this->assertFalse($mock->filtersAreEnabled());
+        $this->assertTrue($mock->filtersAreDisabled());
+
+    }
+
+
+    public function test_can_check_if_filters_can_be_enabled_when_disabled(): void
+    {
+
+        $mock = new class extends PetsTable
+        {
+            public function configure(): void
+            {
+                parent::configure();
+                $this->setFiltersDisabled();
+            }
+
+            public function setFiltersToEnabled()
+            {
+                $this->setFiltersEnabled();
+            }
+
+            public function setFiltersToDisabled()
+            {
+                $this->setFiltersDisabled();
+            }
+
+        };
+
+        $mock->configure();
+        $mock->boot();
+
+        $this->assertTrue($mock->filtersAreDisabled());
+        $this->assertFalse($mock->filtersAreEnabled());
+
+        $mock->setFiltersToEnabled();
+        $this->assertTrue($mock->filtersAreEnabled());
+        $this->assertFalse($mock->filtersAreDisabled());
+
+    }
+
+}

--- a/tests/Unit/Traits/Core/Filters/FilterStatusTest.php
+++ b/tests/Unit/Traits/Core/Filters/FilterStatusTest.php
@@ -34,7 +34,6 @@ final class FilterStatusTest extends TestCase
             {
                 $this->setFiltersDisabled();
             }
-
         };
 
         $mock->configure();
@@ -42,14 +41,13 @@ final class FilterStatusTest extends TestCase
 
         $this->assertTrue($mock->filtersAreEnabled());
         $this->assertFalse($mock->filtersAreDisabled());
-        
+
         $mock->setFiltersToDisabled();
-        
+
         $this->assertFalse($mock->filtersAreEnabled());
         $this->assertTrue($mock->filtersAreDisabled());
 
     }
-
 
     public function test_can_check_if_filters_can_be_enabled_when_disabled(): void
     {
@@ -71,7 +69,6 @@ final class FilterStatusTest extends TestCase
             {
                 $this->setFiltersDisabled();
             }
-
         };
 
         $mock->configure();
@@ -85,5 +82,4 @@ final class FilterStatusTest extends TestCase
         $this->assertFalse($mock->filtersAreDisabled());
 
     }
-
 }


### PR DESCRIPTION
PR that migrates the global Filter Status into it's own trait, to allow increased code segregation

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
