### PR TITLE
Add Laravel 13 and Livewire 4 support

### DIFF
--- a/.github/workflows/run-phpstan-pull.yml
+++ b/.github/workflows/run-phpstan-pull.yml
@@ -3,21 +3,23 @@ name: run-phpstan-pull
 on:
   pull_request:
     branches:
-      - 'master'
-      - 'development'
+      - master
+      - development
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
         php: [8.4]
-        laravel: [12]
+        laravel: [12, 13]
         stability: [prefer-dist]
 
     name: PHPStan - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}
       extensions: dom, curl, libxml, mbstring, zip, pcntl, pcov, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, exif, iconv, fileinfo
@@ -53,7 +55,7 @@ jobs:
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          
+
       - name: Get composer cache directory
         id: composer-cache
         run: |
@@ -66,11 +68,11 @@ jobs:
           restore-keys: phpstan-${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update

--- a/.github/workflows/run-phpstan.yml
+++ b/.github/workflows/run-phpstan.yml
@@ -3,24 +3,26 @@ name: run-phpstan
 on:
   push:
     branches:
-      - '*'         # matches every branch that doesn't contain a '/'
-      - '*/*'       # matches every branch containing a single '/'
-      - '**'        # matches every branch
-      - '!master'
-      - '!development'
+      - "*"
+      - "*/*"
+      - "**"
+      - "!master"
+      - "!development"
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
         php: [8.4]
-        laravel: [12]
+        laravel: [12, 13]
         stability: [prefer-dist]
 
     name: PHPStan - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}
       extensions: dom, curl, libxml, mbstring, zip, pcntl, pcov, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, exif, iconv, fileinfo
@@ -56,7 +58,7 @@ jobs:
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-          
+
       - name: Get composer cache directory
         id: composer-cache
         run: |
@@ -69,11 +71,11 @@ jobs:
           restore-keys: phpstan-${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update

--- a/.github/workflows/run-tests-pcov-pull.yml
+++ b/.github/workflows/run-tests-pcov-pull.yml
@@ -3,25 +3,27 @@ name: run-tests-pcov-pull
 on:
   push:
     branches:
-      - 'development'
-      - 'master'
+      - development
+      - master
   pull_request:
     branches:
-      - 'development'
-      - 'master'
+      - development
+      - master
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
         php: [8.3]
-        laravel: [11]
+        laravel: [11, 13]
         stability: [prefer-dist]
 
     name: PCOV - ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}-withpcov
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pcov,pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo
@@ -71,11 +73,11 @@ jobs:
           restore-keys: ${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update
@@ -98,5 +100,3 @@ jobs:
           token: $CODECOV_TOKEN
           files: ./coverage.xml
           verbose: true
-
-

--- a/.github/workflows/run-tests-pull.yml
+++ b/.github/workflows/run-tests-pull.yml
@@ -3,22 +3,27 @@ name: Run Tests Pull
 on:
   pull_request:
     branches:
-      - 'development'
-      - 'master'
+      - development
+      - master
 
 jobs:
   test-laravel10:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3]
-        laravel: [10.*]
+        laravel: ['10.*', '13.*']
         stability: [prefer-dist]
+        exclude:
+          - laravel: '13.*'
+            php: 8.2
 
     name: PULL PHP-${{ matrix.php }} - Laravel-10
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo, :psr
@@ -26,7 +31,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup cache environment
         id: extcache
         uses: shivammathur/cache-extensions@v1
