### PR TITLE
Fix error exception on non existing keys in CheckKeyPresenceTest

### DIFF
--- a/tests/Localisations/Presence/CheckKeyPresenceTest.php
+++ b/tests/Localisations/Presence/CheckKeyPresenceTest.php
@@ -23,7 +23,7 @@ final class CheckKeyPresenceTest extends BaseLocalisationCase
         $engStrings = self::getEnLocaleStrings();
         $localisedStrings = self::getLocaleStrings($locale);
         foreach ($engStrings as $key => $value) {
-            $this->assertNotNull($localisedStrings[$key]);
+            $this->assertArrayHasKey($key, $localisedStrings);
         }
     }
 }


### PR DESCRIPTION
Some unit test fail because some string are not translated (in the main branch). However some of them fail with an `ErrorException: Undefined array key "cancel"` because cancel is not available in each language. Depending on the PHP config of the machine undefined array keys can throw an exception.

This PR adds an assert if the array key is not available, the existing test to see if the translation is not null remains in place.

After this PR the test will report failures for missing strings.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
