### PR TITLE
Add lazy loading placeholder support for Livewire datatables

### DIFF
--- a/docs/datatable/loaders.md
+++ b/docs/datatable/loaders.md
@@ -78,3 +78,64 @@ public function configure(): void
   $this->setLoadingPlaceholderBlade('');
 }
 ```
+
+## Lazy Placeholder
+
+Livewire supports [lazy loading](https://livewire.laravel.com/docs/lazy) via the `lazy` attribute. When using `lazy="on-load"` on a datatable component, Alpine.js variables need to be pre-initialized on the placeholder to avoid errors during the morph process.
+
+The lazy placeholder feature provides a built-in skeleton placeholder with proper Alpine.js scope, supporting both Tailwind CSS and Bootstrap.
+
+### Basic Usage
+
+Simply add `lazy="on-load"` to your Livewire component tag:
+
+```html
+<livewire:my-table lazy="on-load" />
+```
+
+The default skeleton placeholder is automatically rendered — no configuration needed.
+
+### setLazyPlaceholderStatus
+```php
+public function configure(): void
+{
+  $this->setLazyPlaceholderStatus(true);
+}
+```
+
+### setLazyPlaceholderEnabled
+Enables the lazy placeholder (enabled by default).
+```php
+public function configure(): void
+{
+  $this->setLazyPlaceholderEnabled();
+}
+```
+
+### setLazyPlaceholderDisabled
+Disables the lazy placeholder content. The Alpine.js scope wrapper is still rendered to prevent errors, but no skeleton content is shown.
+```php
+public function configure(): void
+{
+  $this->setLazyPlaceholderDisabled();
+}
+```
+
+### setLazyPlaceholderView
+Set a custom Blade view to use as the placeholder content. Your custom view will be wrapped with the required Alpine.js scope automatically.
+```php
+public function configure(): void
+{
+  $this->setLazyPlaceholderView('components.my-custom-skeleton');
+}
+```
+
+### Overriding the placeholder Method
+For full control, you may override the `placeholder()` method directly:
+```php
+public function placeholder(array $params = []): \Illuminate\Contracts\View\View
+{
+  return view('my-fully-custom-placeholder');
+}
+```
+**Note:** If you override `placeholder()` entirely, you are responsible for including the Alpine.js `x-data` scope on the root element to prevent morph errors.

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -7,7 +7,7 @@
 @php($isBootstrap5 = $this->isBootstrap5)
 @php($localisationPath = $this->getLocalisationPath)
 
-<div x-data="{ currentlyReorderingStatus: false, paginationTotalItemCount: 0, paginationCurrentCount: 0, paginationCurrentItems: [], selectedItems: [], selectAllStatus: false, delaySelectAll: false, hideBulkActionsWhenEmpty: false, reorderStatus: false, reorderDisplayColumn: false, shouldBeDisplayed: true, filtersOpen: false }">
+<div x-data="{{ $this->getAlpineDefaultScope() }}">
     <div {{ $this->getTopLevelAttributes() }}>
 
             @includeWhen(

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -7,9 +7,8 @@
 @php($isBootstrap5 = $this->isBootstrap5)
 @php($localisationPath = $this->getLocalisationPath)
 
-<div>
-    <div x-data="{ currentlyReorderingStatus: false }">
-        <div {{ $this->getTopLevelAttributes() }}>
+<div x-data="{ currentlyReorderingStatus: false, paginationTotalItemCount: 0, paginationCurrentCount: 0, paginationCurrentItems: [], selectedItems: [], selectAllStatus: false, delaySelectAll: false, hideBulkActionsWhenEmpty: false, reorderStatus: false, reorderDisplayColumn: false, shouldBeDisplayed: true, filtersOpen: false }">
+    <div {{ $this->getTopLevelAttributes() }}>
 
             @includeWhen(
                 $this->hasConfigurableAreaFor('before-wrapper'),
@@ -157,6 +156,5 @@
                 $this->getParametersForConfigurableArea('after-wrapper')
             )
 
-        </div>
     </div>
 </div>

--- a/resources/views/lazy-placeholder-content.blade.php
+++ b/resources/views/lazy-placeholder-content.blade.php
@@ -1,0 +1,95 @@
+@if ($isTailwind)
+    <div class="w-full" role="status" aria-label="Loading table data...">
+        <div class="mb-4 flex items-center justify-between">
+            <div class="h-8 w-48 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+            <div class="h-8 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 shadow dark:border-gray-700 sm:rounded-lg">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-none">
+                <thead class="bg-gray-50 dark:bg-gray-800">
+                    <tr>
+                        @for ($col = 0; $col < 4; $col++)
+                            <th class="px-6 py-3">
+                                <div class="h-4 w-3/4 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                            </th>
+                        @endfor
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 bg-white dark:divide-none dark:bg-gray-800">
+                    @for ($i = 0; $i < 10; $i++)
+                        <tr>
+                            @for ($col = 0; $col < 4; $col++)
+                                <td class="px-6 py-4">
+                                    <div class="h-4 animate-pulse rounded bg-gray-200 dark:bg-gray-700" style="width: {{ [60, 75, 50, 40][$col % 4] }}%"></div>
+                                </td>
+                            @endfor
+                        </tr>
+                    @endfor
+                </tbody>
+            </table>
+        </div>
+
+        <div class="mt-4 flex items-center justify-between px-4 sm:px-0">
+            <div class="h-4 w-48 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+            <div class="flex gap-1">
+                <div class="h-8 w-8 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                <div class="h-8 w-8 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+                <div class="h-8 w-8 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+            </div>
+        </div>
+    </div>
+@elseif ($isBootstrap)
+    <div class="w-100" role="status" aria-label="Loading table data...">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <div class="placeholder-glow">
+                <span class="placeholder col-4" style="height: 32px; display: inline-block; border-radius: 4px;"></span>
+            </div>
+            <div class="placeholder-glow">
+                <span class="placeholder col-3" style="height: 32px; display: inline-block; border-radius: 4px;"></span>
+            </div>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        @for ($col = 0; $col < 4; $col++)
+                            <th class="placeholder-glow">
+                                <span class="placeholder col-8" style="border-radius: 4px;"></span>
+                            </th>
+                        @endfor
+                    </tr>
+                </thead>
+                <tbody>
+                    @for ($i = 0; $i < 10; $i++)
+                        <tr>
+                            @for ($col = 0; $col < 4; $col++)
+                                <td class="placeholder-glow">
+                                    <span class="placeholder" style="width: {{ [60, 75, 50, 40][$col % 4] }}%; border-radius: 4px;"></span>
+                                </td>
+                            @endfor
+                        </tr>
+                    @endfor
+                </tbody>
+            </table>
+        </div>
+
+        <div class="d-flex justify-content-between align-items-center mt-3">
+            <div class="placeholder-glow">
+                <span class="placeholder col-6" style="border-radius: 4px;"></span>
+            </div>
+            <div class="d-flex gap-1">
+                <div class="placeholder-glow">
+                    <span class="placeholder" style="width: 32px; height: 32px; display: inline-block; border-radius: 4px;"></span>
+                </div>
+                <div class="placeholder-glow">
+                    <span class="placeholder" style="width: 32px; height: 32px; display: inline-block; border-radius: 4px;"></span>
+                </div>
+                <div class="placeholder-glow">
+                    <span class="placeholder" style="width: 32px; height: 32px; display: inline-block; border-radius: 4px;"></span>
+                </div>
+            </div>
+        </div>
+    </div>
+@endif

--- a/resources/views/lazy-placeholder.blade.php
+++ b/resources/views/lazy-placeholder.blade.php
@@ -1,5 +1,5 @@
 <div
-    x-data="{ currentlyReorderingStatus: false, paginationTotalItemCount: 0, paginationCurrentCount: 0, paginationCurrentItems: [], selectedItems: [], selectAllStatus: false, delaySelectAll: false, hideBulkActionsWhenEmpty: false, reorderStatus: false, reorderDisplayColumn: false, shouldBeDisplayed: true, filtersOpen: false }">
+    x-data="{{ $alpineDefaultScope }}">
     @if($lazyPlaceholderContent ?? null)
         @include($lazyPlaceholderContent, ['isTailwind' => $isTailwind, 'isBootstrap' => $isBootstrap, 'isBootstrap4' => $isBootstrap4 ?? false, 'isBootstrap5' => $isBootstrap5 ?? false])
     @endif

--- a/resources/views/lazy-placeholder.blade.php
+++ b/resources/views/lazy-placeholder.blade.php
@@ -1,0 +1,6 @@
+<div
+    x-data="{ currentlyReorderingStatus: false, paginationTotalItemCount: 0, paginationCurrentCount: 0, paginationCurrentItems: [], selectedItems: [], selectAllStatus: false, delaySelectAll: false, hideBulkActionsWhenEmpty: false, reorderStatus: false, reorderDisplayColumn: false, shouldBeDisplayed: true, filtersOpen: false }">
+    @if($lazyPlaceholderContent ?? null)
+        @include($lazyPlaceholderContent, ['isTailwind' => $isTailwind, 'isBootstrap' => $isBootstrap, 'isBootstrap4' => $isBootstrap4 ?? false, 'isBootstrap5' => $isBootstrap5 ?? false])
+    @endif
+</div>

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -29,4 +29,30 @@ abstract class DataTableComponent extends Component
     {
         return view('livewire-tables::datatable');
     }
+
+    /**
+     * Returns a placeholder view for Livewire lazy loading support.
+     * Uses the configured lazy placeholder view if set, otherwise falls back to the default.
+     * Override this method in your table component to provide a fully custom placeholder.
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function placeholder(array $params = []): \Illuminate\Contracts\View\View
+    {
+        $content = null;
+
+        if ($this->hasLazyPlaceholderEnabled()) {
+            $content = $this->hasLazyPlaceholderView()
+                ? $this->getLazyPlaceholderView()
+                : 'livewire-tables::lazy-placeholder-content';
+        }
+
+        return view('livewire-tables::lazy-placeholder', [
+            'lazyPlaceholderContent' => $content,
+            'isTailwind' => $this->isTailwind,
+            'isBootstrap' => $this->isBootstrap,
+            'isBootstrap4' => $this->isBootstrap4,
+            'isBootstrap5' => $this->isBootstrap5,
+        ]);
+    }
 }

--- a/src/DataTableComponent.php
+++ b/src/DataTableComponent.php
@@ -34,10 +34,8 @@ abstract class DataTableComponent extends Component
      * Returns a placeholder view for Livewire lazy loading support.
      * Uses the configured lazy placeholder view if set, otherwise falls back to the default.
      * Override this method in your table component to provide a fully custom placeholder.
-     *
-     * @param  array<string, mixed>  $params
      */
-    public function placeholder(array $params = []): \Illuminate\Contracts\View\View
+    public function placeholder()
     {
         $content = null;
 
@@ -49,6 +47,7 @@ abstract class DataTableComponent extends Component
 
         return view('livewire-tables::lazy-placeholder', [
             'lazyPlaceholderContent' => $content,
+            'alpineDefaultScope' => $this->getAlpineDefaultScope(),
             'isTailwind' => $this->isTailwind,
             'isBootstrap' => $this->isBootstrap,
             'isBootstrap4' => $this->isBootstrap4,

--- a/src/Traits/Configuration/LazyPlaceholderConfiguration.php
+++ b/src/Traits/Configuration/LazyPlaceholderConfiguration.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Configuration;
+
+trait LazyPlaceholderConfiguration
+{
+    public function setLazyPlaceholderStatus(bool $status): self
+    {
+        $this->lazyPlaceholderEnabled = $status;
+
+        return $this;
+    }
+
+    public function setLazyPlaceholderEnabled(): self
+    {
+        $this->setLazyPlaceholderStatus(true);
+
+        return $this;
+    }
+
+    public function setLazyPlaceholderDisabled(): self
+    {
+        $this->setLazyPlaceholderStatus(false);
+
+        return $this;
+    }
+
+    public function setLazyPlaceholderView(string $view): self
+    {
+        $this->lazyPlaceholderView = $view;
+
+        return $this;
+    }
+}

--- a/src/Traits/HasAllTraits.php
+++ b/src/Traits/HasAllTraits.php
@@ -10,6 +10,7 @@ trait HasAllTraits
     // Note Specific Order Below!
     use WithTableHooks;
     use HasLocalisations,
+        WithLazyPlaceholder,
         WithLoadingPlaceholder,
         HasTheme,
         WithFilters;

--- a/src/Traits/Helpers/LazyPlaceholderHelpers.php
+++ b/src/Traits/Helpers/LazyPlaceholderHelpers.php
@@ -23,4 +23,14 @@ trait LazyPlaceholderHelpers
     {
         return $this->lazyPlaceholderView;
     }
+
+    /**
+     * Returns the fallback Alpine x-data scope used by both the datatable
+     * and lazy-placeholder wrapper views. Centralised here so the two
+     * scopes can never drift out of sync.
+     */
+    public function getAlpineDefaultScope(): string
+    {
+        return '{ currentlyReorderingStatus: false, paginationTotalItemCount: 0, paginationCurrentCount: 0, paginationCurrentItems: [], selectedItems: [], selectAllStatus: false, delaySelectAll: false, hideBulkActionsWhenEmpty: false, reorderStatus: false, reorderDisplayColumn: false, shouldBeDisplayed: true, filtersOpen: false }';
+    }
 }

--- a/src/Traits/Helpers/LazyPlaceholderHelpers.php
+++ b/src/Traits/Helpers/LazyPlaceholderHelpers.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits\Helpers;
+
+trait LazyPlaceholderHelpers
+{
+    public function getLazyPlaceholderEnabled(): bool
+    {
+        return $this->lazyPlaceholderEnabled;
+    }
+
+    public function hasLazyPlaceholderEnabled(): bool
+    {
+        return $this->getLazyPlaceholderEnabled();
+    }
+
+    public function hasLazyPlaceholderView(): bool
+    {
+        return ! is_null($this->getLazyPlaceholderView());
+    }
+
+    public function getLazyPlaceholderView(): ?string
+    {
+        return $this->lazyPlaceholderView;
+    }
+}

--- a/src/Traits/WithLazyPlaceholder.php
+++ b/src/Traits/WithLazyPlaceholder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Traits;
+
+use Rappasoft\LaravelLivewireTables\Traits\Configuration\LazyPlaceholderConfiguration;
+use Rappasoft\LaravelLivewireTables\Traits\Helpers\LazyPlaceholderHelpers;
+
+trait WithLazyPlaceholder
+{
+    use LazyPlaceholderConfiguration,
+        LazyPlaceholderHelpers;
+
+    protected bool $lazyPlaceholderEnabled = true;
+
+    protected ?string $lazyPlaceholderView = null;
+}

--- a/tests/Http/Livewire/PetsTableLazyPlaceholder.php
+++ b/tests/Http/Livewire/PetsTableLazyPlaceholder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
+
+class PetsTableLazyPlaceholder extends PetsTable
+{
+    public function configure(): void
+    {
+        $this->setPrimaryKey('id')
+            ->setLazyPlaceholderEnabled();
+    }
+}

--- a/tests/Http/Livewire/PetsTableLazyPlaceholderCustomView.php
+++ b/tests/Http/Livewire/PetsTableLazyPlaceholderCustomView.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
+
+class PetsTableLazyPlaceholderCustomView extends PetsTable
+{
+    public function configure(): void
+    {
+        $this->setPrimaryKey('id')
+            ->setLazyPlaceholderEnabled()
+            ->setLazyPlaceholderView('livewire-tables-test::test');
+    }
+}

--- a/tests/Http/Livewire/PetsTableLazyPlaceholderDisabled.php
+++ b/tests/Http/Livewire/PetsTableLazyPlaceholderDisabled.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Http\Livewire;
+
+class PetsTableLazyPlaceholderDisabled extends PetsTable
+{
+    public function configure(): void
+    {
+        $this->setPrimaryKey('id')
+            ->setLazyPlaceholderDisabled();
+    }
+}

--- a/tests/Unit/Traits/Configuration/LazyPlaceholderConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/LazyPlaceholderConfigurationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Traits\Configuration;
+
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+final class LazyPlaceholderConfigurationTest extends TestCase
+{
+    public function test_can_set_lazy_placeholder_status_enabled(): void
+    {
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderEnabled());
+
+        $this->basicTable->setLazyPlaceholderDisabled();
+
+        $this->assertFalse($this->basicTable->hasLazyPlaceholderEnabled());
+
+        $this->basicTable->setLazyPlaceholderEnabled();
+
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderEnabled());
+    }
+
+    public function test_can_set_lazy_placeholder_status_disabled(): void
+    {
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderEnabled());
+
+        $this->basicTable->setLazyPlaceholderDisabled();
+
+        $this->assertFalse($this->basicTable->hasLazyPlaceholderEnabled());
+    }
+
+    public function test_can_set_lazy_placeholder_status_via_bool(): void
+    {
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderEnabled());
+
+        $this->basicTable->setLazyPlaceholderStatus(false);
+
+        $this->assertFalse($this->basicTable->hasLazyPlaceholderEnabled());
+
+        $this->basicTable->setLazyPlaceholderStatus(true);
+
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderEnabled());
+    }
+
+    public function test_can_set_lazy_placeholder_view(): void
+    {
+        $this->assertFalse($this->basicTable->hasLazyPlaceholderView());
+
+        $this->assertNull($this->basicTable->getLazyPlaceholderView());
+
+        $this->basicTable->setLazyPlaceholderView('livewire-tables-test::test');
+
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderView());
+
+        $this->assertSame('livewire-tables-test::test', $this->basicTable->getLazyPlaceholderView());
+    }
+
+    public function test_set_lazy_placeholder_view_returns_self(): void
+    {
+        $result = $this->basicTable->setLazyPlaceholderView('livewire-tables-test::test');
+
+        $this->assertSame($this->basicTable, $result);
+    }
+
+    public function test_set_lazy_placeholder_enabled_returns_self(): void
+    {
+        $result = $this->basicTable->setLazyPlaceholderEnabled();
+
+        $this->assertSame($this->basicTable, $result);
+    }
+
+    public function test_set_lazy_placeholder_disabled_returns_self(): void
+    {
+        $result = $this->basicTable->setLazyPlaceholderDisabled();
+
+        $this->assertSame($this->basicTable, $result);
+    }
+
+    public function test_set_lazy_placeholder_status_returns_self(): void
+    {
+        $result = $this->basicTable->setLazyPlaceholderStatus(true);
+
+        $this->assertSame($this->basicTable, $result);
+    }
+}

--- a/tests/Unit/Traits/Helpers/LazyPlaceholderHelpersTest.php
+++ b/tests/Unit/Traits/Helpers/LazyPlaceholderHelpersTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Unit\Traits\Helpers;
+
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+final class LazyPlaceholderHelpersTest extends TestCase
+{
+    public function test_can_get_lazy_placeholder_enabled_status(): void
+    {
+        $this->assertTrue($this->basicTable->getLazyPlaceholderEnabled());
+
+        $this->basicTable->setLazyPlaceholderDisabled();
+
+        $this->assertFalse($this->basicTable->getLazyPlaceholderEnabled());
+    }
+
+    public function test_can_check_has_lazy_placeholder_enabled(): void
+    {
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderEnabled());
+
+        $this->basicTable->setLazyPlaceholderDisabled();
+
+        $this->assertFalse($this->basicTable->hasLazyPlaceholderEnabled());
+    }
+
+    public function test_can_check_has_lazy_placeholder_view(): void
+    {
+        $this->assertFalse($this->basicTable->hasLazyPlaceholderView());
+
+        $this->basicTable->setLazyPlaceholderView('livewire-tables-test::test');
+
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderView());
+    }
+
+    public function test_can_get_lazy_placeholder_view(): void
+    {
+        $this->assertNull($this->basicTable->getLazyPlaceholderView());
+
+        $this->basicTable->setLazyPlaceholderView('livewire-tables-test::test');
+
+        $this->assertSame('livewire-tables-test::test', $this->basicTable->getLazyPlaceholderView());
+    }
+
+    public function test_lazy_placeholder_is_enabled_by_default(): void
+    {
+        $this->assertTrue($this->basicTable->hasLazyPlaceholderEnabled());
+    }
+
+    public function test_lazy_placeholder_view_is_null_by_default(): void
+    {
+        $this->assertNull($this->basicTable->getLazyPlaceholderView());
+        $this->assertFalse($this->basicTable->hasLazyPlaceholderView());
+    }
+}

--- a/tests/Visuals/LazyPlaceholderVisualsTest.php
+++ b/tests/Visuals/LazyPlaceholderVisualsTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Rappasoft\LaravelLivewireTables\Tests\Visuals;
+
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Group;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableLazyPlaceholder;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableLazyPlaceholderCustomView;
+use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableLazyPlaceholderDisabled;
+use Rappasoft\LaravelLivewireTables\Tests\TestCase;
+
+#[Group('Visuals')]
+final class LazyPlaceholderVisualsTest extends TestCase
+{
+    public function test_placeholder_method_returns_view(): void
+    {
+        $table = new PetsTableLazyPlaceholder;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+
+        $this->assertInstanceOf(\Illuminate\Contracts\View\View::class, $placeholder);
+    }
+
+    public function test_placeholder_renders_x_data_with_alpine_fallback_variables(): void
+    {
+        $table = new PetsTableLazyPlaceholder;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $html = $placeholder->render();
+
+        $this->assertStringContainsString('x-data=', $html);
+        $this->assertStringContainsString('currentlyReorderingStatus', $html);
+        $this->assertStringContainsString('paginationTotalItemCount', $html);
+        $this->assertStringContainsString('selectedItems', $html);
+        $this->assertStringContainsString('filtersOpen', $html);
+    }
+
+    public function test_placeholder_renders_default_skeleton_when_enabled(): void
+    {
+        $table = new PetsTableLazyPlaceholder;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $html = $placeholder->render();
+
+        $this->assertStringContainsString('role="status"', $html);
+        $this->assertStringContainsString('aria-label="Loading table data..."', $html);
+    }
+
+    public function test_placeholder_renders_empty_wrapper_when_disabled(): void
+    {
+        $table = new PetsTableLazyPlaceholderDisabled;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $html = $placeholder->render();
+
+        $this->assertStringContainsString('x-data=', $html);
+        $this->assertStringNotContainsString('role="status"', $html);
+    }
+
+    public function test_placeholder_renders_custom_view_inside_wrapper(): void
+    {
+        $table = new PetsTableLazyPlaceholderCustomView;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $html = $placeholder->render();
+
+        $this->assertStringContainsString('x-data=', $html);
+        $this->assertStringContainsString('test', $html);
+    }
+
+    public function test_placeholder_always_has_x_data_regardless_of_status(): void
+    {
+        $enabledTable = new PetsTableLazyPlaceholder;
+        $enabledTable->bootAll();
+
+        $disabledTable = new PetsTableLazyPlaceholderDisabled;
+        $disabledTable->bootAll();
+
+        $enabledHtml = $enabledTable->placeholder()->render();
+        $disabledHtml = $disabledTable->placeholder()->render();
+
+        $this->assertStringContainsString('x-data=', $enabledHtml);
+        $this->assertStringContainsString('x-data=', $disabledHtml);
+    }
+
+    public function test_placeholder_passes_theme_variables(): void
+    {
+        $table = new PetsTableLazyPlaceholder;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $data = $placeholder->getData();
+
+        $this->assertArrayHasKey('isTailwind', $data);
+        $this->assertArrayHasKey('isBootstrap', $data);
+        $this->assertArrayHasKey('isBootstrap4', $data);
+        $this->assertArrayHasKey('isBootstrap5', $data);
+    }
+
+    public function test_default_table_has_placeholder_method(): void
+    {
+        $table = new PetsTable;
+        $table->bootAll();
+
+        $this->assertTrue(method_exists($table, 'placeholder'));
+
+        $placeholder = $table->placeholder();
+
+        $this->assertInstanceOf(\Illuminate\Contracts\View\View::class, $placeholder);
+    }
+
+    public function test_placeholder_content_is_null_when_disabled(): void
+    {
+        $table = new PetsTableLazyPlaceholderDisabled;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $data = $placeholder->getData();
+
+        $this->assertNull($data['lazyPlaceholderContent']);
+    }
+
+    public function test_placeholder_content_is_default_view_when_enabled(): void
+    {
+        $table = new PetsTableLazyPlaceholder;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $data = $placeholder->getData();
+
+        $this->assertSame('livewire-tables::lazy-placeholder-content', $data['lazyPlaceholderContent']);
+    }
+
+    public function test_placeholder_content_is_custom_view_when_set(): void
+    {
+        $table = new PetsTableLazyPlaceholderCustomView;
+        $table->bootAll();
+
+        $placeholder = $table->placeholder();
+        $data = $placeholder->getData();
+
+        $this->assertSame('livewire-tables-test::test', $data['lazyPlaceholderContent']);
+    }
+}

--- a/tests/Visuals/LazyPlaceholderVisualsTest.php
+++ b/tests/Visuals/LazyPlaceholderVisualsTest.php
@@ -2,7 +2,6 @@
 
 namespace Rappasoft\LaravelLivewireTables\Tests\Visuals;
 
-use Livewire\Livewire;
 use PHPUnit\Framework\Attributes\Group;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTable;
 use Rappasoft\LaravelLivewireTables\Tests\Http\Livewire\PetsTableLazyPlaceholder;


### PR DESCRIPTION
## Description

This PR adds built-in support for Livewire's native `lazy="on-load"` directive on datatable components. When a datatable is lazy-loaded, Alpine.js `x-data` variables referenced in the real table (e.g. `currentlyReorderingStatus`, `paginationTotalItemCount`, `selectedItems`, etc.) are not yet initialized during the morph process, causing console errors. This PR solves that by providing a configurable skeleton placeholder with a pre-initialized Alpine.js scope.

### The Problem

When using `<livewire:my-table lazy="on-load" />`, Alpine.js throws errors like:

```
ReferenceError: currentlyReorderingStatus is not defined
ReferenceError: paginationTotalItemCount is not defined
```

This happens because `Alpine.morph()` during lazy loading does not trigger `onNodeAdded` for the morph root element — so `x-data` attributes added during morph never become a reactive Alpine scope.

### The Solution

- The `placeholder()` method on `DataTableComponent` returns a wrapper view with all required Alpine.js fallback variables pre-initialized via `x-data`
- A configurable default skeleton placeholder is rendered inside the wrapper (supports both Tailwind CSS and Bootstrap)
- Users can provide their own custom placeholder view, which is automatically wrapped with the required Alpine scope
<img width="651" height="373" alt="Screenshot_56" src="https://github.com/user-attachments/assets/a10f4709-eed0-4b08-a7ba-1373e11db742" />


## Changes Made

### New Trait

- **WithLazyPlaceholder** (`src/Traits/WithLazyPlaceholder.php`) — Main trait with properties
- **LazyPlaceholderConfiguration** (`src/Traits/Configuration/LazyPlaceholderConfiguration.php`) — Setter methods
- **LazyPlaceholderHelpers** (`src/Traits/Helpers/LazyPlaceholderHelpers.php`) — Getter/boolean methods

### New Views

- **lazy-placeholder.blade.php** — Wrapper view that always provides the Alpine.js `x-data` scope with all required fallback variables
- **lazy-placeholder-content.blade.php** — Default skeleton placeholder supporting both Tailwind CSS (`animate-pulse`) and Bootstrap (`placeholder-glow`)

### Modified Files

- **DataTableComponent.php** — Added `placeholder()` method that returns the lazy placeholder wrapper view with theme variables
- **HasAllTraits.php** — Added `WithLazyPlaceholder` trait
- **datatable.blade.php** — Added Alpine.js `x-data` fallback variables on the root `<div>` to match the placeholder scope
- **docs/datatable/loaders.md** — Added documentation for all lazy placeholder methods

### Tests

- **PetsTableLazyPlaceholder.php** — Test table with lazy placeholder enabled
- **PetsTableLazyPlaceholderDisabled.php** — Test table with lazy placeholder disabled
- **PetsTableLazyPlaceholderCustomView.php** — Test table with custom placeholder view
- **LazyPlaceholderConfigurationTest.php** — 8 unit tests for configuration setters
- **LazyPlaceholderHelpersTest.php** — 6 unit tests for helper/getter methods
- **LazyPlaceholderVisualsTest.php** — 11 visual tests for placeholder rendering

## Usage Examples

### Basic usage (zero config)

```html
<livewire:my-table lazy="on-load" />
```

The default skeleton placeholder renders automatically — no configuration needed.

### Custom placeholder view

```php
public function configure(): void
{
    $this->setPrimaryKey('id')
        ->setLazyPlaceholderView('components.my-custom-skeleton');
}
```

Your custom view is automatically wrapped with the required Alpine.js scope.

### Disable placeholder content

```php
public function configure(): void
{
    $this->setPrimaryKey('id')
        ->setLazyPlaceholderDisabled();
}
```

The Alpine.js wrapper is still rendered (to prevent morph errors), but no skeleton content is shown.

### Override placeholder entirely

```php
public function placeholder(array $params = []): \Illuminate\Contracts\View\View
{
    return view('my-fully-custom-placeholder');
}
```

> **Note:** If you override `placeholder()` entirely, you are responsible for including the Alpine.js `x-data` scope on the root element.

## New Methods

| Method | Description |
|--------|-------------|
| `setLazyPlaceholderStatus(bool $status)` | Set lazy placeholder enabled/disabled via boolean |
| `setLazyPlaceholderEnabled()` | Enable the lazy placeholder (enabled by default) |
| `setLazyPlaceholderDisabled()` | Disable the lazy placeholder content |
| `setLazyPlaceholderView(string $view)` | Set a custom Blade view for the placeholder content |
| `getLazyPlaceholderEnabled()` | Get the current enabled status |
| `hasLazyPlaceholderEnabled()` | Check if lazy placeholder is enabled |
| `hasLazyPlaceholderView()` | Check if a custom view is set |
| `getLazyPlaceholderView()` | Get the custom view path |

## Checklist

- [x] No breaking changes — all existing functionality preserved
- [x] No additional dependencies added
- [x] Methods are typehinted with return values
- [x] Methods have comments explaining their purpose
- [x] Views support Tailwind CSS and Bootstrap (4 & 5)
- [x] Tests added for all new methods (25 tests, 50 assertions — all passing)
- [x] Documentation added for new features
- [x] Follows project conventions (Configuration/Helper trait pattern)
- [x] Compatible with Livewire 4

## Submission Checklist

**All Submissions:**

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

**New Feature Submissions:**

- [x] Does your submission pass tests and did you add any new tests needed for your feature?
- [x] Did you update all templates (if applicable)?
- [x] Did you add the relevant documentation (if applicable)?
- [x] Did you test locally to make sure your feature works as intended?

**Changes to Core Features:**

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
