### PR TITLE
Added database driver check for Postgresql in text search

### DIFF
--- a/src/Traits/WithSearch.php
+++ b/src/Traits/WithSearch.php
@@ -34,12 +34,13 @@ trait WithSearch
             }
 
             if ($searchableColumns->count()) {
-                $this->setBuilder($this->getBuilder()->where(function ($query) use ($searchableColumns, $search) {
+                $likeOperator = $this->getBuilder()->getConnection()->getDriverName() === 'pgsql' ? 'ilike' : 'like';
+                $this->setBuilder($this->getBuilder()->where(function ($query) use ($likeOperator, $searchableColumns, $search) {
                     foreach ($searchableColumns as $index => $column) {
                         if ($column->hasSearchCallback()) {
                             ($column->getSearchCallback())($query, $search);
                         } else {
-                            $query->{$index === 0 ? 'where' : 'orWhere'}($column->getColumn(), 'like', '%'.$search.'%');
+                            $query->{$index === 0 ? 'where' : 'orWhere'}($column->getColumn(), $likeOperator, '%'.$search.'%');
                         }
                     }
                 }));


### PR DESCRIPTION
Add a database driver check to change the 'like' operator to 'ilike'. This enables Postgresql searches to be case-insensitive by default the same as Mysql.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
