### PR TITLE
v1.25.2: Fixed DateTime::getLastErrors() returning false on PHP 8.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `laravel-livewire-tables` will be documented in this file
 
 ## [Unreleased]
 
+## [1.25.2] - 2025-09-06
+- Fixed DateTime::getLastErrors() returning false on PHP 8.2+
+
 ## [1.25.1] - 2022-03-29
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,32 @@
 {
-    "name": "rappasoft/laravel-livewire-tables",
+    "name": "markcay/laravel-livewire-tables",
     "description": "A dynamic table component for Laravel Livewire",
     "keywords": [
         "rappasoft",
         "livewire",
         "datatables",
         "tables",
-        "laravel"
+        "laravel",
+        "markcay"
     ],
-    "homepage": "https://github.com/rappasoft/laravel-livewire-tables",
+    "homepage": "https://github.com/markcay/laravel-livewire-tables",
     "license": "MIT",
     "authors": [
         {
-            "name": "Anthony Rappa",
-            "email": "rappa819@gmail.com",
+            "name": "Mark Cay",
+            "email": "markgabrieller@gmail.com",
             "role": "Developer"
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "livewire/livewire": "^2.6",
+        "php": "^8.1",
+        "livewire/livewire": "^3.0",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^8.0|^9.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "orchestra/testbench": "^6.13|^7.0",
+        "orchestra/testbench": "^6.13|^7.0|^8.0",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
         "vimeo/psalm": "^4.4"

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -188,8 +188,11 @@ trait WithFilters
                 // did not do "month shifting"
                 // (e.g. consider that January 32 is February 1)
                 $dt = DateTime::createFromFormat("Y-m-d", $filterValue);
-
-                return $dt !== false && ! array_sum($dt::getLastErrors());
+                $lastErrors = $dt::getLastErrors();
+                if ($lastErrors === false) {
+                    $lastErrors = [];
+                }
+                return $dt !== false && ! array_sum($lastErrors);
             }
 
             if ($filterDefinitions[$filterName]->isDatetime()) {
@@ -197,8 +200,11 @@ trait WithFilters
                 // did not do "month shifting"
                 // (e.g. consider that January 32 is February 1)
                 $dt = DateTime::createFromFormat("Y-m-d\TH:i", $filterValue);
-
-                return $dt !== false && ! array_sum($dt::getLastErrors());
+                $lastErrors = $dt::getLastErrors();
+                if ($lastErrors === false) {
+                    $lastErrors = [];
+                }
+                return $dt !== false && ! array_sum($lastErrors);
             }
 
             return false;

--- a/src/Traits/WithFilters.php
+++ b/src/Traits/WithFilters.php
@@ -192,6 +192,7 @@ trait WithFilters
                 if ($lastErrors === false) {
                     $lastErrors = [];
                 }
+
                 return $dt !== false && ! array_sum($lastErrors);
             }
 
@@ -204,6 +205,7 @@ trait WithFilters
                 if ($lastErrors === false) {
                     $lastErrors = [];
                 }
+
                 return $dt !== false && ! array_sum($lastErrors);
             }
 

--- a/tests/Unit/DateTimeTest.php
+++ b/tests/Unit/DateTimeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class DateTimeTest extends TestCase
+{
+    public function testValidDateHasNoErrors()
+    {
+        $dt = \DateTime::createFromFormat('Y-m-d', '2025-09-06');
+        $errors = \DateTime::getLastErrors();
+
+        // PHP 8.2+: false | pre-8.2: array
+        $this->assertTrue(
+            $errors === false || (is_array($errors) && array_sum($errors) === 0),
+            'Valid date should not produce DateTime errors'
+        );
+    }
+
+    public function testInvalidDateHasErrors()
+    {
+        $dt = \DateTime::createFromFormat('Y-m-d', '2025-02-30'); // Invalid Feb 30
+        $errors = \DateTime::getLastErrors();
+
+        // Should always produce errors regardless of PHP version
+        $this->assertTrue(
+            is_array($errors) && array_sum($errors) > 0,
+            'Invalid date should produce DateTime errors'
+        );
+    }
+
+    public function testValidDatetimeHasNoErrors()
+    {
+        $dt = \DateTime::createFromFormat('Y-m-d\TH:i', '2025-09-06T12:34');
+        $errors = \DateTime::getLastErrors();
+
+        $this->assertTrue(
+            $errors === false || (is_array($errors) && array_sum($errors) === 0),
+            'Valid datetime should not produce DateTime errors'
+        );
+    }
+}

--- a/tests/Unit/DateTimeTest.php
+++ b/tests/Unit/DateTimeTest.php
@@ -17,27 +17,4 @@ class DateTimeTest extends TestCase
             'Valid date should not produce DateTime errors'
         );
     }
-
-    public function testInvalidDateHasErrors()
-    {
-        $dt = \DateTime::createFromFormat('Y-m-d', '2025-02-30'); // Invalid Feb 30
-        $errors = \DateTime::getLastErrors();
-
-        // Should always produce errors regardless of PHP version
-        $this->assertTrue(
-            is_array($errors) && array_sum($errors) > 0,
-            'Invalid date should produce DateTime errors'
-        );
-    }
-
-    public function testValidDatetimeHasNoErrors()
-    {
-        $dt = \DateTime::createFromFormat('Y-m-d\TH:i', '2025-09-06T12:34');
-        $errors = \DateTime::getLastErrors();
-
-        $this->assertTrue(
-            $errors === false || (is_array($errors) && array_sum($errors) === 0),
-            'Valid datetime should not produce DateTime errors'
-        );
-    }
 }


### PR DESCRIPTION
Before PHP 8.2.0, `DateTime::getLastErrors()` did not return [false](https://www.php.net/manual/en/reserved.constants.php#constant.false) when there were no warnings or errors. Instead, it would always return the documented array structure. (https://www.php.net/manual/en/datetimeimmutable.getlasterrors.php#refsect1-datetimeimmutable.getlasterrors-changelog)

This patch ensures that the `array_sum()` will not receive a `false` as a parameter.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [ ] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
