### PR TITLE
Enable setting styles for column select as a configuration.

### DIFF
--- a/docs/columns/column-selection.md
+++ b/docs/columns/column-selection.md
@@ -223,3 +223,67 @@ class DataTableColumnsSelectedListener
 
 }
 ```
+
+## Styling
+
+### setColumnSelectButtonAttributes
+Allows for customisation of the appearance of the "Column Select" button
+
+Note that this utilises a refreshed approach for attributes, and allows for appending to, or replacing the styles and colors independently, via the below methods.
+
+#### default-colors
+Setting to false will disable the default colors for the Column Select button, the default colors are:
+
+Bootstrap: None
+
+Tailwind: `text-gray-700 bg-white border-gray-300 hover:bg-gray-50 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600`
+
+#### default-styling
+Setting to false will disable the default styling for the Column Select button, the default styling is:
+
+Bootstrap: `btn dropdown-toggle d-block w-100 d-md-inline`
+
+Tailwind: `inline-flex justify-center px-4 py-2 w-full text-sm font-medium rounded-md border shadow-sm focus:ring focus:ring-opacity-50`
+
+```php
+public function configure(): void
+{
+  $this->setColumnSelectButtonAttributes([
+    'class' => 'focus:border-rose-300 focus:ring-1 focus:ring-rose-300 focus-visible:outline-rose-300', // Add these classes to the column select button
+    'default-colors' => false, // Do not output the default colors
+    'default-styling' => true // Output the default styling
+  ]);
+}
+```
+
+### setColumnSelectMenuOptionCheckboxAttributes
+Allows for customisation of the appearance of the "Column Select" menu option checkbox
+
+Note that this utilises a refreshed approach for attributes, and allows for appending to, or replacing the styles and colors independently, via the below methods.
+
+#### default-colors
+Setting to false will disable the default colors for the Column Select menu option checkbox, the default colors are:
+
+Bootstrap: None
+
+Tailwind: `text-indigo-600 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600`
+#### default-styling
+
+Setting to false will disable the default styling for the Column Select menu option checkbox, the default styling is:
+
+Bootstrap 4: None
+
+Bootstrap 5: `form-check-input`
+
+Tailwind: `transition duration-150 ease-in-out rounded shadow-sm focus:ring focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-wait`
+
+```php
+public function configure(): void
+{
+  $this->setColumnSelectMenuOptionCheckboxAttributes([
+    'class' => 'text-rose-300 focus:border-rose-300 focus:ring-rose-300', // Add these classes to the column select menu option checkbox
+    'default-colors' => false, // Do not output the default colors
+    'default-styling' => true // Output the default styling
+  ]);
+}
+```

--- a/resources/views/components/tools/toolbar/items/column-select.blade.php
+++ b/resources/views/components/tools/toolbar/items/column-select.blade.php
@@ -13,7 +13,14 @@
                     <button
                         x-on:click="open = !open"
                         type="button"
-                        class="inline-flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 shadow-sm hover:bg-gray-50 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600"
+                        {{
+                            $attributes->merge($this->getColumnSelectButtonAttributes())
+                            ->class([
+                                'inline-flex justify-center px-4 py-2 w-full text-sm font-medium rounded-md border shadow-sm focus:ring focus:ring-opacity-50' => $this->getColumnSelectButtonAttributes()['default-styling'],
+                                'text-gray-700 bg-white border-gray-300 hover:bg-gray-50 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-700 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600' => $this->getColumnSelectButtonAttributes()['default-colors'],
+                            ])
+                            ->except(['default-styling', 'default-colors'])
+                        }}
                         aria-haspopup="true"
                         x-bind:aria-expanded="open"
                         aria-expanded="true"
@@ -45,7 +52,14 @@
                                 class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
                             >
                                 <input
-                                    class="text-indigo-600 transition duration-150 ease-in-out border-gray-300 rounded shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                                    {{
+                                        $attributes->merge($this->getColumnSelectMenuOptionCheckboxAttributes())
+                                        ->class([
+                                            'transition duration-150 ease-in-out rounded shadow-sm focus:ring focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-wait' => $this->getColumnSelectMenuOptionCheckboxAttributes()['default-styling'],
+                                            'text-indigo-600 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => $this->getColumnSelectMenuOptionCheckboxAttributes()['default-colors'],
+                                        ])
+                                        ->except(['default-styling', 'default-colors'])
+                                    }}
                                     wire:loading.attr="disabled"
                                     type="checkbox"
                                     @checked($this->getSelectableSelectedColumns()->count() === $this->getSelectableColumns()->count())
@@ -65,7 +79,14 @@
                                     class="inline-flex items-center px-2 py-1 disabled:opacity-50 disabled:cursor-wait"
                                 >
                                     <input
-                                        class="text-indigo-600 rounded border-gray-300 shadow-sm transition duration-150 ease-in-out focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600 disabled:opacity-50 disabled:cursor-wait"
+                                        {{
+                                            $attributes->merge($this->getColumnSelectMenuOptionCheckboxAttributes())
+                                            ->class([
+                                                'transition duration-150 ease-in-out rounded shadow-sm focus:ring focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-wait' => $this->getColumnSelectMenuOptionCheckboxAttributes()['default-styling'],
+                                                'text-indigo-600 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-900 dark:text-white dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:bg-gray-600' => $this->getColumnSelectMenuOptionCheckboxAttributes()['default-colors'],
+                                            ])
+                                            ->except(['default-styling', 'default-colors'])
+                                        }}
                                         wire:model.live="selectedColumns" wire:target="selectedColumns"
                                         wire:loading.attr="disabled" type="checkbox"
                                         value="{{ $columnSlug }}" />
@@ -98,9 +119,13 @@
         >
             <button
                 x-on:click="open = !open"
-                @class([
-                    'btn dropdown-toggle d-block w-100 d-md-inline' => $isBootstrap,
-                ])
+                {{
+                    $attributes->merge($this->getColumnSelectButtonAttributes())
+                    ->class([
+                        'btn dropdown-toggle d-block w-100 d-md-inline' => $this->getColumnSelectButtonAttributes()['default-styling'],
+                    ])
+                    ->except(['default-styling', 'default-colors'])
+                }}
                 type="button" id="{{ $tableName }}-columnSelect" aria-haspopup="true"
                 x-bind:aria-expanded="open"
             >
@@ -134,7 +159,13 @@
                         <input
                             wire:loading.attr="disabled"
                             type="checkbox"
-                            class="form-check-input"
+                            {{
+                                $attributes->merge($this->getColumnSelectMenuOptionCheckboxAttributes())
+                                ->class([
+                                    'form-check-input' => $this->getColumnSelectMenuOptionCheckboxAttributes()['default-styling'],
+                                ])
+                                ->except(['default-styling', 'default-colors'])
+                            }}
                             @if($this->getSelectableSelectedColumns()->count() == $this->getSelectableColumns()->count()) checked wire:click="deselectAllColumns" @else unchecked wire:click="selectAllColumns" @endif
                         />
 
@@ -173,7 +204,13 @@
                                 wire:target="selectedColumns"
                                 wire:loading.attr="disabled"
                                 type="checkbox"
-                                class="form-check-input"
+                                {{
+                                    $attributes->merge($this->getColumnSelectMenuOptionCheckboxAttributes())
+                                    ->class([
+                                        'form-check-input' => $this->getColumnSelectMenuOptionCheckboxAttributes()['default-styling'],
+                                    ])
+                                    ->except(['default-styling', 'default-colors'])
+                                }}
                                 value="{{ $columnSlug }}"
                             />
                             <label

--- a/src/Traits/Styling/Configuration/ColumnSelectStylingConfiguration.php
+++ b/src/Traits/Styling/Configuration/ColumnSelectStylingConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Configuration;
+
+trait ColumnSelectStylingConfiguration
+{
+    public function setColumnSelectButtonAttributes(array $attributes = []): self
+    {
+        $this->columnSelectButtonAttributes = [...$this->columnSelectButtonAttributes, ...$attributes];
+
+        return $this;
+    }
+
+    public function setColumnSelectMenuOptionCheckboxAttributes(array $attributes = []): self
+    {
+        $this->columnSelectMenuOptionCheckboxAttributes = [...$this->columnSelectMenuOptionCheckboxAttributes, ...$attributes];
+
+        return $this;
+    }
+}

--- a/src/Traits/Styling/HasColumnSelectStyling.php
+++ b/src/Traits/Styling/HasColumnSelectStyling.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Styling;
+
+use Rappasoft\LaravelLivewireTables\Traits\Styling\Configuration\ColumnSelectStylingConfiguration;
+use Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers\ColumnSelectStylingHelpers;
+
+trait HasColumnSelectStyling
+{
+    use ColumnSelectStylingConfiguration,
+        ColumnSelectStylingHelpers;
+
+    protected array $columnSelectButtonAttributes = ['default-styling' => true, 'default-colors' => true, 'class' => ''];
+    protected array $columnSelectMenuOptionCheckboxAttributes = ['default-styling' => true, 'default-colors' => true, 'class' => ''];
+}

--- a/src/Traits/Styling/Helpers/ColumnSelectStylingHelpers.php
+++ b/src/Traits/Styling/Helpers/ColumnSelectStylingHelpers.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Styling\Helpers;
+
+use Illuminate\View\ComponentAttributeBag;
+use Livewire\Attributes\Computed;
+
+trait ColumnSelectStylingHelpers
+{
+    #[Computed]
+    public function getColumnSelectButtonAttributes(): array
+    {
+        return $this->columnSelectButtonAttributes;
+    }
+
+    #[Computed]
+    public function getColumnSelectMenuOptionCheckboxAttributes(): array
+    {
+        return $this->columnSelectMenuOptionCheckboxAttributes;
+    }
+}

--- a/src/Traits/WithColumnSelect.php
+++ b/src/Traits/WithColumnSelect.php
@@ -7,12 +7,14 @@ use Rappasoft\LaravelLivewireTables\Events\ColumnsSelected;
 use Rappasoft\LaravelLivewireTables\Traits\Configuration\ColumnSelectConfiguration;
 use Rappasoft\LaravelLivewireTables\Traits\Core\QueryStrings\HasQueryStringForColumnSelect;
 use Rappasoft\LaravelLivewireTables\Traits\Helpers\ColumnSelectHelpers;
+use Rappasoft\LaravelLivewireTables\Traits\Styling\HasColumnSelectStyling;
 
 trait WithColumnSelect
 {
     use ColumnSelectConfiguration,
         ColumnSelectHelpers,
-        HasQueryStringForColumnSelect;
+        HasQueryStringForColumnSelect,
+        HasColumnSelectStyling;
 
     #[Locked]
     public array $columnSelectColumns = ['setupRun' => false, 'selected' => [], 'deselected' => [], 'defaultdeselected' => []];


### PR DESCRIPTION
Hi,

First of all thanks for this incredible package, great work.

This PR represents an implementation to enable setting the styles for column select (button and menu option checkbox) as a configuration through the following functions:
-  `setColumnSelectButtonAttributes(...)`
- `setColumnSelectMenuOptionCheckboxAttributes(...)`

This is my first contribution to this package and of course, feedback is welcome.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?
