### PR TITLE
Fixed collapsed function bug with tailwind CSS on mobile version

### DIFF
--- a/resources/views/components/table/collapsed-columns.blade.php
+++ b/resources/views/components/table/collapsed-columns.blade.php
@@ -28,7 +28,7 @@
                 @foreach($this->getCollapsedColumnsForContent as $colIndex => $column)
 
                     <p wire:key="{{ $tableName }}-row-{{ $row->{$primaryKey} }}-collapsed-contents-{{ $colIndex }}" @class([
-                            'block mb-2 hidden' => $isTailwind,
+                            'block mb-2' => $isTailwind,
                             'sm:block' => $isTailwind && $column->shouldCollapseAlways(),
                             'sm:block md:hidden' => $isTailwind && !$column->shouldCollapseAlways() && !$column->shouldCollapseOnTablet() && $column->shouldCollapseOnMobile(),
                             'sm:block lg:hidden' => $isTailwind && !$column->shouldCollapseAlways() && ($column->shouldCollapseOnTablet() || $column->shouldCollapseOnMobile()),


### PR DESCRIPTION
When using the Tailwind CSS package in mobile mode, when pressing the button to display collapsed items, these items were not displayed correctly. This was due to an issue with the visibility of the items inside the collapsed container.

With the change implemented, I adjusted the visibility settings and behavior of the items when interacting with the button in mobile mode.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
