### PR TITLE
Change w-100 to w-auto for Bootstrap Bulk Actions Menu and ColumnSelect

### DIFF
--- a/resources/views/components/tools/toolbar/items/bulk-actions.blade.php
+++ b/resources/views/components/tools/toolbar/items/bulk-actions.blade.php
@@ -94,8 +94,8 @@
                 {{ 
                     $attributes->merge($this->getBulkActionsMenuAttributes)
                     ->class([
-                        'dropdown-menu dropdown-menu-right w-100' => $isBootstrap4 && ($this->getBulkActionsMenuAttributes['default-styling'] ?? true),
-                        'dropdown-menu dropdown-menu-end w-100' => $isBootstrap5 && ($this->getBulkActionsMenuAttributes['default-styling'] ?? true),
+                        'dropdown-menu dropdown-menu-right w-auto' => $isBootstrap4 && ($this->getBulkActionsMenuAttributes['default-styling'] ?? true),
+                        'dropdown-menu dropdown-menu-end w-auto' => $isBootstrap5 && ($this->getBulkActionsMenuAttributes['default-styling'] ?? true),
                     ])
                     ->except(['default','default-styling','default-colors']) 
                 }}

--- a/resources/views/components/tools/toolbar/items/column-select.blade.php
+++ b/resources/views/components/tools/toolbar/items/column-select.blade.php
@@ -122,7 +122,7 @@
                 {{
                     $attributes->merge($this->getColumnSelectButtonAttributes())
                     ->class([
-                        'btn dropdown-toggle d-block w-100 d-md-inline' => $this->getColumnSelectButtonAttributes()['default-styling'],
+                        'btn dropdown-toggle d-block w-auto d-md-inline' => $this->getColumnSelectButtonAttributes()['default-styling'],
                     ])
                     ->except(['default-styling', 'default-colors'])
                 }}
@@ -135,8 +135,8 @@
             <div
                 x-bind:class="{ 'show': open }"
                 @class([
-                    'dropdown-menu dropdown-menu-right w-100 mt-0 mt-md-3' => $isBootstrap4,
-                    'dropdown-menu dropdown-menu-end w-100' => $isBootstrap5,
+                    'dropdown-menu dropdown-menu-right w-auto mt-0 mt-md-3' => $isBootstrap4,
+                    'dropdown-menu dropdown-menu-end w-auto' => $isBootstrap5,
                 ])
                 aria-labelledby="columnSelect-{{ $tableName }}"
             >


### PR DESCRIPTION
This is to fix overflow issues for Bulk Actions Menu and Column Select menu

Both are dropdowns, and this replaces the Bootstrap class "w-100" with "w-auto"

Needs testing prior to merging.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