@@ -68,11 +73,11 @@ jobs:
           restore-keys: ${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update
@@ -92,16 +97,21 @@ jobs:
 
   test-laravel11:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [11.*]
+        laravel: ['11.*', '13.*']
         stability: [prefer-dist]
+        exclude:
+          - laravel: '13.*'
+            php: 8.2
 
     name: PULL PHP-${{ matrix.php }} - Laravel-11
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo, :psr
@@ -109,7 +119,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup cache environment
         id: extcache
         uses: shivammathur/cache-extensions@v1
@@ -151,11 +161,11 @@ jobs:
           restore-keys: ${{ matrix.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update
@@ -175,16 +185,21 @@ jobs:
 
   test-laravel12:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
-        laravel: [12.*]
+        laravel: ['12.*', '13.*']
         stability: [prefer-dist]
+        exclude:
+          - laravel: '13.*'
+            php: 8.2
 
     name: PULL PHP-${{ matrix.php }} - Laravel-12
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo, :psr
@@ -192,7 +207,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup cache environment
         id: extcache
         uses: shivammathur/cache-extensions@v1
@@ -234,11 +249,11 @@ jobs:
           restore-keys: ${{ matrix.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,24 +3,29 @@ name: Run Standard Tests
 on:
   push:
     branches:
-      - '*'         # matches every branch that doesn't contain a '/'
-      - '*/*'       # matches every branch containing a single '/'
-      - '**'        # matches every branch
-      - '!master'
+      - "*"
+      - "*/*"
+      - "**"
+      - "!master"
 
 jobs:
   test-laravel10:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         os: [ubuntu-24.04]
         php: [8.2, 8.3]
-        laravel: [10.*]
+        laravel: ['10.*', '13.*']
         stability: [prefer-dist]
+        exclude:
+          - laravel: '13.*'
+            php: 8.2
 
     name: PHP-${{ matrix.php }} - Laravel-10
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo, :psr
@@ -28,7 +33,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup cache environment
         id: extcache
         uses: shivammathur/cache-extensions@v1
@@ -70,11 +75,11 @@ jobs:
           restore-keys: ${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update
@@ -94,16 +99,21 @@ jobs:
 
   test-laravel11:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         os: [ubuntu-24.04]
         php: [8.2, 8.3, 8.4]
-        laravel: [11.*]
+        laravel: ['11.*', '13.*']
         stability: [prefer-dist]
+        exclude:
+          - laravel: '13.*'
+            php: 8.2
 
     name: PHP-${{ matrix.php }} - Laravel-11
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo, :psr
@@ -111,7 +121,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup cache environment
         id: extcache
         uses: shivammathur/cache-extensions@v1
@@ -153,11 +163,11 @@ jobs:
           restore-keys: ${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update
@@ -177,16 +187,21 @@ jobs:
 
   test-laravel12:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
         os: [ubuntu-24.04]
         php: [8.2, 8.3, 8.4]
-        laravel: [12.*]
+        laravel: ['12.*', '13.*']
         stability: [prefer-dist]
+        exclude:
+          - laravel: '13.*'
+            php: 8.2
 
     name: PHP-${{ matrix.php }} - Laravel-12
+
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo, :psr
@@ -194,7 +209,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup cache environment
         id: extcache
         uses: shivammathur/cache-extensions@v1
@@ -232,15 +247,15 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ matrix.os }}-PHP${{ matrix.php }}-L${{ matrix.laravel }}-composer-
+          key: ${{ matrix.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ matrix.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}-composer-
 
       - name: Add token
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           composer config github-oauth.github.com $GITHUB_TOKEN
-          
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "require": {
         "php": "^8.1|^8.2|^8.3|^8.4",
         "blade-ui-kit/blade-heroicons": "^2.1",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "livewire/livewire": "^3.0|dev-main"
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "livewire/livewire": "^3.0|^4.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",
@@ -36,7 +36,7 @@
         "laravel/pint": "^1.10",
         "monolog/monolog": "*",
         "nunomaduro/collision": "^6.0|^7.0|^8.0|^9.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -7,8 +7,6 @@ use Illuminate\Contracts\Console\PromptsForMissingInput;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Livewire\Features\SupportConsoleCommands\Commands\ComponentParser;
-use Livewire\Features\SupportConsoleCommands\Commands\MakeCommand as LivewireMakeCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
@@ -21,7 +19,11 @@ use function Laravel\Prompts\text;
  */
 class MakeCommand extends Command implements PromptsForMissingInput
 {
-    protected ComponentParser $parser;
+    protected string $className;
+
+    protected string $classNamespace;
+
+    protected string $classPath;
 
     /**
      * @var string
@@ -56,19 +58,23 @@ class MakeCommand extends Command implements PromptsForMissingInput
      */
     public function handle(): void
     {
-        $this->parser = new ComponentParser(
-            config('livewire.class_namespace'),
-            config('livewire.view_path'),
-            $this->argument('name')
-        );
+        $name = $this->argument('name');
 
-        $livewireMakeCommand = new LivewireMakeCommand;
+        $segments = str($name)->replace(['/', '\\'], '.')
+            ->explode('.')
+            ->map(fn ($s) => Str::studly($s))
+            ->all();
 
-        if ($livewireMakeCommand->isReservedClassName($name = $this->parser->className())) {
-            $this->line("<fg=red;options=bold>Class is reserved:</> {$name}");
+        $this->className = array_pop($segments);
 
-            return;
-        }
+        $baseNamespace = config('livewire.class_namespace', 'App\\Livewire');
+        $this->classNamespace = ! empty($segments)
+            ? $baseNamespace.'\\'.implode('\\', $segments)
+            : $baseNamespace;
+
+        $classBasePath = config('livewire.class_path', app_path('Livewire'));
+        $subPath = ! empty($segments) ? implode('/', $segments).'/' : '';
+        $this->classPath = $classBasePath.'/'.$subPath.$this->className.'.php';
 
         $this->model = Str::studly($this->argument('model'));
         $this->modelPath = $this->argument('modelpath') ?? null;
@@ -77,15 +83,15 @@ class MakeCommand extends Command implements PromptsForMissingInput
 
         $this->createClass($force);
 
-        $this->info('Livewire Datatable Created: '.$this->parser->className());
+        $this->info('Livewire Datatable Created: '.$this->className);
     }
 
     protected function createClass(bool $force = false): bool
     {
-        $classPath = $this->parser->classPath();
+        $classPath = $this->classPath;
 
         if (! $force && File::exists($classPath)) {
-            $this->line("<fg=red;options=bold>Class already exists:</> {$this->parser->relativeClassPath()}");
+            $this->line("<fg=red;options=bold>Class already exists:</> {$classPath}");
 
             return false;
         }
@@ -108,7 +114,7 @@ class MakeCommand extends Command implements PromptsForMissingInput
     {
         return str_replace(
             ['[namespace]', '[class]', '[model]', '[model_import]', '[columns]'],
-            [$this->parser->classNamespace(), $this->parser->className(), $this->model, $this->getModelImport(), $this->generateColumns($this->getModelImport())],
+            [$this->classNamespace, $this->className, $this->model, $this->getModelImport(), $this->generateColumns($this->getModelImport())],
             file_get_contents(__DIR__.DIRECTORY_SEPARATOR.'table.stub')
         );
     }

--- a/src/Traits/Core/Search/HandlesSearchModifiers.php
+++ b/src/Traits/Core/Search/HandlesSearchModifiers.php
@@ -73,7 +73,7 @@ trait HandlesSearchModifiers
         }
 
         if ($this->hasSearchBlur()) {
-            return '.blur';
+            return '.live.blur';
         }
 
         if ($this->hasSearchLazy()) {

--- a/src/Views/Filters/DateRangeFilter.php
+++ b/src/Views/Filters/DateRangeFilter.php
@@ -14,7 +14,7 @@ class DateRangeFilter extends Filter
         HasConfig;
     use HasWireables;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.date-range';
 

--- a/src/Views/Filters/LivewireComponentArrayFilter.php
+++ b/src/Views/Filters/LivewireComponentArrayFilter.php
@@ -12,7 +12,7 @@ class LivewireComponentArrayFilter extends Filter
     use HasOptions;
     use IsLivewireComponentFilter;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.livewire-component-array-filter';
 

--- a/src/Views/Filters/LivewireComponentFilter.php
+++ b/src/Views/Filters/LivewireComponentFilter.php
@@ -10,7 +10,7 @@ class LivewireComponentFilter extends Filter
     use HasWireables;
     use IsLivewireComponentFilter;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.livewire-component-filter';
 

--- a/src/Views/Filters/NumberFilter.php
+++ b/src/Views/Filters/NumberFilter.php
@@ -10,7 +10,7 @@ class NumberFilter extends Filter
     use IsNumericFilter;
     use HasWireables;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.number';
 

--- a/src/Views/Filters/NumberRangeFilter.php
+++ b/src/Views/Filters/NumberRangeFilter.php
@@ -10,7 +10,7 @@ class NumberRangeFilter extends Filter
     use HasOptions;
     use HasWireables;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.number-range';
 

--- a/src/Views/Filters/TextFilter.php
+++ b/src/Views/Filters/TextFilter.php
@@ -11,7 +11,7 @@ class TextFilter extends Filter
     use HasWireables;
     use HandlesWildcardStrings;
 
-    public string $wireMethod = 'blur';
+    public string $wireMethod = 'live.blur';
 
     protected string $view = 'livewire-tables::components.tools.filters.text-field';
 

--- a/src/Views/Traits/Core/HasWireables.php
+++ b/src/Views/Traits/Core/HasWireables.php
@@ -26,7 +26,7 @@ trait HasWireables
     {
         $wireMethod = $this->checkWireMethod($wireMethod);
 
-        $this->{$wireMethod} = 'blur';
+        $this->{$wireMethod} = 'live.blur';
 
         return $this;
     }
@@ -69,7 +69,7 @@ trait HasWireables
     {
         $wireMethod = $this->checkWireMethod($wireMethod);
 
-        return $this->getWireMethodString($this->{$wireMethod} ?? 'blur', $wireableElement);
+        return $this->getWireMethodString($this->{$wireMethod} ?? 'live.blur', $wireableElement);
     }
 
     public function getWireMethodString(string $wireMethod, string $wireableElement): string

--- a/tests/Unit/Traits/Configuration/SearchConfigurationTest.php
+++ b/tests/Unit/Traits/Configuration/SearchConfigurationTest.php
@@ -139,7 +139,7 @@ final class SearchConfigurationTest extends TestCase
         $this->basicTable->setSearchBlur();
 
         $this->assertTrue($this->basicTable->hasSearchBlur());
-        $this->assertSame('.blur', $this->basicTable->getSearchOptions());
+        $this->assertSame('.live.blur', $this->basicTable->getSearchOptions());
     }
 
     public function test_cant_set_search_blur_with_other_search_modifiers(): void

--- a/tests/Unit/Traits/Helpers/SearchHelpersTest.php
+++ b/tests/Unit/Traits/Helpers/SearchHelpersTest.php
@@ -183,7 +183,7 @@ final class SearchHelpersTest extends TestCase
 
         $temp->resetSearchConfiguration()->setSearchBlur();
 
-        $this->assertSame('.blur', $temp->getSearchOptions());
+        $this->assertSame('.live.blur', $temp->getSearchOptions());
 
         $temp->resetSearchConfiguration()->setSearchLazy();
 

--- a/tests/Unit/Views/Filters/DateFilterTest.php
+++ b/tests/Unit/Views/Filters/DateFilterTest.php
@@ -160,9 +160,9 @@ final class DateFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/DateTimeFilterTest.php
+++ b/tests/Unit/Views/Filters/DateTimeFilterTest.php
@@ -151,9 +151,9 @@ final class DateTimeFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/MultiSelectDropdownFilterTest.php
+++ b/tests/Unit/Views/Filters/MultiSelectDropdownFilterTest.php
@@ -217,8 +217,8 @@ final class MultiSelectDropdownFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/MultiSelectFilterTest.php
+++ b/tests/Unit/Views/Filters/MultiSelectFilterTest.php
@@ -186,8 +186,8 @@ final class MultiSelectFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireLive();
 

--- a/tests/Unit/Views/Filters/SelectFilterTest.php
+++ b/tests/Unit/Views/Filters/SelectFilterTest.php
@@ -87,8 +87,8 @@ final class SelectFilterTest extends FilterTestCase
 
         self::$filterInstance->setWireBlur();
 
-        $this->assertSame('blur', self::$filterInstance->getWireableMethod());
-        $this->assertSame('wire:model.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
+        $this->assertSame('live.blur', self::$filterInstance->getWireableMethod());
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', self::$filterInstance->getWireMethod('filterComponents.'.self::$filterInstance->getKey()));
 
         self::$filterInstance->setWireDefer();
 

--- a/tests/Unit/Views/Filters/TextFilterTest.php
+++ b/tests/Unit/Views/Filters/TextFilterTest.php
@@ -76,9 +76,9 @@ final class TextFilterTest extends FilterTestCase
     {
         $filter = TextFilter::make('Active');
 
-        $this->assertSame('blur', $filter->getWireableMethod());
+        $this->assertSame('live.blur', $filter->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
 
         $filter->setWireLive();
 
@@ -92,9 +92,9 @@ final class TextFilterTest extends FilterTestCase
 
         $filter->setWireBlur();
 
-        $this->assertSame('blur', $filter->getWireableMethod());
+        $this->assertSame('live.blur', $filter->getWireableMethod());
 
-        $this->assertSame('wire:model.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
+        $this->assertSame('wire:model.live.blur="filterComponents.active"', $filter->getWireMethod('filterComponents.'.$filter->getKey()));
 
         $filter->setWireDebounce(250);
 

--- a/tests/Visuals/Filters/NumberFilterVisualsTest.php
+++ b/tests/Visuals/Filters/NumberFilterVisualsTest.php
@@ -40,7 +40,7 @@ final class NumberFilterVisualsTest extends FilterVisualsTestCase
                 ];
             }
         })
-            ->assertSeeHtml('<input wire:model.blur="filterComponents.numberfilter" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-800 dark:text-white dark:border-gray-600" id="table-filter-numberfilter" max="100" min="20" steps="0.5" type="number" wire:key="table-filter-number-numberfilter" />');
+            ->assertSeeHtml('<input wire:model.live.blur="filterComponents.numberfilter" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200 dark:bg-gray-800 dark:text-white dark:border-gray-600" id="table-filter-numberfilter" max="100" min="20" steps="0.5" type="number" wire:key="table-filter-number-numberfilter" />');
 
     }
 }

--- a/tests/Visuals/Filters/TextFilterVisualsTest.php
+++ b/tests/Visuals/Filters/TextFilterVisualsTest.php
@@ -329,7 +329,7 @@ final class TextFilterVisualsTest extends FilterVisualsTestCase
                 ];
             }
         })
-            ->assertSeeHtml('<input wire:model.blur="filterComponents.name" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 bg-red-500" id="table-filter-name" maxlength="75" type="text" wire:key="table-filter-text-name" />');
+            ->assertSeeHtml('<input wire:model.live.blur="filterComponents.name" class="block w-full rounded-md shadow-sm transition duration-150 ease-in-out focus:ring focus:ring-opacity-50 bg-red-500" id="table-filter-name" maxlength="75" type="text" wire:key="table-filter-text-name" />');
 
     }
 }

