### PR TITLE
Add Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "require": {
         "php": "^8.1|^8.2|^8.3|^8.4",
         "blade-ui-kit/blade-heroicons": "^2.1",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "livewire/livewire": "^3.0|dev-main"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds Laravel 13 compatibility.

Changes:
- Added illuminate/contracts ^13.0
- Added illuminate/support ^13.0

Tested successfully on Laravel 13 and Livewire 3.