### PR TITLE
Upgrade to Livewire 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "blade-ui-kit/blade-heroicons": "^2.1",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "livewire/livewire": "^3.0|dev-main"
+        "livewire/livewire": "^4.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",

--- a/docs/filters/available-filter-methods.md
+++ b/docs/filters/available-filter-methods.md
@@ -92,7 +92,7 @@ For the following Filters, you may customise how the input is wire:model into th
 You may override this using the following methods, on any of the above Filter types:
 
 ### setWireBlur()
-Forces the filter to use a wire:model.blur approach
+Forces the filter to use a wire:model.live.blur approach
 ```php
     TextFilter::make('Name')
     ->config([

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -7,8 +7,6 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Livewire\Features\SupportConsoleCommands\Commands\ComponentParser;
-use Livewire\Features\SupportConsoleCommands\Commands\MakeCommand as LivewireMakeCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
@@ -21,7 +19,11 @@ use function Laravel\Prompts\text;
  */
 class MakeCommand extends Command implements PromptsForMissingInput
 {
-    protected ComponentParser $parser;
+    protected string $className;
+
+    protected string $classNamespace;
+
+    protected string $classPath;
 
     /**
      * @var string
@@ -56,19 +58,23 @@ class MakeCommand extends Command implements PromptsForMissingInput
      */
     public function handle(): void
     {
-        $this->parser = new ComponentParser(
-            config('livewire.class_namespace'),
-            config('livewire.view_path'),
-            $this->argument('name')
-        );
+        $name = $this->argument('name');
 
-        $livewireMakeCommand = new LivewireMakeCommand;
+        $segments = str($name)->replace(['/', '\\'], '.')
+            ->explode('.')
+            ->map(fn ($s) => Str::studly($s))
+            ->all();
 
-        if ($livewireMakeCommand->isReservedClassName($name = $this->parser->className())) {
-            $this->line("<fg=red;options=bold>Class is reserved:</> {$name}");
+        $this->className = array_pop($segments);
 
-            return;
-        }
+        $baseNamespace = config('livewire.class_namespace', 'App\\Livewire');
+        $this->classNamespace = ! empty($segments)
+            ? $baseNamespace.'\\'.implode('\\', $segments)
+            : $baseNamespace;
+
+        $classBasePath = config('livewire.class_path', app_path('Livewire'));
+        $subPath = ! empty($segments) ? implode('/', $segments).'/' : '';
+        $this->classPath = $classBasePath.'/'.$subPath.$this->className.'.php';
 
         $this->model = Str::studly($this->argument('model'));
         $this->modelPath = $this->argument('modelpath') ?? null;
@@ -77,24 +83,22 @@ class MakeCommand extends Command implements PromptsForMissingInput
 
         $this->createClass($force);
 
-        $this->info('Livewire Datatable Created: '.$this->parser->className());
+        $this->info('Livewire Datatable Created: '.$this->className);
     }
 
     protected function createClass(bool $force = false): bool
     {
-        $classPath = $this->parser->classPath();
-
-        if (! $force && File::exists($classPath)) {
-            $this->line("<fg=red;options=bold>Class already exists:</> {$this->parser->relativeClassPath()}");
+        if (! $force && File::exists($this->classPath)) {
+            $this->line("<fg=red;options=bold>Class already exists:</> {$this->classPath}");
 
             return false;
         }
 
-        $this->ensureDirectoryExists($classPath);
+        $this->ensureDirectoryExists($this->classPath);
 
-        File::put($classPath, $this->classContents());
+        File::put($this->classPath, $this->classContents());
 
-        return $classPath;
+        return true;
     }
 
     protected function ensureDirectoryExists(string $path): void
@@ -108,7 +112,7 @@ class MakeCommand extends Command implements PromptsForMissingInput
     {
         return str_replace(
             ['[namespace]', '[class]', '[model]', '[model_import]', '[columns]'],
-            [$this->parser->classNamespace(), $this->parser->className(), $this->model, $this->getModelImport(), $this->generateColumns($this->getModelImport())],
+            [$this->classNamespace, $this->className, $this->model, $this->getModelImport(), $this->generateColumns($this->getModelImport())],
             file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'table.stub')
         );
     }

--- a/src/Traits/Core/Search/HandlesSearchModifiers.php
+++ b/src/Traits/Core/Search/HandlesSearchModifiers.php
@@ -73,7 +73,7 @@ trait HandlesSearchModifiers
         }
 
         if ($this->hasSearchBlur()) {
-            return '.blur';
+            return '.live.blur';
         }
 
         if ($this->hasSearchLazy()) {

--- a/src/Views/Columns/Traits/IsColumn.php
+++ b/src/Views/Columns/Traits/IsColumn.php
@@ -4,7 +4,7 @@ namespace Rappasoft\LaravelLivewireTables\Views\Columns\Traits;
 
 use Rappasoft\LaravelLivewireTables\Traits\Core\HasLocalisations;
 use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Configuration\ColumnConfiguration;
-use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers\{ColumnHelpers};
+use Rappasoft\LaravelLivewireTables\Views\Columns\Traits\Helpers\ColumnHelpers;
 use Rappasoft\LaravelLivewireTables\Views\Traits\Core\{HasAttributes, HasLabelAttributes, HasTheme};
 
 trait IsColumn

--- a/src/Views/Filters/DateRangeFilter.php
+++ b/src/Views/Filters/DateRangeFilter.php
@@ -14,7 +14,7 @@ class DateRangeFilter extends Filter
         HasConfig;
     use HasWireables;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.date-range';
 

--- a/src/Views/Filters/LivewireComponentArrayFilter.php
+++ b/src/Views/Filters/LivewireComponentArrayFilter.php
@@ -12,7 +12,7 @@ class LivewireComponentArrayFilter extends Filter
     use HasOptions;
     use IsLivewireComponentFilter;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.livewire-component-array-filter';
 

--- a/src/Views/Filters/LivewireComponentFilter.php
+++ b/src/Views/Filters/LivewireComponentFilter.php
@@ -10,7 +10,7 @@ class LivewireComponentFilter extends Filter
     use HasWireables;
     use IsLivewireComponentFilter;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.livewire-component-filter';
 

--- a/src/Views/Filters/NumberFilter.php
+++ b/src/Views/Filters/NumberFilter.php
@@ -10,7 +10,7 @@ class NumberFilter extends Filter
     use IsNumericFilter;
     use HasWireables;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.number';
 

--- a/src/Views/Filters/NumberRangeFilter.php
+++ b/src/Views/Filters/NumberRangeFilter.php
@@ -10,7 +10,7 @@ class NumberRangeFilter extends Filter
     use HasOptions;
     use HasWireables;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.number-range';
 

--- a/src/Views/Filters/TextFilter.php
+++ b/src/Views/Filters/TextFilter.php
@@ -11,7 +11,7 @@ class TextFilter extends Filter
     use HasWireables;
     use HandlesWildcardStrings;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.text-field';
 

--- a/src/Views/Filters/Traits/IsFilter.php
+++ b/src/Views/Filters/Traits/IsFilter.php
@@ -3,7 +3,7 @@
 namespace Rappasoft\LaravelLivewireTables\Views\Filters\Traits;
 
 use Rappasoft\LaravelLivewireTables\Traits\Core\HasLocalisations;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\Styling\{HandlesFilterInputAttributes};
+use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\Styling\HandlesFilterInputAttributes;
 use Rappasoft\LaravelLivewireTables\Views\Traits\Core\{HasConfig, HasLabelAttributes, HasView};
 
 trait IsFilter

--- a/src/Views/Traits/Core/HasWireables.php
+++ b/src/Views/Traits/Core/HasWireables.php
@@ -26,7 +26,7 @@ trait HasWireables
     {
         $wireMethod = $this->checkWireMethod($wireMethod);
 
-        $this->{$wireMethod} = 'blur';
+        $this->{$wireMethod} = 'live.blur';
 
         return $this;
     }
@@ -69,7 +69,7 @@ trait HasWireables
     {
         $wireMethod = $this->checkWireMethod($wireMethod);
 
-        return $this->getWireMethodString($this->{$wireMethod} ?? 'blur', $wireableElement);
+        return $this->getWireMethodString($this->{$wireMethod} ?? 'live.blur', $wireableElement);
     }
 
     public function getWireMethodString(string $wireMethod, string $wireableElement): string

--- a/tests/Unit/Traits/Configuration/SearchConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/SearchConfigurationTest.php
@@ -139,7 +139,7 @@ final class SearchConfigurationTest extends TestCase
         $this->basicTable->setSearchBlur();
 
         $this->assertTrue($this->basicTable->hasSearchBlur());
-        $this->assertSame('.blur', $this->basicTable->getSearchOptions());
+        $this->assertSame('.live.blur', $this->basicTable->getSearchOptions());
     }
 
     public function test_cant_set_search_blur_with_other_search_modifiers(): void

--- a/tests/Unit/Traits/Helpers/SearchHelpersTest.php
+++ b/tests/Unit/Traits/Helpers/SearchHelpersTest.php
@@ -183,7 +183,7 @@ final class SearchHelpersTest extends TestCase
 
         $temp->resetSearchConfiguration()->setSearchBlur();
 
-        $this->assertSame('.blur', $temp->getSearchOptions());
+        $this->assertSame('.live.blur', $temp->getSearchOptions());
 
         $temp->resetSearchConfiguration()->setSearchLazy();
 

--- a/tests/Unit/Views/Filters/DateFilterTest.php
+++ b/tests/Unit/Views/Filters/DateFilterTest.php
@@ -160,9 +160,9 @@ final class DateFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/DateTimeFilterTest.php
+++ b/tests/Unit/Views/Filters/DateTimeFilterTest.php
@@ -151,9 +151,9 @@ final class DateTimeFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/MultiSelectDropdownFilterTest.php
+++ b/tests/Unit/Views/Filters/MultiSelectDropdownFilterTest.php
@@ -217,8 +217,8 @@ final class MultiSelectDropdownFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/MultiSelectFilterTest.php
+++ b/tests/Unit/Views/Filters/MultiSelectFilterTest.php
@@ -186,8 +186,8 @@ final class MultiSelectFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/SelectFilterTest.php
+++ b/tests/Unit/Views/Filters/SelectFilterTest.php
@@ -87,8 +87,8 @@ final class SelectFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireDefer();
 

--- a/tests/Unit/Views/Filters/TextFilterTest.php
+++ b/tests/Unit/Views/Filters/TextFilterTest.php
@@ -76,9 +76,9 @@ final class TextFilterTest extends FilterTestCase
     {
         $filter = TextFilter::make('Active');
 
-        $this->assertSame('blur', $filter->getWireableMethod());
+        $this->assertSame('live.blur', $filter->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
 
         $filter->setWireLive();
 
@@ -92,9 +92,9 @@ final class TextFilterTest extends FilterTestCase
 
         $filter->setWireBlur();
 
-        $this->assertSame('blur', $filter->getWireableMethod());
+        $this->assertSame('live.blur', $filter->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
 
         $filter->setWireDebounce(250);
 

--- a/tests/Visuals/Columns/LivewireComponentColumnVisualsTest.php
+++ b/tests/Visuals/Columns/LivewireComponentColumnVisualsTest.php
@@ -8,7 +8,7 @@ use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Group;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\FailingTables\{BrokenSecondaryHeaderTable, NoBuildMethodTable, NoPrimaryKeyTable};
-use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\{PetsTableWithLivewireColumn};
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableWithLivewireColumn;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 #[Group('Visuals')]

--- a/tests/Visuals/Filters/NumberFilterVisualsTest.php
+++ b/tests/Visuals/Filters/NumberFilterVisualsTest.php
@@ -40,7 +40,7 @@ final class NumberFilterVisualsTest extends FilterVisualsTestCase
                 ];
             }
         })
-            ->assertSeeHtml('<input wire:model.blur="filterComponents.numberfilter" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-800 dark:text-white dark:border-gray-600" id="table-filter-numberfilter" max="100" min="20" steps="0.5" type="number" wire:key="table-filter-number-numberfilter" />');
+            ->assertSeeHtml('<input wire:model.live.blur="filterComponents.numberfilter" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-800 dark:text-white dark:border-gray-600" id="table-filter-numberfilter" max="100" min="20" steps="0.5" type="number" wire:key="table-filter-number-numberfilter" />');
 
     }
 }

--- a/tests/Visuals/Filters/TextFilterVisualsTest.php
+++ b/tests/Visuals/Filters/TextFilterVisualsTest.php
@@ -329,7 +329,7 @@ final class TextFilterVisualsTest extends FilterVisualsTestCase
                 ];
             }
         })
-            ->assertSeeHtml('<input wire:model.blur="filterComponents.name" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 bg-red-500" id="table-filter-name" maxlength="75" type="text" wire:key="table-filter-text-name" />');
+            ->assertSeeHtml('<input wire:model.live.blur="filterComponents.name" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 bg-red-500" id="table-filter-name" maxlength="75" type="text" wire:key="table-filter-text-name" />');
 
     }
 }

--- a/tests/Visuals/PaginationVisualsTest.php
+++ b/tests/Visuals/PaginationVisualsTest.php
@@ -5,7 +5,7 @@ namespace Rappasoft\LaravelLivewireTables\Tests\Visuals;
 use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Group;
 use Rappasoft\LaravelLivewireTables\Exceptions\DataTableConfigurationException;
-use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\{PetsTable};
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 use Rappasoft\LaravelLivewireTables\Tests\TestCase;
 
 #[Group('Visuals')]

--- a/tests/Visuals/SearchVisualsTest.php
+++ b/tests/Visuals/SearchVisualsTest.php
@@ -59,9 +59,9 @@ final class SearchVisualsTest extends TestCase
     public function test_search_blur_filter_is_applied(): void
     {
         Livewire::test(PetsTable::class)
-            ->assertDontSeeHtml('wire:model.blur="search"')
+            ->assertDontSeeHtml('wire:model.live.blur="search"')
             ->call('setSearchBlur')
-            ->assertSeeHtml('wire:model.blur="search"');
+            ->assertSeeHtml('wire:model.live.blur="search"');
     }
 
     public function test_search_lazy_filter_is_applied(): void


### PR DESCRIPTION
# Upgrade Summary

Made with the help of Claude Sonnet 4.6. I fed it the upgrade guide, made a plan, review the plan and made sure to adjust some things I thought was necessary.

## Changes
- Bump `livewire/livewire` constraint from `^3.0|dev-main` → `^4.0`
- Refactor `MakeCommand` to remove deleted Livewire v3 internals
- Update `wire:model.blur` → `wire:model.live.blur` to preserve behavior
- Update documentation to reflect the `.live.blur` change

---

## Details
### MakeCommand (`src/Commands/MakeCommand.php`)

Livewire v4 removed:

- `ComponentParser`
- `LivewireMakeCommand`

Both were previously part of the `SupportConsoleCommands` feature.

The `make:datatable` command depended on them for:

| Dependency | Purpose |
|----------|------|
| `ComponentParser` | Resolve class name, namespace, and path from user input |
| `LivewireMakeCommand::isReservedClassName()` | Validate reserved component names |

### Replacement Implementation
A self-contained implementation now:

- Resolves class name using `Str::studly()`
- Resolves namespace and file path using:
  - `livewire.class_namespace`
  - `livewire.class_path`

The reserved class name validation was **removed**.

> It only prevented names like `Component` or `Template`, which are unrealistic for datatable generation.

---

## `wire:model.blur` → `wire:model.live.blur`

### Livewire v3 behavior
- `wire:model` → deferred by default
- `wire:model.blur` → syncs value when the field loses focus

### Livewire v4.1 behavior
- `wire:model` → still deferred
- `wire:model.blur` → **no longer works**
- `.blur` now only applies to **live models**

I thought it would make most sense in this PR to stick to the old behaviour, so all `blur` references were updated to `live.blur`. This should still be compatible with v4.0