### PR TITLE
Improved pagination UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-livewire-tables` will be documented in this file
 
+## [v3.7.1] - 2025-02-28
+### Bug Fixes
+- Ensure that LinkColumn is included in query if "from" is defined
+
 ## [v3.7.0] - 2025-02-27
 
 ### Bug Fixes

--- a/resources/views/specific/bootstrap-4/pagination.blade.php
+++ b/resources/views/specific/bootstrap-4/pagination.blade.php
@@ -3,7 +3,7 @@
         @php(isset($this->numberOfPaginatorsRendered[$paginator->getPageName()]) ? $this->numberOfPaginatorsRendered[$paginator->getPageName()]++ : $this->numberOfPaginatorsRendered[$paginator->getPageName()] = 1)
 
         <nav>
-            <ul class="pagination">
+            <ul class="pagination d-flex flex-wrap justify-content-start">
                 {{-- Previous Page Link --}}
                 @if ($paginator->onFirstPage())
                     <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">

--- a/src/Views/Columns/LinkColumn.php
+++ b/src/Views/Columns/LinkColumn.php
@@ -22,7 +22,9 @@ class LinkColumn extends Column
     {
         parent::__construct($title, $from);
 
-        $this->label(fn () => null);
+        if (! isset($from)) {
+            $this->label(fn () => null);
+        }
     }
 
     public function getContents(Model $row): null|string|\Illuminate\Support\HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

Instead of horrible UX - need to scroll using horizontal scrollbar:

![obrazek](https://github.com/user-attachments/assets/3cbdf655-0463-489b-9b00-aceae506c275)

Pagination is on the new line:

![obrazek](https://github.com/user-attachments/assets/f71872f7-89d0-4d7f-8332-c4447be86e02)

This commit also fixes problem with word wrapping with the current pagination:

![obrazek](https://github.com/user-attachments/assets/b2cd9116-1441-4e97-b914-023d7651d13d)