### PR TITLE
Add Wrapper Options to ArrayColumn

### DIFF
--- a/docs/column-types/array_column.md
+++ b/docs/column-types/array_column.md
@@ -13,13 +13,63 @@ ArrayColumn::make('notes', 'name')
     ->sortable(),
 ```
 
-### Empty Value
+## Empty Value
 You may define the default/empty value using the "emptyValue" method
 
 ```php
 ArrayColumn::make('notes', 'name')
     ->emptyValue('Unknown'),
 ```
+
+## Wrapping the Output
+
+As the ArrayColumn is designed to handle multiple related records, you can choose to wrap these for improved UX.
+
+It is recommended that you utilise the built-in flexCol or flexRow approaches, which will also disable the separator
+
+### flexCol
+This adds either:
+- Tailwind: 'flex flex-col'
+- Bootstrap: 'd-flex d-flex-col'
+
+And merges any attributes specified in the sole parameter (as an array)
+```php
+ArrayColumn::make('notes', 'name')
+    ->data(fn($value, $row) => ($row->notes))
+    ->outputFormat(fn($index, $value) => "<a href='".$value->id."'>".$value->name."</a>")
+    ->flexCol(['class' => 'bg-red-500'])
+    ->sortable(),
+```
+
+### flexRow
+
+This adds either:
+- Tailwind: 'flex flex-row'
+- Bootstrap: 'd-flex d-flex-row'
+
+And merges any attributes specified in the sole parameter (as an array)
+```php
+ArrayColumn::make('notes', 'name')
+    ->data(fn($value, $row) => ($row->notes))
+    ->outputFormat(fn($index, $value) => "<a href='".$value->id."'>".$value->name."</a>")
+    ->flexRow(['class' => 'bg-red-500'])
+    ->sortable(),
+```
+
+### Manually
+
+You can also specify a wrapperStart and wrapperEnd, for example, for an unordered list:
+
+```php
+ArrayColumn::make('notes', 'name')
+    ->data(fn($value, $row) => ($row->notes))
+    ->outputFormat(fn($index, $value) => "<li><a href='".$value->id."'>".$value->name."</a></li>")
+    ->wrapperStart("<ul class='bg-blue'>")
+    ->wrapperEnd("</ul>")
+    ->sortable(),
+```
+
+## See Also
 
 Please also see the following for other available methods:
 <ul>

--- a/src/Views/Columns/ArrayColumn.php
+++ b/src/Views/Columns/ArrayColumn.php
@@ -2,13 +2,13 @@
 
 namespace Rappasoft\LaravelLivewireTables\Views\Columns;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Configuration\ArrayColumnConfiguration;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers\ArrayColumnHelpers;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\IsColumn;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
-use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 
 class ArrayColumn extends Column
 {
@@ -36,7 +36,6 @@ class ArrayColumn extends Column
         }
     }
 
-    
     public function getContents(Model $row): null|string|\BackedEnum|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
     {
         $outputValues = [];

--- a/src/Views/Columns/ArrayColumn.php
+++ b/src/Views/Columns/ArrayColumn.php
@@ -32,5 +32,4 @@ class ArrayColumn extends Column
             $this->label(fn () => null);
         }
     }
-
 }

--- a/src/Views/Columns/ArrayColumn.php
+++ b/src/Views/Columns/ArrayColumn.php
@@ -2,9 +2,6 @@
 
 namespace Rappasoft\LaravelLivewireTables\Views\Columns;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
-use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Configuration\ArrayColumnConfiguration;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers\ArrayColumnHelpers;
@@ -24,6 +21,10 @@ class ArrayColumn extends Column
 
     protected mixed $outputFormat = null;
 
+    public ?string $outputWrapperStart = null;
+
+    public ?string $outputWrapperEnd = null;
+
     public function __construct(string $title, ?string $from = null)
     {
         parent::__construct($title, $from);
@@ -32,23 +33,4 @@ class ArrayColumn extends Column
         }
     }
 
-    public function getContents(Model $row): null|string|\BackedEnum|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
-    {
-        $outputValues = [];
-        $value = $this->getValue($row);
-
-        if (! $this->hasDataCallback()) {
-            throw new DataTableConfigurationException('You must set a data() method on an ArrayColumn');
-        }
-
-        if (! $this->hasOutputFormatCallback()) {
-            throw new DataTableConfigurationException('You must set an outputFormat() method on an ArrayColumn');
-        }
-
-        foreach (call_user_func($this->getDataCallback(), $value, $row) as $i => $v) {
-            $outputValues[] = call_user_func($this->getOutputFormatCallback(), $i, $v);
-        }
-
-        return new HtmlString((! empty($outputValues) ? implode($this->getSeparator(), $outputValues) : $this->getEmptyValue()));
-    }
 }

--- a/src/Views/Columns/ArrayColumn.php
+++ b/src/Views/Columns/ArrayColumn.php
@@ -6,6 +6,9 @@ use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Configuration\ArrayColumnConfiguration;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers\ArrayColumnHelpers;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\IsColumn;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 
 class ArrayColumn extends Column
 {
@@ -31,5 +34,32 @@ class ArrayColumn extends Column
         if (! isset($from)) {
             $this->label(fn () => null);
         }
+    }
+
+    
+    public function getContents(Model $row): null|string|\BackedEnum|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    {
+        $outputValues = [];
+        $value = $this->getValue($row);
+
+        if (! $this->hasDataCallback()) {
+            throw new DataTableConfigurationException('You must set a data() method on an ArrayColumn');
+        }
+
+        if (! $this->hasOutputFormatCallback()) {
+            throw new DataTableConfigurationException('You must set an outputFormat() method on an ArrayColumn');
+        }
+
+        foreach (call_user_func($this->getDataCallback(), $value, $row) as $i => $v) {
+            $outputValues[] = call_user_func($this->getOutputFormatCallback(), $i, $v);
+        }
+
+        $returnedValue = (! empty($outputValues) ? implode($this->getSeparator(), $outputValues) : $this->getEmptyValue());
+
+        if ($this->hasOutputWrapperStart() && $this->hasOutputWrapperEnd()) {
+            $returnedValue = $this->getOutputWrapperStart().$returnedValue.$this->getOutputWrapperEnd();
+        }
+
+        return new HtmlString($returnedValue);
     }
 }

--- a/src/Views/Columns/Traits/Configuration/ArrayColumnConfiguration.php
+++ b/src/Views/Columns/Traits/Configuration/ArrayColumnConfiguration.php
@@ -2,6 +2,8 @@
 
 namespace Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Configuration;
 
+use Illuminate\View\ComponentAttributeBag;
+
 trait ArrayColumnConfiguration
 {
     public function separator(string $value): self
@@ -33,5 +35,49 @@ trait ArrayColumnConfiguration
         $this->emptyValue = $emptyValue;
 
         return $this;
+    }
+
+    public function wrapperStart(string $value): self
+    {
+        $this->outputWrapperStart = $value;
+
+        return $this;
+    }
+
+    public function wrapperEnd(string $value): self
+    {
+        $this->outputWrapperEnd = $value;
+
+        return $this;
+    }
+
+    /**
+     * Setup Flex Col Behaviour
+     *
+     * @param array<mixed> $attribs
+     * @return self
+     */
+    public function flexCol(array $attribs = []): self
+    {
+        $bag = new ComponentAttributeBag(['class' => $this->isTailwind() ? 'flex flex-col' : 'd-flex d-flex-col']);
+
+        return $this->wrapperStart('<div '.$bag->merge($attribs).'>')
+            ->wrapperEnd('</div>')
+            ->separator('');
+    }
+
+    /**
+     * Setup Flex Row Behaviour
+     *
+     * @param array<mixed> $attribs
+     * @return self
+     */
+    public function flexRow(array $attribs = []): self
+    {
+        $bag = new ComponentAttributeBag(['class' => $this->isTailwind() ? 'flex flex-row' : 'd-flex d-flex-row']);
+
+        return $this->wrapperStart('<div '.$bag->merge($attribs).'>')
+            ->wrapperEnd('</div>')
+            ->separator('');
     }
 }

--- a/src/Views/Columns/Traits/Configuration/ArrayColumnConfiguration.php
+++ b/src/Views/Columns/Traits/Configuration/ArrayColumnConfiguration.php
@@ -54,8 +54,7 @@ trait ArrayColumnConfiguration
     /**
      * Setup Flex Col Behaviour
      *
-     * @param array<mixed> $attribs
-     * @return self
+     * @param  array<mixed>  $attribs
      */
     public function flexCol(array $attribs = []): self
     {
@@ -69,8 +68,7 @@ trait ArrayColumnConfiguration
     /**
      * Setup Flex Row Behaviour
      *
-     * @param array<mixed> $attribs
-     * @return self
+     * @param  array<mixed>  $attribs
      */
     public function flexRow(array $attribs = []): self
     {

--- a/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
+++ b/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
@@ -2,9 +2,6 @@
 
 namespace Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
-use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 
 trait ArrayColumnHelpers
 {
@@ -63,29 +60,4 @@ trait ArrayColumnHelpers
         return $this->outputWrapperEnd;
     }
 
-    public function getContents(Model $row): null|string|\BackedEnum|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
-    {
-        $outputValues = [];
-        $value = $this->getValue($row);
-
-        if (! $this->hasDataCallback()) {
-            throw new DataTableConfigurationException('You must set a data() method on an ArrayColumn');
-        }
-
-        if (! $this->hasOutputFormatCallback()) {
-            throw new DataTableConfigurationException('You must set an outputFormat() method on an ArrayColumn');
-        }
-
-        foreach (call_user_func($this->getDataCallback(), $value, $row) as $i => $v) {
-            $outputValues[] = call_user_func($this->getOutputFormatCallback(), $i, $v);
-        }
-
-        $returnedValue = (! empty($outputValues) ? implode($this->getSeparator(), $outputValues) : $this->getEmptyValue());
-
-        if ($this->hasOutputWrapperStart() && $this->hasOutputWrapperEnd()) {
-            $returnedValue = $this->getOutputWrapperStart().$returnedValue.$this->getOutputWrapperEnd();
-        }
-
-        return new HtmlString($returnedValue);
-    }
 }

--- a/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
+++ b/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
@@ -2,6 +2,10 @@
 
 namespace Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
+use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
+
 trait ArrayColumnHelpers
 {
     public function hasSeparator(): bool
@@ -38,4 +42,51 @@ trait ArrayColumnHelpers
     {
         return $this->outputFormat;
     }
+
+    public function hasOutputWrapperStart(): bool
+    {
+        return $this->outputWrapperStart !== null && is_string($this->outputWrapperStart);
+    }
+
+    public function getOutputWrapperStart(): string
+    {
+        return $this->outputWrapperStart;
+    }
+
+    public function hasOutputWrapperEnd(): bool
+    {
+        return $this->outputWrapperEnd !== null && is_string($this->outputWrapperEnd);
+    }
+
+    public function getOutputWrapperEnd(): string
+    {
+        return $this->outputWrapperEnd;
+    }
+
+    public function getContents(Model $row): null|string|\BackedEnum|HtmlString|DataTableConfigurationException|\Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View
+    {
+        $outputValues = [];
+        $value = $this->getValue($row);
+
+        if (! $this->hasDataCallback()) {
+            throw new DataTableConfigurationException('You must set a data() method on an ArrayColumn');
+        }
+
+        if (! $this->hasOutputFormatCallback()) {
+            throw new DataTableConfigurationException('You must set an outputFormat() method on an ArrayColumn');
+        }
+
+        foreach (call_user_func($this->getDataCallback(), $value, $row) as $i => $v) {
+            $outputValues[] = call_user_func($this->getOutputFormatCallback(), $i, $v);
+        }
+
+        $returnedValue = (! empty($outputValues) ? implode($this->getSeparator(), $outputValues) : $this->getEmptyValue());
+
+        if ($this->hasOutputWrapperStart() && $this->hasOutputWrapperEnd()) {
+            $returnedValue = $this->getOutputWrapperStart().$returnedValue.$this->getOutputWrapperEnd();
+        }
+
+        return new HtmlString($returnedValue);
+    }
+
 }

--- a/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
+++ b/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
@@ -88,5 +88,4 @@ trait ArrayColumnHelpers
 
         return new HtmlString($returnedValue);
     }
-
 }

--- a/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
+++ b/src/Views/Columns/Traits/Helpers/ArrayColumnHelpers.php
@@ -2,7 +2,6 @@
 
 namespace Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers;
 
-
 trait ArrayColumnHelpers
 {
     public function hasSeparator(): bool
@@ -59,5 +58,4 @@ trait ArrayColumnHelpers
     {
         return $this->outputWrapperEnd;
     }
-
 }

--- a/tests/Unit/Views/Columns/ArrayColumnTest.php
+++ b/tests/Unit/Views/Columns/ArrayColumnTest.php
@@ -4,7 +4,7 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Views\Columns;
 
 use PHPUnit\Framework\Attributes\Group;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
-use Rappasoft\LaravelLivewireTables\Tests\Models\Pet;
+use Rappasoft\LaravelLivewireTables\Tests\Models\{Pet,Veterinary};
 use Rappasoft\LaravelLivewireTables\Views\Columns\ArrayColumn;
 
 #[Group('Columns')]
@@ -80,4 +80,49 @@ final class ArrayColumnTest extends ColumnTestCase
         $this->assertSame('Unknown', self::$columnInstance->getEmptyValue());
 
     }
+
+    public function test_can_use_flexcol(): void
+    {
+        self::$columnInstance
+            ->data(fn ($value, $row) => ($row->pets))
+            ->outputFormat(fn ($index, $value) => '<a href="'.$value->id.'">'.$value->name.'</a>')
+            ->flexCol();
+
+        $contents = self::$columnInstance->getContents(Veterinary::find(1));
+        $this->assertSame('<div class="flex flex-col"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
+    }
+
+    public function test_can_use_flexcol_with_attributes(): void
+    {
+        self::$columnInstance
+            ->data(fn ($value, $row) => ($row->pets))
+            ->outputFormat(fn ($index, $value) => '<a href="'.$value->id.'">'.$value->name.'</a>')
+            ->flexCol(['class' => 'bg-red-500']);
+
+        $contents = self::$columnInstance->getContents(Veterinary::find(1));
+        $this->assertSame('<div class="bg-red-500 flex flex-col"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
+    }
+
+    public function test_can_use_flexrow(): void
+    {
+        self::$columnInstance
+            ->data(fn ($value, $row) => ($row->pets))
+            ->outputFormat(fn ($index, $value) => '<a href="'.$value->id.'">'.$value->name.'</a>')
+            ->flexRow();
+
+        $contents = self::$columnInstance->getContents(Veterinary::find(1));
+        $this->assertSame('<div class="flex flex-row"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
+    }
+
+    public function test_can_use_flexrow_with_attributes(): void
+    {
+        self::$columnInstance
+            ->data(fn ($value, $row) => ($row->pets))
+            ->outputFormat(fn ($index, $value) => '<a href="'.$value->id.'">'.$value->name.'</a>')
+            ->flexRow(['class' => 'bg-blue-500']);
+
+        $contents = self::$columnInstance->getContents(Veterinary::find(1));
+        $this->assertSame('<div class="bg-blue-500 flex flex-row"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
+    }
+
 }

--- a/tests/Unit/Views/Columns/ArrayColumnTest.php
+++ b/tests/Unit/Views/Columns/ArrayColumnTest.php
@@ -80,14 +80,14 @@ final class ArrayColumnTest extends ColumnTestCase
         $this->assertSame('Unknown', self::$columnInstance->getEmptyValue());
 
     }
-    
+
     public function test_can_use_wrapper(): void
     {
         self::$columnInstance
             ->data(fn ($value, $row) => ($row->pets))
             ->outputFormat(fn ($index, $value) => '<a href="'.$value->id.'">'.$value->name.'</a>')
             ->wrapperStart('<div class="start-of-wrapper">')
-            ->wrapperEnd("</div>");
+            ->wrapperEnd('</div>');
 
         $contents = self::$columnInstance->getContents(Veterinary::find(1));
         $this->assertSame('<div class="start-of-wrapper"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
@@ -99,7 +99,7 @@ final class ArrayColumnTest extends ColumnTestCase
             ->data(fn ($value, $row) => ($row->pets))
             ->outputFormat(fn ($index, $value) => '<li><a href="'.$value->id.'">'.$value->name.'</a></li>')
             ->wrapperStart('<ul class="start-of-wrapper">')
-            ->wrapperEnd("</ul>");
+            ->wrapperEnd('</ul>');
 
         $contents = self::$columnInstance->getContents(Veterinary::find(1));
         $this->assertSame('<ul class="start-of-wrapper"><li><a href="1">Cartman</a></li><li><a href="2">Tux</a></li></ul>', $contents->toHtml());

--- a/tests/Unit/Views/Columns/ArrayColumnTest.php
+++ b/tests/Unit/Views/Columns/ArrayColumnTest.php
@@ -98,7 +98,7 @@ final class ArrayColumnTest extends ColumnTestCase
         self::$columnInstance
             ->data(fn ($value, $row) => ($row->pets))
             ->outputFormat(fn ($index, $value) => '<li><a href="'.$value->id.'">'.$value->name.'</a></li>')
-            ->separator("")
+            ->separator('')
             ->wrapperStart('<ul class="start-of-wrapper">')
             ->wrapperEnd('</ul>');
 

--- a/tests/Unit/Views/Columns/ArrayColumnTest.php
+++ b/tests/Unit/Views/Columns/ArrayColumnTest.php
@@ -90,7 +90,7 @@ final class ArrayColumnTest extends ColumnTestCase
             ->wrapperEnd('</div>');
 
         $contents = self::$columnInstance->getContents(Veterinary::find(1));
-        $this->assertSame('<div class="start-of-wrapper"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
+        $this->assertSame('<div class="start-of-wrapper"><a href="1">Cartman</a><br /><a href="2">Tux</a></div>', $contents->toHtml());
     }
 
     public function test_can_use_wrapper_ul(): void
@@ -98,6 +98,7 @@ final class ArrayColumnTest extends ColumnTestCase
         self::$columnInstance
             ->data(fn ($value, $row) => ($row->pets))
             ->outputFormat(fn ($index, $value) => '<li><a href="'.$value->id.'">'.$value->name.'</a></li>')
+            ->separator("")
             ->wrapperStart('<ul class="start-of-wrapper">')
             ->wrapperEnd('</ul>');
 

--- a/tests/Unit/Views/Columns/ArrayColumnTest.php
+++ b/tests/Unit/Views/Columns/ArrayColumnTest.php
@@ -80,6 +80,30 @@ final class ArrayColumnTest extends ColumnTestCase
         $this->assertSame('Unknown', self::$columnInstance->getEmptyValue());
 
     }
+    
+    public function test_can_use_wrapper(): void
+    {
+        self::$columnInstance
+            ->data(fn ($value, $row) => ($row->pets))
+            ->outputFormat(fn ($index, $value) => '<a href="'.$value->id.'">'.$value->name.'</a>')
+            ->wrapperStart('<div class="start-of-wrapper">')
+            ->wrapperEnd("</div>");
+
+        $contents = self::$columnInstance->getContents(Veterinary::find(1));
+        $this->assertSame('<div class="start-of-wrapper"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
+    }
+
+    public function test_can_use_wrapper_ul(): void
+    {
+        self::$columnInstance
+            ->data(fn ($value, $row) => ($row->pets))
+            ->outputFormat(fn ($index, $value) => '<li><a href="'.$value->id.'">'.$value->name.'</a></li>')
+            ->wrapperStart('<ul class="start-of-wrapper">')
+            ->wrapperEnd("</ul>");
+
+        $contents = self::$columnInstance->getContents(Veterinary::find(1));
+        $this->assertSame('<ul class="start-of-wrapper"><li><a href="1">Cartman</a></li><li><a href="2">Tux</a></li></ul>', $contents->toHtml());
+    }
 
     public function test_can_use_flexcol(): void
     {

--- a/tests/Unit/Views/Columns/ArrayColumnTest.php
+++ b/tests/Unit/Views/Columns/ArrayColumnTest.php
@@ -124,5 +124,4 @@ final class ArrayColumnTest extends ColumnTestCase
         $contents = self::$columnInstance->getContents(Veterinary::find(1));
         $this->assertSame('<div class="bg-blue-500 flex flex-row"><a href="1">Cartman</a><a href="2">Tux</a></div>', $contents->toHtml());
     }
-
 }


### PR DESCRIPTION
This adds the capability to wrap the output of an ArrayColumn with a 
**FlexCol**
flexCol($attributes)

**FlexRow**
flexRow($attributes)

Or

**Manual**
wrapperStart
wrapperEnd

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
2. [x] Did you update all templates (if applicable)?
3. [x] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