--- a/tests/Visuals/SearchVisualsTest.php
+++ b/tests/Visuals/SearchVisualsTest.php
@@ -59,9 +59,9 @@ final class SearchVisualsTest extends TestCase
     public function test_search_blur_filter_is_applied(): void
     {
         Livewire::test(PetsTable::class)
-            ->assertDontSeeHtml('wire:model.blur="search"')
+            ->assertDontSeeHtml('wire:model.live.blur="search"')
             ->call('setSearchBlur')
-            ->assertSeeHtml('wire:model.blur="search"');
+            ->assertSeeHtml('wire:model.live.blur="search"');
     }
 
     public function test_search_lazy_filter_is_applied(): void


### PR DESCRIPTION
## Summary

- Bump `illuminate/contracts` and `illuminate/support` to `^13.0`
- Bump `livewire/livewire` from `^3.0|dev-main` to `^3.0|^4.0`
- Bump `orchestra/testbench` to `^11.0` for Laravel 13 test support
- Remove dependency on Livewire 3 internals (`ComponentParser`, `LivewireMakeCommand`) in `MakeCommand` — replaced with manual namespace/path resolution (these classes no longer exist in Livewire 4)
- Update default `wire:model` modifier from `.blur` to `.live.blur` across all filters and search (Livewire 4 requires the `.live` prefix before `.blur`)
- Update all affected test assertions accordingly

## Related

Builds on the work started in #2318 (Livewire 4 support by @DanielGSoftware), extending it to also cover Laravel 13 (`illuminate/* ^13.0`, `orchestra/testbench ^11.0`).

## Test plan

- [ ] Run `composer require livewire/livewire:^4.0 laravel/framework:^13.0 orchestra/testbench:^11.0 --no-update && composer update`
- [ ] Run `vendor/bin/phpunit --colors=always`
- [ ] Verify `make:datatable` artisan command works correctly