### PR TITLE
Support Closures in getBulkActionsTdCheckboxAttributes for Improved Accessibility

### DIFF
--- a/resources/views/components/forms/checkbox.blade.php
+++ b/resources/views/components/forms/checkbox.blade.php
@@ -1,5 +1,7 @@
 @aware(['tableName','primaryKey', 'isTailwind', 'isBootstrap', 'isBootstrap4', 'isBootstrap5'])
-@props(['checkboxAttributes'])
+@props(['checkboxAttributes',
+//'row'
+])
 <input x-cloak
     {{
         $attributes->merge($checkboxAttributes)->class([
@@ -8,4 +10,5 @@
             'form-check-input' => ($isBootstrap5) && ($checkboxAttributes['default'] ?? true),
         ])->except(['default','default-styling','default-colors'])
     }}
+    {{--    aria-label="select row number {{$row->id}}"--}}
 />

--- a/resources/views/components/table/td/bulk-actions.blade.php
+++ b/resources/views/components/table/td/bulk-actions.blade.php
@@ -3,6 +3,7 @@
 
 @php
     $tdAttributes = $this->getBulkActionsTdAttributes;
+    // $tdCheckboxAttributes = $this->getBulkActionsTdCheckboxAttributes($row, $rowIndex);
     $tdCheckboxAttributes = $this->getBulkActionsTdCheckboxAttributes;
 @endphp
 
@@ -12,9 +13,10 @@
             'inline-flex rounded-md shadow-sm' => $isTailwind,
             'form-check' => $isBootstrap5,
         ])>
-            <x-livewire-tables::forms.checkbox 
-                wire:key="{{ $tableName . 'selectedItems-'.$row->{$primaryKey} }}" 
+            <x-livewire-tables::forms.checkbox
+                wire:key="{{ $tableName . 'selectedItems-'.$row->{$primaryKey} }}"
                 value="{{ $row->{$primaryKey} }}"
+                {{-- :$row--}}
                 :checkboxAttributes=$tdCheckboxAttributes
             />
         </div>

--- a/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/BulkActionsStylingConfigurationTest.php
@@ -176,7 +176,9 @@ final class BulkActionsStylingConfigurationTest extends TestCase
         $this->assertSame($defaultAttributeBag->getAttributes(), $returnedAttributeBag->getAttributes());
 
         $this->basicTable->setBulkActionsTdCheckboxAttributes([
+            'default' => false,
             'default-colors' => true,
+            'default-styling' => false,
             'class' => 'w-12',
         ]);
 


### PR DESCRIPTION
Currently, it is not possible to pass a closure to the getBulkActionsTdCheckboxAttributes method, as it only accepts arrays. For my project, I need to pass the current row index in order to display an appropriate aria-label for each checkbox.

**Changes:**

The method has been adapted to accept both arrays and closures, ensuring backwards compatibility.

**Alternative Considered:**

Hardcoding the aria-label in the checkbox component was considered. However, this approach would require accessing the locale and handling language-specific placement of the row index, which varies (e.g., English: "select row number {{$row->id}}", German: "Zeile {{$row->id}} auswählen"). This alternative is commented out in td/bulk-actions.blade.php and forms/checkbox.blade.php.

I have not yet added documentation or new tests, as I would like to get your feedback on the proposed changes first.

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests and did you add any new tests needed for your feature?
2. [ ] Did you update all templates (if applicable)?
3. [ ] Did you add the [relevant documentation](https://github.com/rappasoft/laravel-livewire-tables-docs) (if applicable)?
4. [x] Did you test locally to make sure your feature works as intended?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
