### PR TITLE
Prevent InvalidCharacterError by correctly rendering x-cloak attribute

### DIFF
--- a/resources/views/components/tools/filter-pills.blade.php
+++ b/resources/views/components/tools/filter-pills.blade.php
@@ -3,7 +3,7 @@
 <div {{ $attributes->merge([
 
     'wire:loading.class' => $this->displayFilterPillsWhileLoading ? '' : 'invisible',
-    'x-cloak',
+    'x-cloak' => '',
 ])
 ->class([
     'mb-4 px-4 md:p-0' => $isTailwind,

--- a/src/Traits/Helpers/TableAttributeHelpers.php
+++ b/src/Traits/Helpers/TableAttributeHelpers.php
@@ -131,7 +131,7 @@ trait TableAttributeHelpers
         return [
             'x-data' => 'laravellivewiretable($wire)',
             'x-init' => "setTableId('".$this->getTableAttributes()['id']."'); setAlpineBulkActions('".$this->showBulkActionsDropdownAlpine()."'); setPrimaryKeyName('".$this->getPrimaryKey()."');",
-            'x-cloak',
+            'x-cloak' => '',
             'x-show' => 'shouldBeDisplayed',
             'x-on:show-table.window' => 'showTable(event)',
             'x-on:hide-table.window' => 'hideTable(event)',


### PR DESCRIPTION
### Description
This PR addresses a bug that caused an `InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': '0' is not a valid attribute name.`

The root cause was that `'x-cloak'` was added as a value without an explicit key in PHP arrays responsible for generating HTML attributes (e.g., in `getTopLevelAttributesArray()`). This led to PHP assigning a numeric index, which was then incorrectly used as the attribute name.

The fix changes the array definition from `..., 'x-cloak', ...` to `..., 'x-cloak' => '', ...`. This ensures `x-cloak` is rendered as a proper attribute (`x-cloak=""`), resolving the JavaScript error and allowing Alpine.js to function as expected.



### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests and did you add any new tests needed for your feature?
*  Did you update all templates (if applicable)?
*  Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
*  Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
