### PR TITLE
Fix Search Field in bootstrap

### DIFF
--- a/resources/views/components/tools/toolbar/items/search-field.blade.php
+++ b/resources/views/components/tools/toolbar/items/search-field.blade.php
@@ -4,7 +4,7 @@
     @class([
         'mb-3 mb-md-0 input-group' => $isBootstrap,
         'rounded-md shadow-sm' => $isTailwind,
-        'flex' => !$this->hasSearchIcon,
+        'flex' => ($isTailwind && !$this->hasSearchIcon),
         'relative inline-flex flex-row' => $this->hasSearchIcon,
     ])>
 


### PR DESCRIPTION
Flex is only for tailwind, this was broken when splitting out the styles for the search icon

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
